### PR TITLE
feat(kraken): add a Fees dashboard backed by the ledger database

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A collection of cryptocurrency tools for [Kraken](https://www.kraken.com/) and [
 - **Order Batch** — Create multiple buy or sell post-limit orders for a trading pair with configurable price and volume distribution functions. Supports dry-run mode for safe testing.
 - **Closed Orders** — View and filter closed orders by asset and date range. Displays buy and sell orders grouped by trading pair with volume, cost, and average price summaries.
 - **Ledger** — Download your complete ledger (trades, deposits, withdrawals, staking and earn rewards) through Kraken's export report endpoints and keep it in a local SQLite database, so other tools can use it without querying the API again. Syncs incrementally, and shows the stored date range, last sync time and entry count alongside a filterable table of entries.
+- **Fees** — Dashboard of everything Kraken has charged since the account was opened — trade fees, withdrawal fees and anything else the ledger records — read from the local database. Totals per asset, a breakdown by ledger entry type, and a stacked chart over time by month, quarter or year. Fees are kept in the asset they were charged in and never converted between currencies.
 - **Balances** — View spot and staking account balances.
 - **xStocks** — AI-powered classification of Kraken tokenized assets (stocks and ETFs) using Anthropic Claude. Generates descriptions with configurable word count and supports filtering by asset type.
 

--- a/src/server/db/ledger-repository.js
+++ b/src/server/db/ledger-repository.js
@@ -10,6 +10,12 @@ const sortableColumns = {
    type: 'type'
 }
 
+// Kraken charges a fee on the row it belongs to, in that row's own asset, so every
+// aggregate below stays grouped by base_asset — there is nothing to convert between.
+// Fees are stored as the exact decimal strings the export returned; casting to REAL
+// is only ever done to add them up for display, never written back to a row.
+const nonZeroFee = 'CAST(fee AS REAL) <> 0'
+
 const upsertStatement = `
    INSERT INTO ledger_entry (
       account_id, entry_key, txid, refid, time, type, subtype, aclass,
@@ -100,6 +106,61 @@ export default function LedgerRepository(accountId) {
          .all(accountId).map(row => row.value)
 
       return { assets: column('base_asset'), types: column('type'), wallets: column('wallet') }
+   }
+
+   this.feeSummary = function (filters = {}) {
+
+      const built = buildWhere(accountId, filters)
+      const where = `${built.where} AND ${nonZeroFee}`
+      const params = built.params
+
+      const assets = db.query(`
+         SELECT base_asset AS asset, SUM(CAST(fee AS REAL)) AS total, COUNT(*) AS entries,
+                MIN(time) AS first, MAX(time) AS last
+         FROM ledger_entry
+         WHERE ${where}
+         GROUP BY base_asset
+         ORDER BY entries DESC, asset`).all(...params)
+
+      const byType = db.query(`
+         SELECT base_asset AS asset, type, SUM(CAST(fee AS REAL)) AS total, COUNT(*) AS entries
+         FROM ledger_entry
+         WHERE ${where}
+         GROUP BY base_asset, type
+         ORDER BY entries DESC`).all(...params)
+
+      // Months are the finest bucket returned; quarters and years are rolled up from
+      // them on the page, so changing the granularity costs no request.
+      // time is in milliseconds, and integer division by 1000 gives the seconds
+      // strftime expects; 'unixepoch' keeps the bucket in UTC like every other date here.
+      const byMonth = db.query(`
+         SELECT strftime('%Y-%m', time / 1000, 'unixepoch') AS month,
+                base_asset AS asset, type,
+                SUM(CAST(fee AS REAL)) AS total, COUNT(*) AS entries
+         FROM ledger_entry
+         WHERE ${where}
+         GROUP BY month, base_asset, type
+         ORDER BY month`).all(...params)
+
+      // Ranked per asset rather than overall: a fee of 5000 DOGE is not "bigger" than
+      // one of 100 EUR, so the page shows the ranking for the asset being looked at.
+      const largest = db.query(`
+         SELECT time, type, subtype, asset, baseAsset, wallet, fee, refid, txid FROM (
+            SELECT time, type, subtype, asset, base_asset AS baseAsset, wallet, fee, refid, txid,
+                   ROW_NUMBER() OVER (PARTITION BY base_asset ORDER BY CAST(fee AS REAL) DESC) AS feeRank
+            FROM ledger_entry
+            WHERE ${where})
+         WHERE feeRank <= 10`).all(...params)
+
+      return {
+         assets,
+         byType,
+         byMonth,
+         largest,
+         entries: assets.reduce((count, asset) => count + asset.entries, 0),
+         first: assets.length > 0 ? Math.min(...assets.map(asset => asset.first)) : null,
+         last: assets.length > 0 ? Math.max(...assets.map(asset => asset.last)) : null
+      }
    }
 
    this.readSyncState = function () {

--- a/src/server/routes/kraken-ledger.js
+++ b/src/server/routes/kraken-ledger.js
@@ -75,6 +75,9 @@ app.post('/entries', async (c) => withAccount(c, ({ body, repository }) =>
 app.post('/filters', async (c) => withAccount(c, ({ repository }) =>
    c.json(repository.distinctFilters())))
 
+app.post('/fees', async (c) => withAccount(c, ({ body, repository }) =>
+   c.json(repository.feeSummary(body.filters))))
+
 app.post('/clear', async (c) => withAccount(c, ({ accountId, repository }) => {
 
    if (isRunning(jobFor(accountId))) {

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -17,6 +17,15 @@ export function asDecimal(number, decimalCount = 2) {
    return new Intl.NumberFormat(locales, options).format(number)
 }
 
+// Asset amounts run from fiat totals down to satoshis, so the precision follows the
+// magnitude rather than being fixed: 1 234.56 stays readable and 0.00000420 survives.
+export function asAssetAmount(number) {
+   const magnitude = Math.abs(number)
+   if (magnitude >= 1) return asDecimal(number, 2)
+   if (magnitude >= 0.01) return asDecimal(number, 4)
+   return asDecimal(number, 8)
+}
+
 export function asDecimalOne(number) {
    return decimalOneFormatter.format(number)
 }

--- a/src/views/app.jsx
+++ b/src/views/app.jsx
@@ -6,6 +6,7 @@ import Settings from './pages/settings'
 import BinanceStaking from './pages/binance/staking'
 import KrakenBalances from './pages/kraken/balances'
 import KrakenClosedOrders from './pages/kraken/closed-orders'
+import KrakenFees from './pages/kraken/fees'
 import KrakenLedger from './pages/kraken/ledger'
 import KrakenOrderBatch from './pages/kraken/order-batch'
 import KrakenXStocks from './pages/kraken/xstocks'
@@ -67,6 +68,7 @@ export default function App() {
                <Route path="/binance/staking" element={<BinanceStaking />} />
                <Route path="/kraken/balances" element={<KrakenBalances />} />
                <Route path="/kraken/closed-orders" element={<KrakenClosedOrders />} />
+               <Route path="/kraken/fees" element={<KrakenFees />} />
                <Route path="/kraken/ledger" element={<KrakenLedger />} />
                <Route path="/kraken/order-batch" element={<KrakenOrderBatch />} />
                <Route path="/kraken/xstocks" element={<KrakenXStocks />} />

--- a/src/views/components/kraken/fee-breakdown-card.jsx
+++ b/src/views/components/kraken/fee-breakdown-card.jsx
@@ -1,0 +1,114 @@
+import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
+import { asAssetAmount, asPercentage } from '../../../utils/format'
+
+// Kraken records ledger times in UTC; rendering them in the browser's zone would
+// silently shift every entry.
+const asUtcTimestamp = (time) => new Date(time).toISOString().replace('T', ' ').slice(0, 19)
+
+
+export default function FeeBreakdownCard({ fees, colors, asset }) {
+
+   const assetTotals = new Map((fees?.assets ?? []).map(row => [row.asset, row.total]))
+   const byType = fees?.byType ?? []
+   const largest = (fees?.largest ?? []).filter(entry => entry.baseAsset === asset)
+
+   return (
+      <Card>
+         <CardHeader>
+            <CardTitle>By type</CardTitle>
+            {asset && <CardAction><Badge variant="outline">{asset}</Badge></CardAction>}
+         </CardHeader>
+         <CardContent className="space-y-6">
+
+            {byType.length === 0
+               ? <p className="text-sm text-muted-foreground">
+                  No fees in the stored ledger for these filters.
+               </p>
+               : <div className="overflow-x-auto">
+                  <Table className="tabular-nums">
+                     <TableHeader>
+                        <TableRow>
+                           <TableHead>Type</TableHead>
+                           <TableHead>Asset</TableHead>
+                           <TableHead className="text-right">Total fees</TableHead>
+                           <TableHead className="text-right">Fees</TableHead>
+                           <TableHead className="text-right">Share of asset</TableHead>
+                        </TableRow>
+                     </TableHeader>
+                     <TableBody>
+                        {byType.map(row =>
+                           <TableRow key={`${row.asset}-${row.type}`}>
+                              <TableCell>
+                                 <div className="flex items-center gap-2">
+                                    <span
+                                       className="size-2.5 shrink-0 rounded-[2px]"
+                                       style={{ backgroundColor: colors.get(row.type) }} />
+                                    <Badge variant="secondary">{row.type}</Badge>
+                                 </div>
+                              </TableCell>
+                              <TableCell className="font-medium">{row.asset}</TableCell>
+                              <TableCell className="text-right font-medium">
+                                 {asAssetAmount(row.total)}
+                              </TableCell>
+                              <TableCell className="text-right text-muted-foreground">
+                                 {row.entries.toLocaleString('en-GB')}
+                              </TableCell>
+                              <TableCell className="text-right text-muted-foreground">
+                                 {assetTotals.get(row.asset)
+                                    ? asPercentage(row.total / assetTotals.get(row.asset))
+                                    : '—'}
+                              </TableCell>
+                           </TableRow>)}
+                     </TableBody>
+                  </Table>
+               </div>}
+
+            {largest.length > 0 &&
+               <div className="space-y-3 border-t border-border pt-4">
+                  <p className="text-sm font-medium">Largest single fees</p>
+                  <div className="overflow-x-auto">
+                     <Table className="tabular-nums">
+                        <TableHeader>
+                           <TableRow>
+                              <TableHead>Time (UTC)</TableHead>
+                              <TableHead>Type</TableHead>
+                              <TableHead className="text-right">Fee</TableHead>
+                              <TableHead>Wallet</TableHead>
+                              <TableHead>Ref</TableHead>
+                           </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                           {largest.map(entry =>
+                              <TableRow key={entry.txid || `${entry.refid}-${entry.time}`}>
+                                 <TableCell className="whitespace-nowrap">
+                                    {asUtcTimestamp(entry.time)}
+                                 </TableCell>
+                                 <TableCell>
+                                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                                       <Badge variant="secondary">{entry.type}</Badge>
+                                       {entry.subtype &&
+                                          <span className="text-xs text-muted-foreground">{entry.subtype}</span>}
+                                    </div>
+                                 </TableCell>
+                                 <TableCell className="text-right font-medium">{entry.fee}</TableCell>
+                                 <TableCell className="text-muted-foreground">{entry.wallet || '—'}</TableCell>
+                                 <TableCell className="font-mono text-xs text-muted-foreground">
+                                    {entry.refid || '—'}
+                                 </TableCell>
+                              </TableRow>)}
+                        </TableBody>
+                     </Table>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                     The ten biggest single fees charged in {asset}. Ranked per asset, because a
+                     large number of one coin is not a bigger fee than a small number of another —
+                     change the asset above to see a different one.
+                  </p>
+               </div>}
+
+         </CardContent>
+      </Card>
+   )
+}

--- a/src/views/components/kraken/fee-chart-card.jsx
+++ b/src/views/components/kraken/fee-chart-card.jsx
@@ -1,0 +1,174 @@
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import {
+   ChartContainer, ChartTooltip, ChartTooltipContent, ChartLegend, ChartLegendContent
+} from '@/components/ui/chart'
+import SelectField from '../lib/select-field'
+import { asAssetAmount, asShortMonthYearDate } from '../../../utils/format'
+
+const granularities = [
+   { value: 'month', label: 'Month' },
+   { value: 'quarter', label: 'Quarter' },
+   { value: 'year', label: 'Year' }
+]
+
+// Axis ticks have to stay short where the values do not: a fiat total wants no
+// decimals, a BTC one still has to show that it is not zero.
+const asAxisTick = (value) => {
+   const magnitude = Math.abs(value)
+   if (magnitude === 0) return '0'
+   if (magnitude >= 1000) return value.toLocaleString('en-GB', { notation: 'compact', maximumFractionDigits: 1 })
+   if (magnitude >= 1) return value.toLocaleString('en-GB', { maximumFractionDigits: 1 })
+   return Number(value.toPrecision(2)).toString()
+}
+
+// The server buckets by month; anything coarser is folded from those here.
+const bucketOf = (month, granularity) => {
+
+   const [year, index] = month.split('-').map(Number)
+
+   if (granularity === 'year') return { key: `${year}`, label: `${year}` }
+
+   if (granularity === 'quarter') {
+      const quarter = Math.floor((index - 1) / 3) + 1
+      return { key: `${year}-Q${quarter}`, label: `Q${quarter} ${String(year).slice(2)}` }
+   }
+
+   return { key: month, label: asShortMonthYearDate(Date.UTC(year, index - 1, 1)) }
+}
+
+// Months with no fee produce no row, so the buckets are walked from the first to the
+// last rather than taken from the data — otherwise a quiet year would be squeezed out
+// of the axis and the bars either side would read as consecutive.
+function bucketsBetween(firstMonth, lastMonth, granularity) {
+
+   const [lastYear, lastIndex] = lastMonth.split('-').map(Number)
+   const buckets = []
+   let [year, index] = firstMonth.split('-').map(Number)
+
+   while (year < lastYear || (year === lastYear && index <= lastIndex)) {
+
+      const bucket = bucketOf(`${year}-${String(index).padStart(2, '0')}`, granularity)
+      if (buckets.at(-1)?.key !== bucket.key) buckets.push(bucket)
+
+      index += 1
+      if (index > 12) {
+         index = 1
+         year += 1
+      }
+   }
+
+   return buckets
+}
+
+function buildChart(byMonth, asset, granularity) {
+
+   const rows = byMonth.filter(row => row.asset === asset)
+   if (rows.length === 0) return { data: [], types: [] }
+
+   const totals = new Map()
+   for (const row of rows) totals.set(row.type, (totals.get(row.type) ?? 0) + row.total)
+
+   // The biggest contributor sits at the bottom of the stack. This is the drawing
+   // order only — colours come from the ledger's full type list, so re-ordering here
+   // never repaints a series.
+   const types = [...totals.keys()].toSorted((a, b) => totals.get(b) - totals.get(a))
+
+   const months = [...new Set(rows.map(row => row.month))].toSorted()
+
+   // Every series gets a value in every bucket, including zero. A stacked bar chart
+   // needs the full set: leaving a key out makes the offsets of the segments above it
+   // in that bucket come out as NaN, and the whole stack then draws nothing.
+   const buckets = new Map(bucketsBetween(months[0], months.at(-1), granularity)
+      .map(bucket => [bucket.key, { period: bucket.label, ...Object.fromEntries(types.map(type => [type, 0])) }]))
+
+   for (const row of rows) {
+      buckets.get(bucketOf(row.month, granularity).key)[row.type] += row.total
+   }
+
+   return { data: [...buckets.values()], types }
+}
+
+
+export default function FeeChartCard({ fees, colors, assets, asset, granularity, onAssetChange, onGranularityChange }) {
+
+   const { data, types } = buildChart(fees?.byMonth ?? [], asset, granularity)
+
+   const config = Object.fromEntries(types.map(type =>
+      [type, { label: type, color: colors.get(type) }]))
+
+   return (
+      <Card>
+         <CardHeader>
+            <CardTitle>Over time</CardTitle>
+         </CardHeader>
+         <CardContent className="space-y-4">
+
+            <div className="flex flex-wrap gap-4">
+               <SelectField
+                  name="fee-chart-asset"
+                  label="Asset"
+                  className="w-40"
+                  value={asset ?? ''}
+                  onValueChange={onAssetChange}
+                  options={assets.map(value => ({ value, label: value }))}
+                  disabled={assets.length === 0} />
+               <SelectField
+                  name="fee-chart-granularity"
+                  label="Group by"
+                  className="w-40"
+                  value={granularity}
+                  onValueChange={onGranularityChange}
+                  options={granularities} />
+            </div>
+
+            {data.length === 0
+               ? <p className="text-sm text-muted-foreground">
+                  No fees to chart. Sync your ledger on the Ledger tab, or widen the filters.
+               </p>
+               : <ChartContainer config={config} className="h-[320px] w-full">
+                  <BarChart data={data} margin={{ top: 8, right: 8 }}>
+                     <CartesianGrid vertical={false} />
+                     <XAxis dataKey="period" tickLine={false} axisLine={false} tickMargin={8} minTickGap={16} />
+                     <YAxis tickLine={false} axisLine={false} tickMargin={8} width={72} tickFormatter={asAxisTick} />
+                     <ChartTooltip content={
+                        <ChartTooltipContent
+                           formatter={(value, name) =>
+                              <>
+                                 <div
+                                    className="size-2.5 shrink-0 rounded-[2px]"
+                                    style={{ backgroundColor: colors.get(name) }} />
+                                 <div className="flex flex-1 items-center justify-between gap-4 leading-none">
+                                    <span className="text-muted-foreground">{name}</span>
+                                    <span className="font-mono font-medium tabular-nums text-foreground">
+                                       {asAssetAmount(value)}
+                                    </span>
+                                 </div>
+                              </>} />} />
+                     <ChartLegend content={<ChartLegendContent />} />
+                     {/* The entry animation is off on purpose: under StrictMode its effect is
+                         mounted, torn down and remounted, and the bars can stay stuck on the
+                         zero-height first frame, which renders no rectangles at all. */}
+                     {types.map((type, index) =>
+                        <Bar
+                           key={type}
+                           dataKey={type}
+                           stackId="fee"
+                           fill={colors.get(type)}
+                           stroke="var(--card)"
+                           strokeWidth={2}
+                           isAnimationActive={false}
+                           radius={index === types.length - 1 ? [4, 4, 0, 0] : 0} />)}
+                  </BarChart>
+               </ChartContainer>}
+
+            <p className="text-xs text-muted-foreground">
+               Fees charged in <b>{asset ?? '—'}</b>, stacked by ledger entry type. Only one asset
+               is shown at a time: putting a fiat and a crypto total on the same axis would make
+               both unreadable.
+            </p>
+
+         </CardContent>
+      </Card>
+   )
+}

--- a/src/views/components/kraken/fee-summary-card.jsx
+++ b/src/views/components/kraken/fee-summary-card.jsx
@@ -1,0 +1,92 @@
+import { Loader2Icon } from 'lucide-react'
+import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
+import LedgerFilters from './ledger-filters'
+import Field from '../lib/field'
+import { asAssetAmount, asLongDate, asPercentage } from '../../../utils/format'
+
+
+export default function FeeSummaryCard({ fees, filters, filtersKey, options, isLoading, onFiltersChange, onFiltersReset }) {
+
+   const assets = fees?.assets ?? []
+   const entries = fees?.entries ?? 0
+
+   return (
+      <Card>
+         <CardHeader>
+            <CardTitle>Fees paid</CardTitle>
+            <CardAction>
+               {isLoading
+                  ? <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
+                  : <Badge variant="outline">{entries.toLocaleString('en-GB')} charged</Badge>}
+            </CardAction>
+         </CardHeader>
+         <CardContent className="space-y-4">
+
+            <LedgerFilters
+               key={filtersKey}
+               filters={filters}
+               options={options}
+               onChange={onFiltersChange}
+               onReset={onFiltersReset}
+               showSearch={false} />
+
+            <div className="grid grid-cols-2 gap-x-6 gap-y-3 border-t border-border pt-4 md:grid-cols-4">
+               <Field label="Assets charged in">{assets.length.toLocaleString('en-GB')}</Field>
+               <Field label="Fees charged">{entries.toLocaleString('en-GB')}</Field>
+               <Field label="First fee">{fees?.first ? asLongDate(fees.first) : '—'}</Field>
+               <Field label="Last fee">{fees?.last ? asLongDate(fees.last) : '—'}</Field>
+            </div>
+
+            {assets.length === 0
+               ? <p className="text-sm text-muted-foreground">
+                  No fees in the stored ledger for these filters.
+               </p>
+               : <div className="overflow-x-auto">
+                  <Table className="tabular-nums">
+                     <TableHeader>
+                        <TableRow>
+                           <TableHead>Asset</TableHead>
+                           <TableHead className="text-right">Total fees</TableHead>
+                           <TableHead className="text-right">Fees</TableHead>
+                           <TableHead className="text-right">Share</TableHead>
+                           <TableHead className="text-right">First</TableHead>
+                           <TableHead className="text-right">Last</TableHead>
+                        </TableRow>
+                     </TableHeader>
+                     <TableBody>
+                        {assets.map(asset =>
+                           <TableRow key={asset.asset}>
+                              <TableCell className="font-medium">{asset.asset}</TableCell>
+                              <TableCell className="text-right font-medium">
+                                 {asAssetAmount(asset.total)}
+                              </TableCell>
+                              <TableCell className="text-right text-muted-foreground">
+                                 {asset.entries.toLocaleString('en-GB')}
+                              </TableCell>
+                              <TableCell className="text-right text-muted-foreground">
+                                 {asPercentage(asset.entries / entries)}
+                              </TableCell>
+                              <TableCell className="text-right whitespace-nowrap text-muted-foreground">
+                                 {asLongDate(asset.first)}
+                              </TableCell>
+                              <TableCell className="text-right whitespace-nowrap text-muted-foreground">
+                                 {asLongDate(asset.last)}
+                              </TableCell>
+                           </TableRow>)}
+                     </TableBody>
+                  </Table>
+               </div>}
+
+            <p className="text-xs text-muted-foreground">
+               Every total is in the asset the fee was charged in — a trade fee lands in the
+               pair&apos;s quote currency, a withdrawal fee in the coin withdrawn. Nothing is
+               converted between assets, so <b>Share</b> compares how many fees each asset was
+               charged in, not how much they were worth.
+            </p>
+
+         </CardContent>
+      </Card>
+   )
+}

--- a/src/views/components/kraken/kraken-layout.jsx
+++ b/src/views/components/kraken/kraken-layout.jsx
@@ -4,6 +4,7 @@ import Layout from '../layout'
 
 const tabs = [
    { label: 'Ledger', href: '/kraken/ledger' },
+   { label: 'Fees', href: '/kraken/fees' },
    { label: 'Order Batch', href: '/kraken/order-batch' },
    { label: 'Closed Orders', href: '/kraken/closed-orders' },
    { label: 'Balances', href: '/kraken/balances' },

--- a/src/views/components/kraken/ledger-filters.jsx
+++ b/src/views/components/kraken/ledger-filters.jsx
@@ -22,7 +22,9 @@ export const defaultFilters = { asset: '', type: '', wallet: '', from: null, to:
 // Changing the filters from outside (Reset, or clicking a reference in the table)
 // remounts this component through its key, so the search box needs no separate
 // effect to stay in step with the filters it was given.
-export default function LedgerFilters({ filters, options, onChange, onReset }) {
+// showSearch is off on aggregate views, where narrowing to a single transaction id
+// says nothing.
+export default function LedgerFilters({ filters, options, onChange, onReset, showSearch = true }) {
 
    const [search, setSearch] = useState(filters.search)
 
@@ -36,11 +38,11 @@ export default function LedgerFilters({ filters, options, onChange, onReset }) {
    const update = (changes) => onChange({ ...filters, ...changes })
 
    const isFiltered = filters.asset || filters.type || filters.wallet
-      || filters.from || filters.to || filters.search
+      || filters.from || filters.to || (showSearch && filters.search)
 
    return (
       <div className="space-y-3">
-         <div className="grid grid-cols-2 gap-x-4 gap-y-3 md:grid-cols-3 lg:grid-cols-6">
+         <div className={`grid grid-cols-2 gap-x-4 gap-y-3 md:grid-cols-3 ${showSearch ? 'lg:grid-cols-6' : 'lg:grid-cols-5'}`}>
 
             <ComboboxField
                name="ledger-asset"
@@ -81,11 +83,12 @@ export default function LedgerFilters({ filters, options, onChange, onReset }) {
                value={asDateInput(filters.to)}
                onChange={(e) => update({ to: e.target.value ? Date.parse(`${e.target.value}T23:59:59Z`) : null })} />
 
-            <Input
-               name="ledger-search"
-               label="Search id"
-               value={search}
-               onChange={(e) => setSearch(e.target.value)} />
+            {showSearch &&
+               <Input
+                  name="ledger-search"
+                  label="Search id"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)} />}
 
          </div>
 

--- a/src/views/components/kraken/ledger-sync-card.jsx
+++ b/src/views/components/kraken/ledger-sync-card.jsx
@@ -5,6 +5,7 @@ import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/componen
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import Field from '../lib/field'
 import { asLongDate } from '../../../utils/format'
 
 const phaseLabels = {
@@ -21,15 +22,6 @@ const asFileSize = (bytes) => {
    const units = ['B', 'kB', 'MB', 'GB']
    const exponent = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)))
    return `${(bytes / 1024 ** exponent).toFixed(exponent === 0 ? 0 : 1)} ${units[exponent]}`
-}
-
-function Field({ label, children, title }) {
-   return (
-      <div className="space-y-0.5">
-         <p className="text-xs text-muted-foreground">{label}</p>
-         <p className="text-sm tabular-nums" title={title}>{children}</p>
-      </div>
-   )
 }
 
 export default function LedgerSyncCard({ state, job, isRunning, error, isStarting, onSync, onFullResync, onCancel, onClear }) {

--- a/src/views/components/lib/field.jsx
+++ b/src/views/components/lib/field.jsx
@@ -1,0 +1,10 @@
+// A read-only stat tile: a muted caption above a value. Meant to be laid out in a
+// grid by the caller, which owns the column count.
+export default function Field({ label, children, title }) {
+   return (
+      <div className="space-y-0.5">
+         <p className="text-xs text-muted-foreground">{label}</p>
+         <p className="text-sm tabular-nums" title={title}>{children}</p>
+      </div>
+   )
+}

--- a/src/views/components/ui/chart.jsx
+++ b/src/views/components/ui/chart.jsx
@@ -1,0 +1,318 @@
+import * as React from 'react'
+import * as RechartsPrimitive from 'recharts'
+
+import { cn } from '@/lib/utils'
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = {
+   light: '',
+   dark: '.dark'
+}
+
+const INITIAL_DIMENSION = {
+   width: 320,
+   height: 200
+}
+
+const ChartContext = React.createContext(null)
+
+function useChart() {
+   const context = React.useContext(ChartContext)
+
+   if (!context) {
+      throw new Error('useChart must be used within a <ChartContainer />')
+   }
+
+   return context
+}
+
+function ChartContainer({
+   id,
+   className,
+   children,
+   config,
+   initialDimension = INITIAL_DIMENSION,
+   ...props
+}) {
+   const uniqueId = React.useId()
+   const chartId = `chart-${id ?? uniqueId.replace(/:/g, '')}`
+
+   return (
+      <ChartContext.Provider value={{ config }}>
+         <div
+            data-slot="chart"
+            data-chart={chartId}
+            className={cn(
+               'flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke=\'#ccc\']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke=\'#fff\']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-polar-grid_[stroke=\'#ccc\']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke=\'#ccc\']]:stroke-border [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke=\'#fff\']]:stroke-transparent [&_.recharts-surface]:outline-hidden',
+               className
+            )}
+            {...props}>
+            <ChartStyle id={chartId} config={config} />
+            <RechartsPrimitive.ResponsiveContainer initialDimension={initialDimension}>
+               {children}
+            </RechartsPrimitive.ResponsiveContainer>
+         </div>
+      </ChartContext.Provider>
+   )
+}
+
+const ChartStyle = ({
+   id,
+   config
+}) => {
+   const colorConfig = Object.entries(config).filter(([, config]) => config.theme ?? config.color)
+
+   if (!colorConfig.length) {
+      return null
+   }
+
+   return (
+      <style
+         dangerouslySetInnerHTML={{
+            __html: Object.entries(THEMES)
+               .map(([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+         .map(([key, itemConfig]) => {
+            const color =
+  itemConfig.theme?.[theme] ??
+  itemConfig.color
+            return color ? `  --color-${key}: ${color};` : null
+         })
+         .join('\n')}
+}
+`)
+               .join('\n'),
+         }} />
+   )
+}
+
+const ChartTooltip = RechartsPrimitive.Tooltip
+
+function ChartTooltipContent({
+   active,
+   payload,
+   className,
+   indicator = 'dot',
+   hideLabel = false,
+   hideIndicator = false,
+   label,
+   labelFormatter,
+   labelClassName,
+   formatter,
+   color,
+   nameKey,
+   labelKey
+}) {
+   const { config } = useChart()
+
+   const tooltipLabel = React.useMemo(() => {
+      if (hideLabel || !payload?.length) {
+         return null
+      }
+
+      const [item] = payload
+      const key = `${labelKey ?? item?.dataKey ?? item?.name ?? 'value'}`
+      const itemConfig = getPayloadConfigFromPayload(config, item, key)
+      const value =
+      !labelKey && typeof label === 'string'
+         ? (config[label]?.label ?? label)
+         : itemConfig?.label
+
+      if (labelFormatter) {
+         return (
+            <div className={cn('font-medium', labelClassName)}>
+               {labelFormatter(value, payload)}
+            </div>
+         )
+      }
+
+      if (!value) {
+         return null
+      }
+
+      return <div className={cn('font-medium', labelClassName)}>{value}</div>
+   }, [
+      label,
+      labelFormatter,
+      payload,
+      hideLabel,
+      labelClassName,
+      config,
+      labelKey,
+   ])
+
+   if (!active || !payload?.length) {
+      return null
+   }
+
+   const nestLabel = payload.length === 1 && indicator !== 'dot'
+
+   return (
+      <div
+         className={cn(
+            'grid min-w-32 items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl',
+            className
+         )}>
+         {!nestLabel ? tooltipLabel : null}
+         <div className="grid gap-1.5">
+            {payload
+               .filter((item) => item.type !== 'none')
+               .map((item, index) => {
+                  const key = `${nameKey ?? item.name ?? item.dataKey ?? 'value'}`
+                  const itemConfig = getPayloadConfigFromPayload(config, item, key)
+                  const indicatorColor = color ?? item.payload?.fill ?? item.color
+
+                  return (
+                     <div
+                        key={index}
+                        className={cn(
+                           'flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground',
+                           indicator === 'dot' && 'items-center'
+                        )}>
+                        {formatter && item?.value !== undefined && item.name ? (
+                           formatter(item.value, item.name, item, index, item.payload)
+                        ) : (
+                           <>
+                              {itemConfig?.icon ? (
+                                 <itemConfig.icon />
+                              ) : (
+                                 !hideIndicator && (
+                                    <div
+                                       className={cn('shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)', {
+                                          'h-2.5 w-2.5': indicator === 'dot',
+                                          'w-1': indicator === 'line',
+                                          'w-0 border-[1.5px] border-dashed bg-transparent':
+                              indicator === 'dashed',
+                                          'my-0.5': nestLabel && indicator === 'dashed',
+                                       })}
+                                       style={
+                                          {
+                                             '--color-bg': indicatorColor,
+                                             '--color-border': indicatorColor
+                                          }
+                                       } />
+                                 )
+                              )}
+                              <div
+                                 className={cn(
+                                    'flex flex-1 justify-between leading-none',
+                                    nestLabel ? 'items-end' : 'items-center'
+                                 )}>
+                                 <div className="grid gap-1.5">
+                                    {nestLabel ? tooltipLabel : null}
+                                    <span className="text-muted-foreground">
+                                       {itemConfig?.label ?? item.name}
+                                    </span>
+                                 </div>
+                                 {item.value != null && (
+                                    <span className="font-mono font-medium text-foreground tabular-nums">
+                                       {typeof item.value === 'number'
+                                          ? item.value.toLocaleString()
+                                          : String(item.value)}
+                                    </span>
+                                 )}
+                              </div>
+                           </>
+                        )}
+                     </div>
+                  )
+               })}
+         </div>
+      </div>
+   )
+}
+
+const ChartLegend = RechartsPrimitive.Legend
+
+function ChartLegendContent({
+   className,
+   hideIcon = false,
+   payload,
+   verticalAlign = 'bottom',
+   nameKey
+}) {
+   const { config } = useChart()
+
+   if (!payload?.length) {
+      return null
+   }
+
+   return (
+      <div
+         className={cn(
+            'flex items-center justify-center gap-4',
+            verticalAlign === 'top' ? 'pb-3' : 'pt-3',
+            className
+         )}>
+         {payload
+            .filter((item) => item.type !== 'none')
+            .map((item, index) => {
+               const key = `${nameKey ?? item.dataKey ?? 'value'}`
+               const itemConfig = getPayloadConfigFromPayload(config, item, key)
+
+               return (
+                  <div
+                     key={index}
+                     className={cn(
+                        'flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground'
+                     )}>
+                     {itemConfig?.icon && !hideIcon ? (
+                        <itemConfig.icon />
+                     ) : (
+                        <div
+                           className="h-2 w-2 shrink-0 rounded-[2px]"
+                           style={{
+                              backgroundColor: item.color,
+                           }} />
+                     )}
+                     {itemConfig?.label}
+                  </div>
+               )
+            })}
+      </div>
+   )
+}
+
+function getPayloadConfigFromPayload(
+   config,
+   payload,
+   key
+) {
+   if (typeof payload !== 'object' || payload === null) {
+      return undefined
+   }
+
+   const payloadPayload =
+    'payload' in payload &&
+    typeof payload.payload === 'object' &&
+    payload.payload !== null
+       ? payload.payload
+       : undefined
+
+   let configLabelKey = key
+
+   if (
+      key in payload &&
+    typeof payload[key] === 'string'
+   ) {
+      configLabelKey = payload[key]
+   } else if (
+      payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key] === 'string'
+   ) {
+      configLabelKey = payloadPayload[key]
+   }
+
+   return configLabelKey in config ? config[configLabelKey] : config[key]
+}
+
+export {
+   ChartContainer,
+   ChartTooltip,
+   ChartTooltipContent,
+   ChartLegend,
+   ChartLegendContent,
+   ChartStyle,
+}

