### PR TITLE
feat(electron): DMG distribution, rename to CryptoTools, improve error handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           name: dist-${{ matrix.platform }}
           path: |
-            dist/*.zip
+            dist/*.dmg
             dist/*.exe
             dist/*.AppImage
           if-no-files-found: error
@@ -149,7 +149,7 @@ jobs:
       - name: Create GitHub release
         run: |
           gh release create "v${{ needs.prepare.outputs.release_version }}" \
-            dist/*.zip \
+            dist/*.dmg \
             dist/*.exe \
             dist/*.AppImage \
             --title "Release v${{ needs.prepare.outputs.release_version }}" \

--- a/README.md
+++ b/README.md
@@ -30,20 +30,39 @@ A collection of cryptocurrency tools for [Kraken](https://www.kraken.com/), [Bin
 
 ## Desktop App
 
-A standalone desktop app is available for macOS (no Node.js or Git required):
+A standalone desktop app is available for macOS (Apple Silicon, no Node.js or Git required):
 
-1. Download `crypto-tools-{version}-arm64-mac.zip` from the [releases page](https://github.com/nyg/crypto-tools/releases)
-2. Unzip it to get `crypto-tools.app`
-3. Move it to your `Applications` folder and double-click to run
+1. Download `CryptoTools-{version}-arm64.dmg` from the [releases page](https://github.com/nyg/crypto-tools/releases)
+2. Open the DMG and drag **CryptoTools.app** to your **Applications** folder
+3. Double-click **CryptoTools** in Applications to launch
 
-> **macOS Gatekeeper warning**: Because the app is not signed with an Apple Developer certificate, macOS will block it on first launch. Right-click (or Control-click) the app and choose **Open**, then confirm in the dialog.
+### macOS Gatekeeper
+
+Because the app is not signed with an Apple Developer certificate, macOS will block it on first launch. To allow it:
+
+1. Try to open the app — macOS will show a warning and block it
+2. Open **System Settings → Privacy & Security**
+3. Scroll down to the security section — you will see *"CryptoTools was blocked from use because it is not from an identified developer"*
+4. Click **Open Anyway**, then confirm in the dialog
+
+You only need to do this once per installation.
+
+### Debugging a crash
+
+If the app launches but immediately quits without showing a window, run it from Terminal to see the full log output:
+
+```sh
+/Applications/CryptoTools.app/Contents/MacOS/CryptoTools
+```
+
+You can also check **Console.app** or crash reports in `~/Library/Logs/DiagnosticReports/`.
 
 API keys can be configured in the app on the **Settings** page (stored in `localStorage`).
 
 ### Building the desktop app
 
 ```sh
-pnpm electron:build   # produces dist/crypto-tools-{version}-arm64-mac.zip
+pnpm electron:build   # produces dist/CryptoTools-{version}-arm64.dmg
 ```
 
 To test the desktop app locally without building a distributable:

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,6 +1,6 @@
 'use strict'
 
-const { app, BrowserWindow, utilityProcess } = require('electron')
+const { app, BrowserWindow, dialog, utilityProcess } = require('electron')
 const path = require('path')
 const http = require('http')
 
@@ -25,6 +25,16 @@ function startNextServer() {
 
    serverProcess.stdout.on('data', (d) => process.stdout.write(`[next] ${d}`))
    serverProcess.stderr.on('data', (d) => process.stderr.write(`[next] ${d}`))
+
+   serverProcess.on('exit', (code) => {
+      if (code !== 0) {
+         dialog.showErrorBox(
+            'CryptoTools — Server Error',
+            `The Next.js server exited unexpectedly (code ${code}).\n\nRun the app from Terminal to see the full error output:\n  open -a CryptoTools`,
+         )
+         app.quit()
+      }
+   })
 }
 
 function waitForServer(retries = 40, intervalMs = 250) {
@@ -51,7 +61,7 @@ function createWindow() {
    const win = new BrowserWindow({
       width: 1280,
       height: 800,
-      title: 'crypto-tools',
+      title: 'CryptoTools',
       webPreferences: {
          nodeIntegration: false,
          contextIsolation: true,
@@ -67,6 +77,10 @@ app.whenReady().then(async () => {
       createWindow()
    } catch (err) {
       console.error(err.message)
+      dialog.showErrorBox(
+         'CryptoTools — Server Timeout',
+         `The Next.js server did not respond in time.\n\nRun the app from Terminal to see logs:\n  /Applications/CryptoTools.app/Contents/MacOS/CryptoTools`,
+      )
       app.quit()
    }
 })

--- a/package.json
+++ b/package.json
@@ -81,10 +81,11 @@
          {
             "from": ".next/standalone",
             "to": "next-app",
-            "filter": [
-               "**/*",
-               "!.next/node_modules/**"
-            ]
+            "filter": ["**/*"]
+         },
+         {
+            "from": ".next/standalone/node_modules",
+            "to": "next-app/node_modules"
          }
       ],
       "asarUnpack": [

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
    },
    "build": {
       "appId": "com.nyg.crypto-tools",
-      "productName": "crypto-tools",
+      "productName": "CryptoTools",
       "asar": true,
       "npmRebuild": false,
       "files": [
@@ -93,7 +93,7 @@
       "mac": {
          "target": [
             {
-               "target": "zip"
+               "target": "dmg"
             }
          ],
          "category": "public.app-category.finance"

--- a/scripts/copy-static.cjs
+++ b/scripts/copy-static.cjs
@@ -1,7 +1,7 @@
 'use strict'
 
-const { cpSync, existsSync } = require('fs')
-const { join } = require('path')
+const { cpSync, existsSync, lstatSync, unlinkSync, readdirSync, readlinkSync } = require('fs')
+const { join, resolve, dirname } = require('path')
 
 const root = join(__dirname, '..')
 const standaloneDir = join(root, '.next', 'standalone')
@@ -19,3 +19,25 @@ for (const { from, to } of copies) {
       console.warn(`Skipped (not found): ${from}`)
    }
 }
+
+// Remove dangling symlinks left by pnpm's virtual store — they cause ENOENT
+// during electron-builder's codesign step.
+function removeDanglingSymlinks(dir) {
+   if (!existsSync(dir)) return
+   for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name)
+      if (entry.isSymbolicLink()) {
+         const target = readlinkSync(full)
+         const resolved = resolve(dirname(full), target)
+         if (!existsSync(resolved)) {
+            unlinkSync(full)
+            console.log(`Removed dangling symlink: ${full} → ${target}`)
+         }
+      }
+      else if (entry.isDirectory()) {
+         removeDanglingSymlinks(full)
+      }
+   }
+}
+
+removeDanglingSymlinks(join(standaloneDir, 'node_modules'))


### PR DESCRIPTION
## Changes

### 1. DMG instead of ZIP
Switches the macOS build target from `zip` to `dmg`. Users now get a disk image with a drag-to-Applications interface — the standard macOS distribution format.

### 2. Rename to CryptoTools
- `productName`: `"crypto-tools"` → `"CryptoTools"` — controls the `.app` bundle name
- Window title updated to match

### 3. Better crash visibility
Previously, if the Next.js server failed to start, the app silently quit (`app.quit()` with only a `console.error`). Now:
- A `dialog.showErrorBox` is shown with the error and how to debug
- A `serverProcess` exit handler catches early crashes (e.g. missing files, bad path) before the timeout is even reached

### 4. README updates
- Updated install steps for DMG workflow
- Fixed Gatekeeper instructions for macOS 15 Sequoia — the right-click "Open Anyway" dialog was removed; the correct flow is System Settings → Privacy & Security → Open Anyway
- Added Terminal debug instructions for crash diagnosis