### PR TITLE
fix: ad-hoc sign app bundle to prevent macOS "damaged" error

### DIFF
--- a/electrobun.config.ts
+++ b/electrobun.config.ts
@@ -29,5 +29,6 @@ export default {
   },
   scripts: {
     preBuild: "scripts/prebuild.ts",
+    postWrap: "scripts/postwrap.ts",
   },
 } satisfies ElectrobunConfig;

--- a/scripts/postwrap.ts
+++ b/scripts/postwrap.ts
@@ -1,0 +1,26 @@
+/// <reference types="bun-types" />
+import { $ } from "bun";
+import { existsSync } from "fs";
+
+// This hook runs after ElectroBun assembles the self-extracting .app bundle,
+// before the DMG is created. We apply an ad-hoc signature so macOS does not
+// report the app as "damaged" when Gatekeeper encounters a linker-signed
+// binary inside an otherwise unsigned bundle.
+//
+// This is only a local/ad-hoc signature. For notarized distribution, set
+// `build.mac.codesign = true` and provide ELECTROBUN_DEVELOPER_ID.
+
+const os = process.env.ELECTROBUN_OS;
+if (os !== "macos") {
+  process.exit(0);
+}
+
+const bundlePath = process.env.ELECTROBUN_WRAPPER_BUNDLE_PATH;
+if (!bundlePath || !existsSync(bundlePath)) {
+  console.error(`postwrap: bundle not found at ${bundlePath ?? "(unset)"}`);
+  process.exit(1);
+}
+
+console.log(`postwrap: ad-hoc signing ${bundlePath}`);
+await $`codesign --sign - --deep --force ${bundlePath}`;
+console.log("postwrap: signing complete");


### PR DESCRIPTION
macOS Gatekeeper reports the app as "damaged and can't be opened" when it finds linker-signed binaries inside an unsigned bundle downloaded from the internet. Applying an ad-hoc codesign (`codesign --sign - --deep --force`) replaces those internal signatures with a consistent ad-hoc one, resolving the error - no Apple Developer account or certificates required.

**Changes:**
- `scripts/postwrap.ts`: new Electrobun post-wrap hook that runs after the self-extracting `.app` is assembled but before the DMG is created (macOS only); applies the ad-hoc signature
- `electrobun.config.ts`: registers the hook as `scripts.postWrap`