### PR TITLE
ci: fix electron release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -92,17 +92,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: v${{ needs.prepare.outputs.release_version }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -117,7 +117,7 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: false
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist-${{ matrix.platform }}
           path: |
@@ -135,7 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
       "start": "next start",
       "lint": "eslint . --fix",
       "electron:dev": "npx electron .",
-      "electron:build": "next build && node scripts/copy-static.cjs && electron-builder"
+      "electron:build": "next build && node scripts/copy-static.cjs && electron-builder --publish never"
    },
    "dependencies": {
       "@ai-sdk/anthropic": "3.0.64",


### PR DESCRIPTION
## Summary

### Root cause fix
`electron-builder` has no `publish` config set, so when running in GitHub Actions it auto-detects the GitHub repo and defaults to publishing directly to GitHub Releases — requiring `GH_TOKEN` which isn't set in the build job. This caused all 3 platform builds to fail.

Added `--publish never` to the `electron:build` script so electron-builder only produces local artifact files. The `release` job already handles creating the GitHub Release via `gh release create`.

### Action version updates (Node.js 20 deprecation)
Updated all 5 GitHub Actions to their latest Node.js 24-compatible versions:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `pnpm/action-setup` | v4 | v5 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |

Node.js 20 action runtime will be force-removed on September 16, 2026.