### PR TITLE
ci(release): trigger homebrew-tap cask update on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,3 +157,27 @@ jobs:
             -F git-cliff/CHANGELOG.md
         env:
           GH_TOKEN: ${{ github.token }}
+
+      - name: Compute DMG SHA256
+        id: sha
+        run: |
+          # GitHub converts spaces to dots in asset names; CryptoTools.dmg has no spaces
+          gh release download "v${{ needs.prepare.outputs.release_version }}" \
+            --repo nyg/crypto-tools --pattern "CryptoTools.dmg" --output crypto-tools.dmg
+          SHA256=$(sha256sum crypto-tools.dmg | awk '{print $1}')
+          echo "dmg_sha256=$SHA256" >> "$GITHUB_OUTPUT"
+          rm crypto-tools.dmg
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Trigger homebrew tap cask update
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          repository: nyg/homebrew-tap
+          event-type: update-crypto-tools-cask
+          client-payload: >-
+            {
+              "version": "${{ needs.prepare.outputs.release_version }}",
+              "dmg_sha256": "${{ steps.sha.outputs.dmg_sha256 }}"
+            }


### PR DESCRIPTION
## Summary

After the GitHub release is created, the release workflow now:
1. Downloads `CryptoTools.dmg` from the new release and computes its SHA256
2. Dispatches an `update-crypto-tools-cask` repository event to `nyg/homebrew-tap`

The tap then opens an automated PR to bump `version` and `sha256` in `Casks/crypto-tools.rb`.

## Changes

### `nyg/crypto-tools` (this PR)
- `.github/workflows/release.yml` — added "Compute DMG SHA256" and "Trigger homebrew tap cask update" steps at the end of the `release` job

### `nyg/homebrew-tap` (already pushed to master)
- `Casks/crypto-tools.rb` — new cask file
- `.github/workflows/update-crypto-tools-cask.yml` — new workflow that handles the dispatch event

## Secrets

No new secrets needed — `RELEASE_TOKEN` (already in this repo) and `HOMEBREW_TAP_TOKEN` (already in `homebrew-tap`) are reused.