--- a/src/views/mocks/index.js
+++ b/src/views/mocks/index.js
@@ -1,7 +1,7 @@
 import { tradingPairs, orderBatch, balances, closedOrders, xstocks } from './kraken'
 import {
    ledgerSync, ledgerSyncStatus, ledgerSyncCancel, ledgerClear,
-   ledgerEntries, ledgerFilters
+   ledgerEntries, ledgerFilters, ledgerFees
 } from './kraken-ledger'
 import { aggregateBalance } from './binance'
 
@@ -17,6 +17,7 @@ const mockRoutes = {
    '/api/kraken/ledger/sync/cancel': () => ledgerSyncCancel(),
    '/api/kraken/ledger/entries': (params) => ledgerEntries(params?.arg),
    '/api/kraken/ledger/filters': () => ledgerFilters(),
+   '/api/kraken/ledger/fees': (params) => ledgerFees(params?.arg),
    '/api/kraken/ledger/clear': () => ledgerClear(),
    '/api/binance/aggregate-balance': () => aggregateBalance,
 }

--- a/src/views/mocks/kraken-ledger.js
+++ b/src/views/mocks/kraken-ledger.js
@@ -1,9 +1,13 @@
 // Deterministic pseudo-random source, so the fixture is identical across reloads.
+// The low bits of a linear congruential generator cycle far too quickly to be taken
+// modulo anything — the lowest one alternates every draw, so `state % 10` came out
+// even nine times out of ten and the rarer entry types never appeared. The draw is
+// taken from the high bits instead.
 function randomizer(seed) {
    let state = seed
    return (max) => {
       state = (state * 1103515245 + 12345) % 2147483648
-      return state % max
+      return Math.floor(state / 65536) % max
    }
 }
 
