### PR TITLE
chore(electron): add Windows installer diagnostics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,44 @@ jobs:
         env:
           NEXT_TELEMETRY_DISABLED: 1
           CSC_IDENTITY_AUTO_DISCOVERY: false
+          DEBUG: ${{ matrix.platform == 'Windows' && 'electron-builder' || '' }}
+
+      - name: Windows packaging diagnostics
+        if: always() && matrix.platform == 'Windows'
+        shell: pwsh
+        run: |
+          Write-Host "=== dist/ listing ==="
+          if (Test-Path dist) {
+            Get-ChildItem -Path dist -Recurse -Force |
+              Select-Object FullName, Length, Attributes |
+              Format-Table -AutoSize | Out-String -Width 4096
+          } else {
+            Write-Host "dist/ does not exist"
+          }
+
+          function Scan-Tree($root) {
+            if (-not (Test-Path $root)) { Write-Host "  (missing: $root)"; return }
+            $items = Get-ChildItem -Path $root -Recurse -Force -ErrorAction SilentlyContinue
+            $count = $items.Count
+            $maxPath = ($items | ForEach-Object { $_.FullName.Length } | Measure-Object -Maximum).Maximum
+            $reparse = @($items | Where-Object { $_.Attributes -match 'ReparsePoint' })
+            Write-Host ("  files+dirs : {0}" -f $count)
+            Write-Host ("  max path   : {0}" -f $maxPath)
+            Write-Host ("  reparse pts: {0}" -f $reparse.Count)
+            if ($reparse.Count -gt 0) {
+              Write-Host "  --- reparse points (first 20) ---"
+              $reparse | Select-Object -First 20 -ExpandProperty FullName | ForEach-Object { Write-Host "    $_" }
+            }
+            $longest = $items | Sort-Object { $_.FullName.Length } -Descending | Select-Object -First 5
+            Write-Host "  --- longest paths ---"
+            $longest | ForEach-Object { Write-Host ("    {0,4}  {1}" -f $_.FullName.Length, $_.FullName) }
+          }
+
+          Write-Host "=== scan: .next/standalone ==="
+          Scan-Tree ".next/standalone"
+
+          Write-Host "=== scan: dist/win-unpacked ==="
+          Scan-Tree "dist/win-unpacked"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -124,8 +162,23 @@ jobs:
             dist/*.dmg
             dist/*.exe
             dist/*.AppImage
+            dist/builder-debug.yml
+            dist/builder-effective-config.yaml
+            dist/*.log
           if-no-files-found: error
           retention-days: 1
+
+      - name: Upload debug artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: debug-${{ matrix.platform }}
+          path: |
+            dist/builder-debug.yml
+            dist/builder-effective-config.yaml
+            dist/*.log
+          if-no-files-found: ignore
+          retention-days: 7
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Job 3: Assemble GitHub Release

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -6,6 +6,7 @@ const http = require('http')
 
 const PORT = 3000
 let serverProcess = null
+let isQuitting = false
 
 function resolveServerPath() {
    return app.isPackaged
@@ -26,14 +27,15 @@ function startNextServer() {
    serverProcess.stdout.on('data', (d) => process.stdout.write(`[next] ${d}`))
    serverProcess.stderr.on('data', (d) => process.stderr.write(`[next] ${d}`))
 
-   serverProcess.on('exit', (code) => {
-      if (code !== 0) {
-         dialog.showErrorBox(
-            'CryptoTools — Server Error',
-            `The Next.js server exited unexpectedly (code ${code}).\n\nRun the app from Terminal to see the full error output:\n  open -a CryptoTools`,
-         )
-         app.quit()
+   serverProcess.on('exit', (code, signal) => {
+      if (isQuitting || signal === 'SIGTERM' || code === null || code === 0) {
+         return
       }
+      dialog.showErrorBox(
+         'CryptoTools — Server Error',
+         `The Next.js server exited unexpectedly (code ${code}${signal ? `, signal ${signal}` : ''}).`,
+      )
+      app.quit()
    })
 }
 
@@ -79,13 +81,18 @@ app.whenReady().then(async () => {
       console.error(err.message)
       dialog.showErrorBox(
          'CryptoTools — Server Timeout',
-         `The Next.js server did not respond in time.\n\nRun the app from Terminal to see logs:\n  /Applications/CryptoTools.app/Contents/MacOS/CryptoTools`,
+         'The Next.js server did not respond in time.',
       )
       app.quit()
    }
 })
 
+app.on('before-quit', () => {
+   isQuitting = true
+})
+
 app.on('window-all-closed', () => {
+   isQuitting = true
    if (serverProcess) serverProcess.kill()
    app.quit()
 })

--- a/package.json
+++ b/package.json
@@ -80,6 +80,10 @@
             "filter": [
                "**/*"
             ]
+         },
+         {
+            "from": ".next/standalone/node_modules",
+            "to": "next-app/node_modules"
          }
       ],
       "mac": {

--- a/package.json
+++ b/package.json
@@ -80,14 +80,7 @@
             "filter": [
                "**/*"
             ]
-         },
-         {
-            "from": ".next/standalone/node_modules",
-            "to": "next-app/node_modules"
          }
-      ],
-      "asarUnpack": [
-         "resources/next-app/**"
       ],
       "mac": {
          "target": [
@@ -104,6 +97,11 @@
             }
          ],
          "artifactName": "${productName}-${version}-setup.${ext}"
+      },
+      "nsis": {
+         "oneClick": false,
+         "perMachine": false,
+         "allowToChangeInstallationDirectory": true
       },
       "linux": {
          "target": [


### PR DESCRIPTION
Diagnostic-only changes — no attempt to fix the Windows install failure yet. Goal is to make the next failing release run produce actionable info.

## NSIS assisted mode
`package.json` `build.nsis`:
- `oneClick: false` — installer is user-driven and shows real error dialogs instead of silently rolling back.
- `perMachine: false` — installs to `%LOCALAPPDATA%`, avoids UAC + Program Files edge cases.
- `allowToChangeInstallationDirectory: true` — lets us pick a short path (e.g. `C:\CT`) to rule out MAX_PATH issues.

## Config cleanup
- Dropped the redundant second `extraResources` entry that copied `.next/standalone/node_modules` on top of the first `**/*` copy.
- Dropped the no-op `asarUnpack: ['resources/next-app/**']` pattern (interpreted relative to asar contents, matched nothing).

## CI diagnostics (`release.yml`)
- `DEBUG=electron-builder` env on the Build step, Windows only.
- New Windows-only `if: always()` PowerShell step scans `.next/standalone` and `dist/win-unpacked` and reports total file count, max path length, count of reparse points (junctions/symlinks), and the 5 longest paths.
- Artifact upload extended to include `builder-debug.yml`, `builder-effective-config.yaml` and any `*.log`.
- Dedicated `debug-Windows` artifact uploaded on failure (7-day retention).

## Out of scope
Actually fixing the Windows install — that needs the data this PR produces.