### PR TITLE
fix(ci): fix macOS ENOENT and pin runner to macos-15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest    # arm64 (Apple Silicon)
+          - os: macos-15      # arm64 (Apple Silicon, Sequoia — compatible with macOS 26+)
             platform: macOS
           - os: windows-latest  # x64
             platform: Windows

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
             "from": ".next/standalone",
             "to": "next-app",
             "filter": [
-               "**/*"
+               "**/*",
+               "!.next/node_modules/**"
             ]
          }
       ],


### PR DESCRIPTION
## Changes

### Fix macOS build failure (ENOENT)
- **Root cause:** electron-builder 26 changed how it handles files during macOS code signing. pnpm's content-addressable symlinks in `.next/standalone/.next/node_modules/` (a Turbopack build artifact, e.g. `ai-200ae424068b95cd`) become dangling when copied into the app bundle, causing `ENOENT` during signing.

### Pin macOS runner to `macos-15`
- `macos-latest` currently resolves to macOS 15 Sequoia (confirmed from build logs: Darwin 24.6.0). arm64 Electron builds on macOS 15 are compatible with macOS 26 (Tahoe), so one build is sufficient.
- Replaced `macos-latest` → `macos-15` to pin explicitly and avoid future breakage when GitHub upgrades `macos-latest` to macOS 26.