@@ -50,8 +54,10 @@ function buildEntries() {
             asset, baseAsset, wallet: 'earn', amount: (random(100000) / 10000).toFixed(8), balance })
       }
       else if (roll < 9) {
+         // Kraken charges on some fiat funding methods, so deposits carry a fee too.
          push({ txid: `L${i}`, refid: `DP${i}`, time, type: 'deposit',
-            asset: 'ZUSD', baseAsset: 'USD', amount: `${500 + random(4500)}.0000`, balance })
+            asset: 'ZUSD', baseAsset: 'USD', amount: `${500 + random(4500)}.0000`,
+            fee: (random(600) / 100).toFixed(4), balance })
       }
       else {
          push({ txid: `L${i}`, refid: `WD${i}`, time, type: 'withdrawal',
@@ -206,6 +212,61 @@ export function ledgerEntries(body = {}) {
    const pageSize = body.pageSize ?? 50
 
    return { rows: sorted.slice(page * pageSize, (page + 1) * pageSize), total: filtered.length, page, pageSize }
+}
+
+// Mirrors LedgerRepository.feeSummary: same groupings, same shape, computed over the
+// fixture so the page exercises its real rendering rather than a canned response.
+export function ledgerFees(body = {}) {
+
+   const charged = applyFilters(body.filters).filter(entry => Number(entry.fee) !== 0)
+
+   const group = (keyOf) => {
+      const groups = new Map()
+      for (const entry of charged) {
+         const key = keyOf(entry)
+         const group = groups.get(key)
+            ?? { total: 0, entries: 0, first: entry.time, last: entry.time }
+         group.total += Number(entry.fee)
+         group.entries += 1
+         group.first = Math.min(group.first, entry.time)
+         group.last = Math.max(group.last, entry.time)
+         groups.set(key, group)
+      }
+      return groups
+   }
+
+   const monthOf = entry => new Date(entry.time).toISOString().slice(0, 7)
+
+   const assets = [...group(entry => entry.baseAsset)]
+      .map(([asset, group]) => ({ asset, ...group }))
+      .toSorted((a, b) => b.entries - a.entries || a.asset.localeCompare(b.asset))
+
+   const byType = [...group(entry => `${entry.baseAsset}|${entry.type}`)]
+      .map(([key, group]) => ({ asset: key.split('|')[0], type: key.split('|')[1], total: group.total, entries: group.entries }))
+      .toSorted((a, b) => b.entries - a.entries)
+
+   const byMonth = [...group(entry => `${monthOf(entry)}|${entry.baseAsset}|${entry.type}`)]
+      .map(([key, group]) => {
+         const [month, asset, type] = key.split('|')
+         return { month, asset, type, total: group.total, entries: group.entries }
+      })
+      .toSorted((a, b) => a.month.localeCompare(b.month))
+
+   // Ranked per asset, like the SQL window function does.
+   const largest = assets.flatMap(({ asset }) => charged
+      .filter(entry => entry.baseAsset === asset)
+      .toSorted((a, b) => Number(b.fee) - Number(a.fee))
+      .slice(0, 10))
+
+   return {
+      assets,
+      byType,
+      byMonth,
+      largest,
+      entries: charged.length,
+      first: charged.length > 0 ? Math.min(...charged.map(entry => entry.time)) : null,
+      last: charged.length > 0 ? Math.max(...charged.map(entry => entry.time)) : null
+   }
 }
 
 export function ledgerFilters() {

--- a/src/views/pages/home.jsx
+++ b/src/views/pages/home.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Link } from 'react-router'
-import { CoinsIcon, HistoryIcon, KeyRoundIcon, LayersIcon, ScrollTextIcon, SparklesIcon, WalletIcon } from 'lucide-react'
+import { CoinsIcon, HistoryIcon, KeyRoundIcon, LayersIcon, ReceiptIcon, ScrollTextIcon, SparklesIcon, WalletIcon } from 'lucide-react'
 import Layout from '../components/layout'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
@@ -27,6 +27,12 @@ const toolGroups = [
             title: 'Ledger',
             description: 'Sync your full ledger to a local database and browse it.',
             icon: ScrollTextIcon
+         },
+         {
+            href: '/kraken/fees',
+            title: 'Fees',
+            description: 'Everything Kraken has charged you, totalled per asset and over time.',
+            icon: ReceiptIcon
          },
          {
             href: '/kraken/balances',

--- a/src/views/pages/kraken/fees.jsx
+++ b/src/views/pages/kraken/fees.jsx
@@ -1,0 +1,124 @@
+import { useState } from 'react'
+import { Link } from 'react-router'
+import useSWR from 'swr'
+import { InfoIcon } from 'lucide-react'
+import KrakenLayout from '../../components/kraken/kraken-layout'
+import FeeSummaryCard from '../../components/kraken/fee-summary-card'
+import FeeChartCard from '../../components/kraken/fee-chart-card'
+import FeeBreakdownCard from '../../components/kraken/fee-breakdown-card'
+import { defaultFilters } from '../../components/kraken/ledger-filters'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+
+const isUnfiltered = filters => Object.keys(defaultFilters)
+   .every(key => filters[key] === defaultFilters[key])
+
+
+export default function KrakenFees() {
+
+   const [credentials] = useState(() => ({
+      apiKey: (typeof window !== 'undefined' && localStorage.getItem('kraken.api.key')) || ''
+   }))
+
+   const [filters, setFilters] = useState(defaultFilters)
+   const [filtersKey, setFiltersKey] = useState(0)
+   const [asset, setAsset] = useState(null)
+   const [granularity, setGranularity] = useState('month')
+
+   // This page never contacts Kraken — it only reads the ledger the Ledger tab
+   // already downloaded — so the secret is neither needed nor sent.
+   const account = credentials.apiKey ? { apiKey: credentials.apiKey } : null
+
+   const { data: fees, error, isLoading } = useSWR(
+      account ? ['/api/kraken/ledger/fees', { credentials: account, filters }] : null,
+      { keepPreviousData: true })
+
+   const { data: filterOptions } = useSWR(
+      account ? ['/api/kraken/ledger/filters', { credentials: account }] : null)
+
+   if (!credentials.apiKey) {
+      return (
+         <KrakenLayout name="Fees">
+            <Alert>
+               <AlertDescription>
+                  Generate an API key and secret on Kraken and add them in Settings to sync your ledger.
+               </AlertDescription>
+            </Alert>
+         </KrakenLayout>
+      )
+   }
+
+   // Colours are assigned from every entry type the ledger holds rather than the ones
+   // left after filtering, so narrowing the range never repaints the types that survive.
+   const knownTypes = [...new Set([
+      ...(filterOptions?.types ?? []),
+      ...(fees?.byType ?? []).map(row => row.type)
+   ])].toSorted()
+
+   const colors = new Map(knownTypes.map((type, index) => [type, `var(--chart-${(index % 8) + 1})`]))
+
+   // Derived rather than stored: filtering the selected asset out of the results falls
+   // back to the one charged most often instead of leaving the charts blank.
+   const assetOptions = (fees?.assets ?? []).map(row => row.asset)
+   const selectedAsset = assetOptions.includes(asset) ? asset : (assetOptions[0] ?? null)
+
+   const changeFilters = (next) => setFilters(next)
+
+   const resetFilters = () => {
+      setFilters(defaultFilters)
+      setFiltersKey(key => key + 1)
+   }
+
+   return (
+      <KrakenLayout name="Fees">
+         <div className="space-y-6">
+
+            <div className="flex items-center gap-3 rounded-lg border border-blue-300/60 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-500/25 dark:bg-blue-950/30 dark:text-blue-100">
+               <InfoIcon className="size-5 shrink-0" />
+               <p>
+                  Everything Kraken has charged you since the account was opened — mostly trade
+                  fees, but also withdrawal fees and anything else the ledger records — read from
+                  the local database the Ledger tab fills. Fees are kept in the asset they were
+                  charged in and never converted, so each asset is totalled on its own.
+               </p>
+            </div>
+
+            {error &&
+               <Alert variant="destructive">
+                  <AlertDescription>{error}</AlertDescription>
+               </Alert>}
+
+            {fees?.entries === 0 && isUnfiltered(filters) &&
+               <Alert>
+                  <AlertDescription>
+                     No ledger entries stored yet. Sync your ledger on the{' '}
+                     <Link to="/kraken/ledger" className="font-medium text-foreground underline underline-offset-4">
+                        Ledger
+                     </Link>{' '}
+                     tab first, then come back.
+                  </AlertDescription>
+               </Alert>}
+
+            <FeeSummaryCard
+               fees={fees}
+               filters={filters}
+               filtersKey={filtersKey}
+               options={filterOptions}
+               isLoading={isLoading}
+               onFiltersChange={changeFilters}
+               onFiltersReset={resetFilters} />
+
+            <FeeChartCard
+               fees={fees}
+               colors={colors}
+               assets={assetOptions}
+               asset={selectedAsset}
+               granularity={granularity}
+               onAssetChange={setAsset}
+               onGranularityChange={setGranularity} />
+
+            <FeeBreakdownCard fees={fees} colors={colors} asset={selectedAsset} />
+
+         </div>
+      </KrakenLayout>
+   )
+}

--- a/src/views/pages/kraken/ledger.jsx
+++ b/src/views/pages/kraken/ledger.jsx
@@ -145,7 +145,7 @@ export default function KrakenLedger() {
                onSync={() => sync('incremental')}
                onFullResync={() => sync('full')}
                onCancel={() => cancelSync({ credentials: account }).catch(() => {})}
-               onClear={() => clearLedger({ credentials: account }).then(refreshLedger).catch(() => {})} />
+               onClear={() => clearLedger({ credentials: account }).then(refreshStoredData).catch(() => {})} />
 
             <Card>
                <CardHeader>

--- a/src/views/styles/global.css
+++ b/src/views/styles/global.css
@@ -15,6 +15,9 @@
     --color-sidebar-primary: var(--sidebar-primary);
     --color-sidebar-foreground: var(--sidebar-foreground);
     --color-sidebar: var(--sidebar);
+    --color-chart-8: var(--chart-8);
+    --color-chart-7: var(--chart-7);
+    --color-chart-6: var(--chart-6);
     --color-chart-5: var(--chart-5);
     --color-chart-4: var(--chart-4);
     --color-chart-3: var(--chart-3);
@@ -66,11 +69,17 @@
     --border: oklch(0.922 0 0);
     --input: oklch(0.922 0 0);
     --ring: oklch(0.708 0 0);
-    --chart-1: oklch(0.87 0 0);
-    --chart-2: oklch(0.556 0 0);
-    --chart-3: oklch(0.439 0 0);
-    --chart-4: oklch(0.371 0 0);
-    --chart-5: oklch(0.269 0 0);
+    /* Categorical series colours, assigned in slot order and never cycled. The
+       ordering is what keeps adjacent series apart under colour-vision deficiency,
+       so re-order rather than re-mix if a pair ever reads as the same colour. */
+    --chart-1: oklch(0.575 0.163 255.5);
+    --chart-2: oklch(0.671 0.175 40.6);
+    --chart-3: oklch(0.669 0.141 162.1);
+    --chart-4: oklch(0.764 0.161 75.1);
+    --chart-5: oklch(0.716 0.141 357.4);
+    --chart-6: oklch(0.529 0.180 142.5);
+    --chart-7: oklch(0.433 0.167 283.6);
+    --chart-8: oklch(0.623 0.191 24.9);
     --radius: 0.625rem;
     --sidebar: oklch(0.985 0 0);
     --sidebar-foreground: oklch(0.145 0 0);
@@ -101,11 +110,16 @@
     --border: oklch(1 0 0 / 10%);
     --input: oklch(1 0 0 / 15%);
     --ring: oklch(0.556 0 0);
-    --chart-1: oklch(0.87 0 0);
-    --chart-2: oklch(0.556 0 0);
-    --chart-3: oklch(0.439 0 0);
-    --chart-4: oklch(0.371 0 0);
-    --chart-5: oklch(0.269 0 0);
+    /* The same eight hues re-stepped for the dark card surface, not an automatic
+       flip of the light values, which would drop below the contrast floor. */
+    --chart-1: oklch(0.622 0.161 255.1);
+    --chart-2: oklch(0.622 0.173 40.1);
+    --chart-3: oklch(0.621 0.128 163.1);
+    --chart-4: oklch(0.670 0.143 73.2);
+    --chart-5: oklch(0.622 0.171 0.8);
+    --chart-6: oklch(0.529 0.180 142.5);
+    --chart-7: oklch(0.670 0.145 286.8);
+    --chart-8: oklch(0.669 0.159 22.3);
     --sidebar: oklch(0.205 0 0);
     --sidebar-foreground: oklch(0.985 0 0);
     --sidebar-primary: oklch(0.488 0.243 264.376);


### PR DESCRIPTION
Adds a **Fees** page under `/kraken/fees` answering "what has Kraken charged me since I opened this account?", reading only the local SQLite ledger the Ledger tab fills. No Kraken API calls.

## Why fees stay per-asset

A fee is denominated in its own row's asset — a trade fee lands in the pair's quote currency, a withdrawal fee in the coin withdrawn — and `ledger_entry` has no fee-asset column. Every figure therefore stays grouped by asset. Nothing is converted between currencies, which keeps the page exact and free of any price-data dependency. In practice one fiat line dominates, so the answer still reads as a single number.

## Server

`LedgerRepository.feeSummary(filters)` reuses the existing `buildWhere` helper and groups fees four ways:

| Key | Grouping |
|---|---|
| `assets` | per `base_asset` — total, count, first and last |
| `byType` | per asset and entry type |
| `byMonth` | per month, asset and type (UTC, via `strftime('%Y-%m', time / 1000, 'unixepoch')`) |
| `largest` | the ten biggest single fees **per asset**, via `ROW_NUMBER() OVER (PARTITION BY base_asset …)` |

Ranking largest fees across assets would compare a number of DOGE against a number of EUR, hence the partition. Fees stay exact decimal strings in storage; the `CAST(fee AS REAL)` is only for summing to display, mirroring how `amount_num` already works.

Exposed as `POST /api/kraken/ledger/fees` through the existing `withAccount` wrapper.

## Page

Three cards, styled to match Ledger and Order Batch:

- **Fees paid** — filters, overall stat tiles, per-asset totals table.
- **Over time** — stacked bar chart by ledger entry type, one asset at a time, grouped by month, quarter or year. Putting a fiat and a crypto total on one axis would make both unreadable, hence the asset selector. Quiet months are walked rather than taken from the data, so a gap doesn't collapse the axis.
- **By type** — every asset × type with its share, plus the largest single fees for the selected asset.

The filter bar is `LedgerFilters` reused behind a new `showSearch` prop — narrowing an aggregate view to a single transaction id says nothing. The `Field` stat tile moves out of `ledger-sync-card.jsx` into `components/lib/field.jsx` so both pages share it.

## Chart palette

`--chart-1..5` were five identical neutral greys, so any multi-series chart rendered as one colour. Replaced with eight categorical hues, stepped separately for the light and dark card surfaces and checked for colour-vision separation and contrast against both. Series colours are assigned from the ledger's full list of entry types rather than the types left after filtering, so narrowing the range never repaints the survivors.

`isAnimationActive={false}` on the bars is deliberate: under `StrictMode` the animation effect is mounted, torn down and remounted, and the bars can stay stuck on the zero-height first frame, rendering no rectangles at all.

## Also in here

- **`fix(kraken): refresh the ledger after clearing it`** (separate commit) — `onClear` called an undefined `refreshLedger`; the `ReferenceError` was swallowed by the promise chain, so clearing left stale rows on screen.
- The mock fixture's generator drew from the low bits of a linear congruential sequence, which barely vary — `roll(10)` came out even in about 97% of draws, so the withdrawal branch almost never fired and the fixture held little more than trades. It now draws from the high bits, and fiat deposits carry a fee. Mocked mode exercises the new page, and the Ledger type filter gains real variety.
- `recharts` stays pinned at `3.10.1`; the shadcn CLI had downgraded it to `3.8.0` when adding the chart component.

## Verification

No test framework is configured, so this was checked by hand.

- `bun run lint` clean.
- `feeSummary` exercised against a real `bun:sqlite` database: account scoping, each filter, and the empty-account case.
- `bun run mocked` — tables, chart geometry across all nine months, month/quarter/year switching, asset switching, filters narrowing every card at once, tooltip values and swatches, and dark mode. Ledger page re-checked after the shared-component changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
