### PR TITLE
docs: update all docs for Vite + Bun + Electrobun migration

### DIFF
--- a/.env.development.local.example
+++ b/.env.development.local.example
@@ -1,5 +1,10 @@
-NEXT_PUBLIC_BINANCE_API_KEY=<Your Binance API key>
-NEXT_PUBLIC_BINANCE_API_SECRET=<Your Binance API secret>
+VITE_BINANCE_API_KEY=<Your Binance API key>
+VITE_BINANCE_API_SECRET=<Your Binance API secret>
 
-# Set to true to use mock data (no API keys or database needed)
-NEXT_PUBLIC_MOCK_DATA=false
+VITE_KRAKEN_API_KEY=<Your Kraken API key>
+VITE_KRAKEN_API_SECRET=<Your Kraken API secret>
+
+VITE_ANTHROPIC_API_KEY=<Your Anthropic API key>
+
+# Set to true to use mock data (no API keys or server needed)
+VITE_MOCK_DATA=false

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,64 +2,72 @@
 
 ## Build & Run
 
-- **Package manager**: pnpm
-- **Dev server**: `pnpm dev` (runs Next.js in development mode)
-- **Mocked mode**: `pnpm mocked` (sets `NEXT_PUBLIC_MOCK_DATA=true`, runs with mock data — no API keys or database required)
-- **Build**: `pnpm build`
-- **Lint**: `pnpm lint` (ESLint with next/core-web-vitals)
+- **Package manager / runtime**: bun
+- **Dev server**: `bun run dev` (starts Vite dev server on port 3000 + Hono API server on port 3001 via `concurrently`)
+- **Mocked mode**: `bun run mocked` (sets `VITE_MOCK_DATA=true`, Vite-only — no API keys or server required)
+- **Build (frontend)**: `bun run build`
+- **Build (desktop app)**: `bun run build:stable`
+- **Lint**: `bun run lint` (ESLint)
 
 No test framework is configured.
 
 ## Architecture
 
