### PR TITLE
fix(ci): add checkout step to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,12 @@ jobs:
     needs: [prepare, build]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: v${{ needs.prepare.outputs.release_version }}
+          sparse-checkout: .github
+
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
## Problem

The `release` job runs `gh release create` but had no `actions/checkout` step, causing:
```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

`gh` needs a git repository to resolve the remote URL / repository context.

## Fix

Added a sparse checkout of the release tag (only `.github/` dir for speed) as the first step of the `release` job.