### PR TITLE
Fix date-picker setState-in-effect lint error

### DIFF
--- a/src/views/components/lib/date-picker.jsx
+++ b/src/views/components/lib/date-picker.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { DayPicker } from 'react-day-picker'
 import 'react-day-picker/style.css'
 import { Label } from '@/components/ui/label'
@@ -34,6 +34,7 @@ export default function DatePicker({ name, label, defaultValue, className = '' }
             parseInt(seconds) || 0
          ))
          setSelectedDate(newDate)
+         setInputValue(formatDisplayDate(newDate, hours, minutes, seconds))
       }
    }
 
@@ -53,12 +54,8 @@ export default function DatePicker({ name, label, defaultValue, className = '' }
       setHours(newHours)
       setMinutes(newMinutes)
       setSeconds(newSeconds)
+      setInputValue(formatDisplayDate(newDate, newHours, newMinutes, newSeconds))
    }
-
-   // Keep inputValue in sync when date/time changes via picker
-   useEffect(() => {
-      setInputValue(formatDisplayDate(selectedDate, hours, minutes, seconds))
-   }, [selectedDate, hours, minutes, seconds])
 
    const handleInputChange = (e) => {
       setInputValue(e.target.value)
@@ -71,10 +68,14 @@ export default function DatePicker({ name, label, defaultValue, className = '' }
             parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate(),
             parsed.getUTCHours(), parsed.getUTCMinutes(), parsed.getUTCSeconds()
          ))
+         const newHours = utc.getUTCHours().toString().padStart(2, '0')
+         const newMinutes = utc.getUTCMinutes().toString().padStart(2, '0')
+         const newSeconds = utc.getUTCSeconds().toString().padStart(2, '0')
          setSelectedDate(utc)
-         setHours(utc.getUTCHours().toString().padStart(2, '0'))
-         setMinutes(utc.getUTCMinutes().toString().padStart(2, '0'))
-         setSeconds(utc.getUTCSeconds().toString().padStart(2, '0'))
+         setHours(newHours)
+         setMinutes(newMinutes)
+         setSeconds(newSeconds)
+         setInputValue(formatDisplayDate(utc, newHours, newMinutes, newSeconds))
       } else {
          setInputValue(formatDisplayDate(selectedDate, hours, minutes, seconds))
       }


### PR DESCRIPTION
## Context

`bun run lint` fails on `src/views/components/lib/date-picker.jsx` with `react-hooks/set-state-in-effect` (eslint-plugin-react-hooks 7.1.1). The offending effect resynced the text `inputValue` whenever the picker changed the date/time:

```js
useEffect(() => {
   setInputValue(formatDisplayDate(selectedDate, hours, minutes, seconds))
}, [selectedDate, hours, minutes, seconds])
```

Calling `setState` synchronously in an effect body is the anti-pattern the rule catches.

## Fix

Remove the effect and set `inputValue` directly in the three handlers that change the date/time:
- `handleSelect` (calendar day picked)
- `handleTimeChange` (HH/MM/SS inputs)
- the valid branch of `handleInputBlur` (typed date parsed OK)

The typed-input path (`handleInputChange` / invalid-blur reset) is unchanged.

## Verification

`bun run lint` passes. Drove the Closed Orders date picker under `bun run mocked`:
- Picking Jan 15 → field becomes `2023-01-15T00:00:00Z`
- Setting hours to 08 → `2023-01-15T08:00:00Z`
- Typing `2023-03-05` and blurring → reformats to `2023-03-05T00:00:00Z`

No console errors.

## Note

This is independent of the Order Batch redesign (PR #199) — the error is pre-existing (the file was last touched in the Vite migration) and just surfaced when a fresh install materialized react-hooks 7.1.1. Kept as its own PR so it can merge to `master` on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)