-This is a Next.js 16 app (Pages Router) providing cryptocurrency tools for Binance, Kraken, and SwissBorg exchanges, plus AI-powered asset classification via Anthropic.
+This is a **Vite + React Router + Hono** app providing cryptocurrency tools for Binance and Kraken exchanges, plus AI-powered asset classification via Anthropic. The desktop app is built with **[Electrobun](https://electrobun.dev/)**.
+
+The project is split into two runtime targets:
+
+- **`src/views/`** — React frontend, built by Vite, served on port 3000 in dev
+- **`src/server/`** — Hono API server, run by Bun, served on port 3001 in dev
+
+Vite proxies all `/api/*` requests to the Hono server during development. In production (web), the Hono server serves the built frontend as static files. In the desktop app (Electrobun), the Hono server runs in the Electrobun main process and the frontend is loaded from `views://main/index.html`.
 
 ### Layers
 
-**Pages** (`pages/`) — file-based routing. Each exchange has its own subdirectory (`binance/`, `kraken/`, `swissborg/`). `pages/api/` contains server-side API routes that proxy to external exchange APIs.
+**Pages** (`src/views/pages/`) — React Router route components. Each exchange has its own subdirectory (`binance/`, `kraken/`). `settings.jsx` handles API key management.
 
-**Components** (`components/`) — exchange-specific components live in `components/binance/`, `components/kraken/`, and `components/swissborg/`. Custom wrapper components (NumericInput, Checkbox, Select, DatePicker, etc.) live in `components/lib/` and wrap the shadcn/ui primitives in `components/ui/`. shadcn/ui is configured with `rsc: false`, `tsx: false`, and `radix-nova` style.
+**Components** (`src/views/components/`) — exchange-specific components live in `components/binance/` and `components/kraken/`. Custom wrapper components (NumericInput, Checkbox, Select, DatePicker, etc.) live in `components/lib/` and wrap the shadcn/ui primitives in `components/ui/`. shadcn/ui is configured with `rsc: false`, `tsx: false`, and `radix-nova` style.
 
-**Adapters** (`lib/adapters/`) — each external API has an adapter directory (`binance-api/`, `binance-gateway-api/`, `kraken-api/`, `anthropic/`) following a three-layer pattern documented in `lib/adapters/README.md`:
+**Adapters** (`src/server/adapters/`) — each external API has an adapter directory (`binance-api/`, `binance-gateway-api/`, `kraken-api/`, `anthropic/`) following a three-layer pattern:
 - `adapter.js` — public interface with domain methods (constructor function, default export)
 - `resource.js` — raw HTTP endpoint calls (named exports)
 - `authenticator.js` — request signing as a higher-order function: `authenticator(credentials)` returns `async (request) => signedRequest`
 
-Two HTTP requester singletons (`lib/adapters/http-requester/`) abstract the transport layer: `server-http-requester.js` uses `got` (Node.js), `browser-http-requester.js` uses `fetch`. Both export `httpRequester` as a pre-instantiated singleton.
+A single HTTP requester (`src/server/adapters/http-requester/server-http-requester.js`) abstracts the transport layer using Bun's native `fetch`. It exports `httpRequester` as a pre-instantiated singleton.
 
-**Services** (`lib/services/`) — `rate-finder.js` uses Dijkstra's algorithm (`modern-dijkstra`) to find trading pair paths and calculate fiat rates against USDT.
+**Routes** (`src/server/routes/`) — Hono route handlers, one file per exchange (`binance.js`, `kraken.js`). Each route destructures credentials from the request body, validates they exist (401 if missing), instantiates the appropriate adapter, and returns JSON.
 
-**Utils** (`utils/`) — `crypto.js` wraps Web Crypto API using higher-order factory functions (`hash(algo)`, `hmac(algo)`) that export `sha256`, `hmacSha256`, `hmacSha512`. `format.js` provides en-GB locale formatting via `Intl`. `event-bus.js` is a DOM-based pub/sub (SSR-safe, returns cleanup functions for `useEffect`). `swissborg-config.js` provides chart color, yield rate multiplier, and default-visible asset configuration for SwissBorg components.
+**Services** (`src/server/services/`) — `rate-finder.js` uses Dijkstra's algorithm (`modern-dijkstra`) to find trading pair paths and calculate fiat rates against USDT.
+
+**Utils** (`src/utils/`) — `crypto.js` wraps Web Crypto API using higher-order factory functions (`hash(algo)`, `hmac(algo)`) that export `sha256`, `hmacSha256`, `hmacSha512`. `format.js` provides en-GB locale formatting via `Intl`. `event-bus.js` is a DOM-based pub/sub (SSR-safe, returns cleanup functions for `useEffect`).
+
+**Electrobun main process** (`src/electrobun/index.ts`) — TypeScript entry point for the desktop app. Starts the Hono server on port 3001, opens a `BrowserWindow`, and wires up menus and external link handling.
 
 ### Data Flow
 
 1. Pages fetch data via SWR. Public/read-only data uses `useSWR` (auto-fetch); authenticated operations use `useSWRMutation` (manual trigger).
-2. The global SWR fetcher in `pages/_app.js` routes GET vs POST based on the presence of `params.arg`.
-3. API routes destructure credentials from `req.body.credentials`, validate they exist (401 if missing), instantiate the appropriate adapter with `new AdapterName(credentials)`, and return JSON.
-4. API keys are stored in `localStorage` per provider (e.g. `binance.api.key`, `kraken.api.secret`) with fallback to `NEXT_PUBLIC_*` env vars. Always guard localStorage access with `typeof window !== 'undefined'`.
-
-### Database & Cron
-
-SwissBorg data (community index scores, yield averages) is stored in a PostgreSQL database via the `postgres` package (`lib/db.js`). Cron routes in `pages/api/swissborg/cron/` periodically fetch and store this data. The database connection string is configured via the `POSTGRES_URL` environment variable and cron requests are authenticated with a `CRON_KEY`.
+2. The global SWR fetcher in `src/views/app.jsx` routes GET vs POST based on the presence of `params.arg`.
+3. Hono route handlers destructure credentials from `req.body.credentials`, validate they exist (401 if missing), instantiate the appropriate adapter, and return JSON.
+4. API keys are stored in `localStorage` per provider (e.g. `binance.api.key`, `kraken.api.secret`) with fallback to `VITE_*` env vars. Always guard localStorage access with `typeof window !== 'undefined'`.
 
 ### AI Integration
 
-`lib/adapters/anthropic/adapter.js` uses Vercel AI SDK (`ai` + `@ai-sdk/anthropic`) with Zod-validated structured output to classify Kraken tokenized assets as stock/ETF/unknown. Called from the `/api/kraken/xstocks` route.
+`src/server/adapters/anthropic/adapter.js` uses Vercel AI SDK (`ai` + `@ai-sdk/anthropic`) with Zod-validated structured output to classify Kraken tokenized assets as stock/ETF/unknown. Called from the `/api/kraken/xstocks` Hono route.
 
 ### Mocked Mode
 
-The app supports a mocked mode for development and demos, activated via `pnpm mocked` or `NEXT_PUBLIC_MOCK_DATA=true`. In `pages/_app.js`, the global SWR fetcher checks this env var and routes all API calls through `mockFetcher()` from `lib/mocks/index.js` instead of making real HTTP requests. Mock data generators live in `lib/mocks/` with per-exchange files (`kraken.js`, `binance.js`, `swissborg.js`). On startup, `initMockCredentials()` auto-populates `localStorage` with fake API keys so authenticated features work without configuration.
+The app supports a mocked mode for development and demos, activated via `bun run mocked` or `VITE_MOCK_DATA=true`. In `src/views/app.jsx`, the global SWR fetcher checks this env var and routes all API calls through `mockFetcher()` from `src/views/mocks/index.js` instead of making real HTTP requests. Mock data generators live in `src/views/mocks/` with per-exchange files (`kraken.js`, `binance.js`). On startup, `initMockCredentials()` auto-populates `localStorage` with fake API keys so authenticated features work without configuration.
 
 ## Code Conventions
 
 - **3-space indentation**, no semicolons, single quotes (enforced by ESLint; `react-hooks/exhaustive-deps` is disabled)
-- **Styling**: Tailwind CSS v4 + shadcn/ui components — no custom CSS, no daisyUI
+- **Styling**: Tailwind CSS v4 + shadcn/ui components — no custom CSS
 - **Precision math**: use `big.js` for all numeric calculations involving asset amounts or rates
 - **Constructor functions** over ES6 classes (e.g. `export default function BinanceAPI(credentials) { this.method = async function () { ... } }`)
 - **Functional React components** with hooks; no class components, no global state libraries
-- All files use `.js` extension (no TypeScript); shadcn/ui components use `.jsx`
-- **Path alias**: `@/*` maps to project root (configured in `jsconfig.json`)
-- **Class merging**: use `cn()` from `lib/utils.js` (`clsx` + `tailwind-merge`) for conditional Tailwind classes
+- All files use `.js`/`.jsx` extension (no TypeScript except `src/electrobun/index.ts` and `electrobun.config.ts`); shadcn/ui components use `.jsx`
+- **Path alias**: `@/*` maps to `src/views/` (configured in `jsconfig.json` and `vite.config.js`)
+- **Class merging**: use `cn()` from `src/views/lib/utils.js` (`clsx` + `tailwind-merge`) for conditional Tailwind classes
 
 ## Branching workflow
 
@@ -83,4 +91,5 @@ Common types: `feat`, `fix`, `chore`, `docs`, `refactor`, `ci`, `perf`, `build`,
 - `docs`: documentation only
 - `refactor`: code change with no behaviour change
 - `ci`: CI/CD workflow changes
-- `build`: changes to build system (electron-builder, next.config, etc.)
+- `build`: changes to build system (electrobun.config.ts, vite.config.js, etc.)
+

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Crypto Tools
 
-A collection of cryptocurrency tools for [Kraken](https://www.kraken.com/), [Binance](https://www.binance.com/), and [SwissBorg](https://swissborg.com/) exchanges. Built with Next.js, React, and Tailwind CSS.
-
-> **Live version**: https://crypto-tools.andstuff.dev
+A collection of cryptocurrency tools for [Kraken](https://www.kraken.com/) and [Binance](https://www.binance.com/) exchanges. Built with Vite, React, React Router, Hono, and Tailwind CSS.
 
 ## Features
 
@@ -25,20 +23,17 @@ A collection of cryptocurrency tools for [Kraken](https://www.kraken.com/), [Bin
 
 ![Binance Staking](public/screenshot-binance-staking.png)
 
-### SwissBorg
-
-- **Smart Yield** — Interactive chart of SwissBorg Smart Yield rates over time with configurable yield rate types, line types, and time frames. Toggle individual yield lines via the chart legend — hidden yields are also removed from the averages table below.
-- **Community Index** — Historical chart of the SwissBorg Community Index score.
-
-![SwissBorg Smart Yield](public/screenshot-swissborg-smart-yield.png)
-
 ## Desktop App
 
-A standalone desktop app is available for macOS (Apple Silicon, no Node.js or Git required):
+Standalone desktop apps are available for macOS (Apple Silicon) and Windows — no Bun or Git required:
 
-1. Download `CryptoTools-{version}-arm64.dmg` from the [releases page](https://github.com/nyg/crypto-tools/releases)
-2. Open the DMG and drag **CryptoTools.app** to your **Applications** folder
-3. Double-click **CryptoTools** in Applications to launch
+1. Download the installer from the [releases page](https://github.com/nyg/crypto-tools/releases):
+   - macOS: `CryptoTools.dmg`
+   - Windows: `CryptoTools.zip`
+2. **macOS**: open the DMG, drag **CryptoTools.app** to your **Applications** folder, then double-click to launch
+3. **Windows**: extract the ZIP and run the executable inside
+
+API keys can be configured in the app on the **Settings** page (stored in `localStorage`).
 
 ### macOS Gatekeeper
 
@@ -51,88 +46,81 @@ Because the app is not signed with an Apple Developer certificate, macOS will bl
 
 You only need to do this once per installation.
 
-### Debugging a crash
-
-If the app launches but immediately quits without showing a window, run it from Terminal to see the full log output:
-
-```sh
-/Applications/CryptoTools.app/Contents/MacOS/CryptoTools
-```
-
-You can also check **Console.app** or crash reports in `~/Library/Logs/DiagnosticReports/`.
-
-API keys can be configured in the app on the **Settings** page (stored in `localStorage`).
-
 ### Building the desktop app
 
 ```sh
-pnpm electron:build   # produces dist/CryptoTools-{version}-arm64.dmg
+bun run build:stable   # produces artifacts/ with .dmg (macOS) or .zip (Windows)
 ```
 
-To test the desktop app locally without building a distributable:
+To run the desktop app locally without building a distributable:
 
 ```sh
-pnpm electron:dev
+bun run desktop:dev
 ```
 
-## Web App Installation
+## Development
 
-1. Install [Node.js](https://nodejs.org/) and [pnpm](https://pnpm.io/)
-2. Clone the repository
+### Prerequisites
+
+- [Bun](https://bun.sh/) — runtime and package manager
+
+### Installation
+
+1. Clone the repository
    ```sh
    git clone https://github.com/nyg/crypto-tools.git
    cd crypto-tools
    ```
-3. Install dependencies
+2. Install dependencies
    ```sh
-   pnpm install
+   bun install
    ```
-4. (Optional) Copy `.env.development.local.example` to `.env.development.local` and fill in your API keys
-5. Start the development server
+3. (Optional) Copy `.env.development.local.example` to `.env.development.local` and fill in your API keys
+4. Start the development server
    ```sh
-   pnpm dev
+   bun run dev
    ```
-6. Open http://localhost:3000
+5. Open http://localhost:3000
+
+`bun run dev` starts both the Vite dev server (port 3000) and the Hono API server (port 3001) concurrently. Vite proxies `/api` requests to the Hono server.
 
 ### Mocked Mode
 
-Run the app with mock data (no API keys or database required):
+Run the frontend only with mock data (no API keys or server required):
 
 ```sh
-pnpm mocked
+bun run mocked
 ```
 
-This sets `NEXT_PUBLIC_MOCK_DATA=true`, which intercepts all API calls with a mock fetcher and auto-initializes `localStorage` with fake credentials. Useful for development and demos.
+This sets `VITE_MOCK_DATA=true`, which intercepts all API calls with a mock fetcher and auto-initializes `localStorage` with fake credentials. Useful for development and demos.
 
 ## Usage
 
 Navigate via the top menu bar to access each exchange's tools. Each exchange section has sub-navigation for its specific features.
 
-API keys for Kraken, Binance, and Anthropic can be configured on the **Settings** page (stored in `localStorage`) or via environment variables.
+API keys for Kraken, Binance, and Anthropic can be configured on the **Settings** page (stored in `localStorage`) or via environment variables (`VITE_*`).
 
 ## Project Structure
 
 ```
-pages/                  File-based routing (Next.js Pages Router)
-├── api/                Server-side API routes
-│   ├── binance/        Binance API proxy routes
-│   ├── kraken/         Kraken API proxy routes
-│   └── swissborg/      SwissBorg API & cron routes
-├── binance/            Binance pages
-├── kraken/             Kraken pages
-├── swissborg/          SwissBorg pages
-└── settings.js         API key management
-components/             React components
-├── binance/            Binance-specific components
-├── kraken/             Kraken-specific components
-├── swissborg/          SwissBorg-specific components
-├── lib/                Custom wrapper components
-└── ui/                 shadcn/ui primitives
-lib/
-├── adapters/           External API adapters (Binance, Kraken, Anthropic)
-│   └── http-requester/ HTTP transport abstraction (got for server, fetch for browser)
-└── services/           Business logic (rate finder using Dijkstra's algorithm)
-utils/                  Utility functions (crypto, formatting, event bus)
+src/
+├── electrobun/         Electrobun main process (TypeScript)
+├── server/             Hono API server (runs on Bun)
+│   ├── adapters/       External API adapters (Binance, Kraken, Anthropic)
+│   │   └── http-requester/  HTTP transport abstraction
+│   ├── routes/         Hono route handlers (binance.js, kraken.js)
+│   └── services/       Business logic (rate finder using Dijkstra's algorithm)
+├── utils/              Shared utility functions (crypto, formatting, event bus)
+└── views/              React frontend (built by Vite)
+    ├── components/     React components
+    │   ├── binance/    Binance-specific components
+    │   ├── kraken/     Kraken-specific components
+    │   ├── lib/        Custom wrapper components (NumericInput, Select, etc.)
+    │   └── ui/         shadcn/ui primitives
+    ├── mocks/          Mock data generators for development
+    └── pages/          Page-level React components
+        ├── binance/
+        └── kraken/
 ```
 
 ## Disclaimer

--- a/docs/auto-update.md
+++ b/docs/auto-update.md
@@ -1,6 +1,10 @@
-# Auto-Update for CryptoTools (macOS & Windows)
+# Auto-Update for CryptoTools
 
-## Executive Summary
+> **Note:** This document was originally written when the desktop app used **Electron** and `electron-updater`. The project has since migrated to **[Electrobun](https://electrobun.dev/)** as its desktop runtime. The implementation details below are no longer applicable. Auto-update via Electrobun is not yet implemented.
+
+---
+
+## Original Research (Electron / electron-updater — archived)
 
 Adding auto-update to this Electron app is **fully achievable for Windows** and **conditionally achievable for macOS**. The project already has `electron-builder` installed and a GitHub-based release workflow, so the foundation is almost entirely in place. The core requirement is `electron-updater` (a runtime companion to `electron-builder`) plus a `publish` configuration pointing at GitHub. The one major friction point is **macOS code signing**: `electron-updater` requires a valid Apple Developer ID signature to install updates on macOS; without it the updater will throw an error. Windows has no such hard requirement (users only get a SmartScreen warning with unsigned installers).
 


### PR DESCRIPTION
## Summary

The project has been fully migrated from Next.js + pnpm + Electron to Vite + React Router + Hono + Bun + Electrobun. All documentation was stale and has been updated.

### Changes

**`README.md`**
- Removed SwissBorg section (no longer in the app)
- Replaced tech stack description (Next.js → Vite + React Router + Hono + Bun)
- Updated desktop app section: Electron → Electrobun; new build/dev commands
- Release artifacts now `CryptoTools.dmg` (macOS) and `CryptoTools.zip` (Windows)
- Updated development section: use Bun instead of Node.js + pnpm
- Updated mocked mode: `VITE_MOCK_DATA` instead of `NEXT_PUBLIC_MOCK_DATA`
- Replaced project structure tree with new `src/` layout

**`.env.development.local.example`**
- Replaced all `NEXT_PUBLIC_*` vars with `VITE_*`
- Added Kraken and Anthropic API key vars

**`.github/copilot-instructions.md`**
- Full rewrite: Vite + Hono + Bun architecture, new file paths, updated data flow
- Removed Database & Cron section (SwissBorg/PostgreSQL removed)
- Updated `@/*` alias target (`src/views/` instead of project root)

**`docs/auto-update.md`**
- Added deprecation notice: Electron/electron-updater no longer used; auto-update via Electrobun not yet implemented