### PR TITLE
feat(kraken): redesign the Balances page and read it from the ledger

### DIFF
--- a/src/server/adapters/kraken-api/adapter.js
+++ b/src/server/adapters/kraken-api/adapter.js
@@ -1,7 +1,7 @@
 import Big from 'big.js'
 import { unzipSync } from 'fflate'
 import * as resource from './resource'
-import { assetCategory, normalizeAsset } from './assets'
+import { normalizeAsset } from './assets'
 import { buildPairIndex, resolvePair } from './pairs'
 import { parseCsv, parseCsvTime } from './csv'
 
@@ -77,32 +77,67 @@ export default function KrakenAPI(credentials) {
       return buildPairIndex(assetPairs)
    }
 
-   this.fetchBalances = async function () {
+   // The total Kraken holds per asset, and how much of it is reserved by open orders.
+   //
+   // Deliberately not split by wallet the way the ledger is: BalanceEx has no wallet
+   // field, and a modern Earn allocation carries no suffix to infer one from — only
+   // the retired staking names (DOT28.S) ever did. Splitting here would invent a
+   // breakdown. This answers "how much, in total, and how much of it is spoken for";
+   // where each coin sits is the ledger's question.
+   this.fetchLiveBalances = async function () {
 
       const response = await resource.fetchExtendedBalance(credentials)
-      return Object.keys(response.result)
-         .reduce((balances, asset) => {
 
-            const normalizedAsset = normalizeAsset(asset)
-            const category = assetCategory(asset)
+      const totals = new Map()
 
-            const freeBalance = Big(response.result[asset].balance)
-            const holdTradeBalance = Big(response.result[asset].hold_trade)
+      for (const [asset, entry] of Object.entries(response.result ?? {})) {
 
-            if (freeBalance.add(holdTradeBalance).eq(0)) {
-               return balances
-            }
+         const normalizedAsset = normalizeAsset(asset)
+         const held = Big(entry.balance ?? 0)
+         const hold = Big(entry.hold_trade ?? 0)
 
-            balances[normalizedAsset] ??= {}
-            if (!freeBalance.eq(0)) {
-               balances[normalizedAsset][category] = freeBalance.add(balances[normalizedAsset][category] ?? 0)
-            }
-            if (!holdTradeBalance.eq(0)) {
-               balances[normalizedAsset].trade = holdTradeBalance.add(balances[normalizedAsset].trade ?? 0)
-            }
+         if (held.add(hold).eq(0)) continue
 
-            return balances
-         }, {})
+         const total = totals.get(normalizedAsset) ?? { total: Big(0), hold: Big(0) }
+         // Kraken reports hold_trade as part of the balance, not on top of it.
+         totals.set(normalizedAsset, { total: total.total.add(held), hold: total.hold.add(hold) })
+      }
+
+      return [...totals.entries()]
+         .map(([asset, { total, hold }]) => ({
+            asset,
+            total: total.toFixed(),
+            totalNum: Number(total),
+            hold: hold.toFixed(),
+            holdNum: Number(hold)
+         }))
+         .toSorted((a, b) => a.asset.localeCompare(b.asset))
+   }
+
+   // The orders behind the hold above, so that a balance that looks short can be
+   // explained rather than just flagged.
+   this.fetchOpenOrders = async function () {
+
+      const response = await resource.fetchOpenOrders(credentials)
+      const orders = Object.entries(response.result?.open ?? {})
+      if (orders.length === 0) return []
+
+      // Resolved through the same index the trade sync uses, so an open order reads
+      // with the names the rest of the app shows (XXBTZUSD becomes BTC/USD).
+      const pairIndex = await this.fetchPairIndex()
+
+      return orders
+         .map(([txid, order]) => ({
+            txid,
+            ...resolvePair(order.descr?.pair, pairIndex),
+            type: order.descr?.type ?? '',
+            ordertype: order.descr?.ordertype ?? '',
+            price: order.descr?.price ?? '0',
+            volume: order.vol ?? '0',
+            executed: order.vol_exec ?? '0',
+            opened: Math.round((order.opentm ?? 0) * 1000)
+         }))
+         .toSorted((a, b) => b.opened - a.opened)
    }
 
    // What one unit of each asset is worth in USD right now, for the assets asked for.

--- a/src/server/adapters/kraken-api/adapter.js
+++ b/src/server/adapters/kraken-api/adapter.js
@@ -89,7 +89,7 @@ export default function KrakenAPI(credentials) {
    //    "staked" but sits in the bonded wallet, .M is "opt-in rewards" but is the
    //    flexible one, .B is "new yield-bearing products" but is the locked one. The
    //    letters are also not stable — a position keyed XBT.F in mid-2025 is XBT.M now.
-   //  - Auto Earn has no suffix at all. Kraken pays those rewards onto the plain spot
+   //  - An opted-in holding has no suffix at all. Kraken pays those rewards onto the spot
    //    balance, so an asset earning that way is indistinguishable here from one that
    //    is doing nothing. The ledger's reward entries are the only way to tell.
    //

--- a/src/server/adapters/kraken-api/adapter.js
+++ b/src/server/adapters/kraken-api/adapter.js
@@ -79,11 +79,22 @@ export default function KrakenAPI(credentials) {
 
    // The total Kraken holds per asset, and how much of it is reserved by open orders.
    //
-   // Deliberately not split by wallet the way the ledger is: BalanceEx has no wallet
-   // field, and a modern Earn allocation carries no suffix to infer one from — only
-   // the retired staking names (DOT28.S) ever did. Splitting here would invent a
-   // breakdown. This answers "how much, in total, and how much of it is spoken for";
-   // where each coin sits is the ledger's question.
+   // Deliberately not split by placement, even though BalanceEx does key earn positions
+   // separately and does so accurately — checked against a real response, its suffixed
+   // balances match the ledger's per-wallet amounts to the last digit. Two reasons the
+   // breakdown is still read from the ledger:
+   //
+   //  - The suffix does not name the wallet, and the names it does carry are Kraken's
+   //    product vocabulary rather than the one its own Earn screen shows: .S is
+   //    "staked" but sits in the bonded wallet, .M is "opt-in rewards" but is the
+   //    flexible one, .B is "new yield-bearing products" but is the locked one. The
+   //    letters are also not stable — a position keyed XBT.F in mid-2025 is XBT.M now.
+   //  - Auto Earn has no suffix at all. Kraken pays those rewards onto the plain spot
+   //    balance, so an asset earning that way is indistinguishable here from one that
+   //    is doing nothing. The ledger's reward entries are the only way to tell.
+   //
+   // This answers "how much, in total, and how much of it is spoken for"; where each
+   // coin sits is the ledger's question.
    this.fetchLiveBalances = async function () {
 
       const response = await resource.fetchExtendedBalance(credentials)

--- a/src/server/adapters/kraken-api/assets.js
+++ b/src/server/adapters/kraken-api/assets.js
@@ -23,23 +23,14 @@ export function normalizeAsset(asset) {
    if (!asset) return ''
 
    // Strip any staking, earn or parachain suffix: DOT28.S becomes DOT, XBT.F becomes
-   // XBT. Tickers that are entirely digits-and-letters (0G, 1INCH) fall back to the
-   // original, since splitting them would leave nothing.
-   let base = asset.split(/[0-9.]/)[0] || asset
+   // XBT. Only a trailing suffix is removed, digits and all — splitting on the first
+   // digit anywhere would turn AI16Z into AI and USD1 into USD, which are different
+   // assets entirely. Tickers that carry no suffix (0G, 1INCH, AI16Z) come back whole.
+   let base = asset.replace(/\d*\.[A-Z]+$/, '') || asset
 
    if (prefixedAssets.has(asset) || prefixedAssets.has(base)) {
       base = base.slice(1)
    }
 
    return assetAliases[base] ?? assetAliases[asset] ?? base
-}
-
-// Which balance bucket an asset name belongs to. The order matters: DOT28.S is
-// staking rather than earning because the earn pattern needs a letter immediately
-// before the dot.
-export function assetCategory(asset) {
-   if (/[A-Z]+\.P/.test(asset)) return 'parachain'
-   if (/[A-Z]+\.[SFMB]/.test(asset)) return 'earning'
-   if (/[A-Z]+[0-9]+\.S/.test(asset)) return 'staking'
-   return 'free'
 }

--- a/src/server/adapters/kraken-api/resource.js
+++ b/src/server/adapters/kraken-api/resource.js
@@ -11,6 +11,7 @@ const tickerEndpoint = '/0/public/Ticker'
 
 const addOrderBatchEndpoint = '/0/private/AddOrderBatch'
 const balanceExtendedEndpoint = '/0/private/BalanceEx'
+const openOrdersEndpoint = '/0/private/OpenOrders'
 
 const addExportEndpoint = '/0/private/AddExport'
 const exportStatusEndpoint = '/0/private/ExportStatus'
@@ -45,6 +46,16 @@ export async function fetchTicker(pairs) {
 export async function fetchExtendedBalance(apiCredentials) {
    return await httpRequester.private(
       urlFor(balanceExtendedEndpoint),
+      authenticator(apiCredentials),
+      { method: 'POST' })
+}
+
+// What is still on the book. The ledger only ever learns about an order once it has
+// filled, so this is the one thing it cannot answer: which of the balance it shows is
+// already spoken for.
+export async function fetchOpenOrders(apiCredentials) {
+   return await httpRequester.private(
+      urlFor(openOrdersEndpoint),
       authenticator(apiCredentials),
       { method: 'POST' })
 }

--- a/src/server/adapters/kraken-api/resource.js
+++ b/src/server/adapters/kraken-api/resource.js
@@ -43,31 +43,46 @@ export async function fetchTicker(pairs) {
 
 /* Private endpoints */
 
+// Kraken checks that the nonce of each private call arrives in increasing order, and
+// the authenticator can only guarantee the order they are *generated* in. Two calls in
+// flight at once can reach Kraken the other way round, which it rejects with
+// EAPI:Invalid nonce — as it did for every page that asked for balances while a sync
+// was polling, or twice at once under React's StrictMode.
+//
+// So private calls queue behind one another. A slow one (retrieving an export) holds up
+// the next, which is the price of never having one rejected outright.
+let pending = Promise.resolve()
+
+function inNonceOrder(request) {
+   const result = pending.then(request, request)
+   // The queue must survive a failed call: chaining on `result` itself would leave
+   // every later request rejected by the first error.
+   pending = result.then(() => {}, () => {})
+   return result
+}
+
+const privateRequest = (url, apiCredentials, options = {}) =>
+   inNonceOrder(() => httpRequester.private(
+      url, authenticator(apiCredentials), { method: 'POST', ...options }))
+
 export async function fetchExtendedBalance(apiCredentials) {
-   return await httpRequester.private(
-      urlFor(balanceExtendedEndpoint),
-      authenticator(apiCredentials),
-      { method: 'POST' })
+   return await privateRequest(urlFor(balanceExtendedEndpoint), apiCredentials)
 }
 
 // What is still on the book. The ledger only ever learns about an order once it has
 // filled, so this is the one thing it cannot answer: which of the balance it shows is
 // already spoken for.
 export async function fetchOpenOrders(apiCredentials) {
-   return await httpRequester.private(
-      urlFor(openOrdersEndpoint),
-      authenticator(apiCredentials),
-      { method: 'POST' })
+   return await privateRequest(urlFor(openOrdersEndpoint), apiCredentials)
 }
 
 /* Export report endpoints, used to fetch the full ledger and trade history in one go */
 
 export async function addExport(apiCredentials, { report = 'ledgers', description, fromDate, toDate }) {
-   return await httpRequester.private(
+   return await privateRequest(
       urlFor(addExportEndpoint),
-      authenticator(apiCredentials),
+      apiCredentials,
       {
-         method: 'POST',
          bodyParams: {
             report,
             format: 'CSV',
@@ -86,32 +101,26 @@ export async function addExport(apiCredentials, { report = 'ledgers', descriptio
 // that was exported — a ledgers-only listing never contains the trades report, and
 // waiting for it there would simply time out.
 export async function fetchExportStatus(apiCredentials, report = 'ledgers') {
-   return await httpRequester.private(
-      urlFor(exportStatusEndpoint),
-      authenticator(apiCredentials),
-      { method: 'POST', bodyParams: { report } })
+   return await privateRequest(urlFor(exportStatusEndpoint), apiCredentials, { bodyParams: { report } })
 }
 
 export async function retrieveExport(apiCredentials, { reportId }) {
-   return await httpRequester.private(
-      urlFor(retrieveExportEndpoint),
-      authenticator(apiCredentials),
-      { method: 'POST', bodyParams: { id: reportId }, responseType: 'binary' })
+   return await privateRequest(
+      urlFor(retrieveExportEndpoint), apiCredentials,
+      { bodyParams: { id: reportId }, responseType: 'binary' })
 }
 
 export async function removeExport(apiCredentials, { reportId, type = 'delete' }) {
-   return await httpRequester.private(
-      urlFor(removeExportEndpoint),
-      authenticator(apiCredentials),
-      { method: 'POST', bodyParams: { id: reportId, type } })
+   return await privateRequest(
+      urlFor(removeExportEndpoint), apiCredentials,
+      { bodyParams: { id: reportId, type } })
 }
 
 export async function createOrderBatch(apiCredentials, { pair, direction, dryRun, orders }) {
-   return await httpRequester.private(
+   return await privateRequest(
       urlFor(addOrderBatchEndpoint),
-      authenticator(apiCredentials),
+      apiCredentials,
       {
-         method: 'POST',
          bodyParams: {
             pair,
             validate: dryRun,

--- a/src/server/db/ledger-repository.js
+++ b/src/server/db/ledger-repository.js
@@ -1,3 +1,4 @@
+import Big from 'big.js'
 import { getDatabase } from './database.js'
 import { entryKeyFor } from './entry-key.js'
 
@@ -207,6 +208,103 @@ export default function LedgerRepository(accountId) {
          entries: rows.reduce((count, row) => count + row.entries, 0),
          first: rows.length > 0 ? Math.min(...rows.map(row => row.first)) : null,
          last: rows.length > 0 ? Math.max(...rows.map(row => row.last)) : null
+      }
+   }
+
+   // What is held right now, per asset and per wallet, rebuilt from the entries
+   // themselves rather than read off Kraken's running balance column: that column is
+   // only ever a snapshot of the last row written for a wallet, and says nothing about
+   // an asset whose most recent entry was somewhere else.
+   //
+   // Kraken's own running balance is what this was checked against — summing
+   // amount - fee per (asset, wallet) reproduces it to the last digit for every asset
+   // in the database, which is why the fold below is done with Big rather than the
+   // REAL mirrors the fee and reward summaries use. A balance is compared against
+   // Kraken by eye; a rounding artefact in the eighth decimal would look like a bug.
+   this.balanceSummary = function () {
+
+      const amounts = db.query(`
+         SELECT base_asset AS baseAsset, wallet, asset AS rawAsset, amount, fee
+         FROM ledger_entry WHERE account_id = ?`).all(accountId)
+
+      const positions = new Map()
+      const keyFor = row => `${row.baseAsset} ${row.wallet}`
+
+      for (const row of amounts) {
+         const position = positions.get(keyFor(row))
+            ?? { asset: row.baseAsset, wallet: row.wallet, amount: Big(0), rawAssets: new Set() }
+
+         position.amount = position.amount.plus(row.amount || 0).minus(row.fee || 0)
+         position.rawAssets.add(row.rawAsset)
+         positions.set(keyFor(row), position)
+      }
+
+      // Counted separately from the fold: the row count and the first and last time an
+      // asset moved are what SQLite is good at, and neither needs exact arithmetic.
+      for (const row of db.query(`
+         SELECT base_asset AS baseAsset, wallet, COUNT(*) AS entries,
+                MIN(time) AS first, MAX(time) AS last
+         FROM ledger_entry WHERE account_id = ?
+         GROUP BY base_asset, wallet`).all(accountId)) {
+         const position = positions.get(keyFor(row))
+         if (position) Object.assign(position, { entries: row.entries, first: row.first, last: row.last })
+      }
+
+      // When a wallet last paid out. Kraken now pays Auto Earn rewards straight into
+      // the spot wallet instead of moving the coins, so this is the only thing that
+      // tells a spot position that earns from one that just sits there.
+      for (const row of db.query(`
+         SELECT base_asset AS baseAsset, wallet, MAX(time) AS lastRewardAt,
+                COUNT(*) AS rewardEntries
+         FROM ledger_entry
+         WHERE account_id = ? AND ${isReward}
+         GROUP BY base_asset, wallet`).all(accountId)) {
+         const position = positions.get(keyFor(row))
+         if (position) Object.assign(position, { lastRewardAt: row.lastRewardAt, rewardEntries: row.rewardEntries })
+      }
+
+      const assets = new Map()
+
+      for (const position of positions.values()) {
+
+         // An exactly zero position is one that was closed, not a dust holding: the
+         // coins left, and listing it would bury the assets that are still held.
+         if (position.amount.eq(0)) continue
+
+         const asset = assets.get(position.asset)
+            ?? { asset: position.asset, total: Big(0), positions: [] }
+
+         asset.total = asset.total.plus(position.amount)
+         asset.positions.push({
+            wallet: position.wallet,
+            amount: position.amount.toFixed(),
+            amountNum: Number(position.amount),
+            // Sorted so that the plain ticker leads and a legacy staking name (DOT.S)
+            // reads as the footnote it is.
+            rawAssets: [...position.rawAssets].toSorted(),
+            entries: position.entries ?? 0,
+            first: position.first ?? null,
+            last: position.last ?? null,
+            lastRewardAt: position.lastRewardAt ?? null,
+            rewardEntries: position.rewardEntries ?? 0
+         })
+         assets.set(position.asset, asset)
+      }
+
+      const range = this.entryTimeRange()
+      const held = [...assets.values()]
+
+      return {
+         assets: held.map(asset => ({
+            asset: asset.asset,
+            total: asset.total.toFixed(),
+            totalNum: Number(asset.total),
+            positions: asset.positions.toSorted((a, b) => b.amountNum - a.amountNum)
+         })),
+         positions: held.reduce((count, asset) => count + asset.positions.length, 0),
+         entries: amounts.length,
+         first: range.first,
+         last: range.last
       }
    }
 

--- a/src/server/routes/kraken-ledger.js
+++ b/src/server/routes/kraken-ledger.js
@@ -67,6 +67,9 @@ app.post('/fees', async (c) => withAccount(c, ({ body, accountId }) =>
 app.post('/rewards', async (c) => withAccount(c, ({ accountId }) =>
    c.json(new LedgerRepository(accountId).rewardSummary())))
 
+app.post('/balances', async (c) => withAccount(c, ({ accountId }) =>
+   c.json(new LedgerRepository(accountId).balanceSummary())))
+
 app.post('/clear', async (c) => withAccount(c, ({ accountId }) => {
 
    if (isRunning(jobFor(accountId))) {

--- a/src/server/routes/kraken.js
+++ b/src/server/routes/kraken.js
@@ -21,10 +21,11 @@ app.post('/balances', async (c) => {
    try {
       const krakenAPI = new KrakenAPI(credentials)
 
-      const [assets, openOrders] = await Promise.all([
-         krakenAPI.fetchLiveBalances(),
-         krakenAPI.fetchOpenOrders()
-      ])
+      // Sequentially, not with Promise.all: Kraken wants the nonce of each private
+      // call to arrive in increasing order, and two requests in flight at once can
+      // reach it the other way round — which it answers with EAPI:Invalid nonce.
+      const assets = await krakenAPI.fetchLiveBalances()
+      const openOrders = await krakenAPI.fetchOpenOrders()
 
       return c.json({ fetchedAt: Date.now(), assets, openOrders })
    }

--- a/src/server/routes/kraken.js
+++ b/src/server/routes/kraken.js
@@ -21,9 +21,9 @@ app.post('/balances', async (c) => {
    try {
       const krakenAPI = new KrakenAPI(credentials)
 
-      // Sequentially, not with Promise.all: Kraken wants the nonce of each private
-      // call to arrive in increasing order, and two requests in flight at once can
-      // reach it the other way round — which it answers with EAPI:Invalid nonce.
+      // Sequentially rather than with Promise.all. The resource layer would queue them
+      // anyway — Kraken rejects private calls whose nonces arrive out of order — and
+      // asking for them one at a time says so at the call site.
       const assets = await krakenAPI.fetchLiveBalances()
       const openOrders = await krakenAPI.fetchOpenOrders()
 

--- a/src/server/routes/kraken.js
+++ b/src/server/routes/kraken.js
@@ -1,5 +1,4 @@
 import { Hono } from 'hono'
-import Big from 'big.js'
 import KrakenAPI from '../adapters/kraken-api/adapter.js'
 import AnthropicAPI from '../adapters/anthropic/adapter.js'
 import ledgerRoutes from './kraken-ledger.js'
@@ -10,6 +9,10 @@ const app = new Hono()
 // route table: adding it in only one of them would 404 in the other runtime.
 app.route('/ledger', ledgerRoutes)
 
+// What the local ledger cannot know: the balance Kraken holds this second, and how
+// much of it an open order has already claimed. The Balances page reads everything
+// else from the database and asks for this on top, so a stale sync shows up as a
+// difference rather than as a wrong number.
 app.post('/balances', async (c) => {
 
    const { credentials } = await c.req.json()
@@ -17,27 +20,13 @@ app.post('/balances', async (c) => {
 
    try {
       const krakenAPI = new KrakenAPI(credentials)
-      const balances = await krakenAPI.fetchBalances()
 
-      const balancesSum = Object.keys(balances)
-         .map(asset => {
-            const free = balances[asset]?.free ?? Big(0)
-            const staking = balances[asset]?.staking ?? Big(0)
-            const earning = balances[asset]?.earning ?? Big(0)
-            const parachain = balances[asset]?.parachain ?? Big(0)
-            return { asset, balance: free.add(staking).add(earning).add(parachain) }
-         })
-         .filter(balance => balance.balance != 0)
-         .reduce((balances, balance) => {
-            balances[balance.asset] = balance.balance
-            return balances
-         }, {})
+      const [assets, openOrders] = await Promise.all([
+         krakenAPI.fetchLiveBalances(),
+         krakenAPI.fetchOpenOrders()
+      ])
 
-      const acceptHeader = c.req.header('accept') || 'application/json'
-      if (acceptHeader.includes('text/csv')) {
-         return c.text(Object.keys(balancesSum).map(asset => `${asset};${balancesSum[asset]}`).join('\n'))
-      }
-      return c.json(balancesSum)
+      return c.json({ fetchedAt: Date.now(), assets, openOrders })
    }
    catch (error) {
       if (error.message === 'HTTP Requester Error') {

--- a/src/views/components/kraken/balance-chart-card.jsx
+++ b/src/views/components/kraken/balance-chart-card.jsx
@@ -2,26 +2,26 @@ import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import Donut, { foldSlices } from './donut'
 
 
-export default function RewardChartCard({ rewards, rates }) {
+export default function BalanceChartCard({ balances, rates }) {
 
-   const slices = foldSlices((rewards?.assets ?? [])
+   const slices = foldSlices((balances?.assets ?? [])
       .filter(asset => rates?.[asset.asset] != null)
       .map(asset => ({
          key: asset.asset,
          label: asset.asset,
-         value: asset.total * rates[asset.asset],
-         amount: asset.total
+         value: asset.totalNum * rates[asset.asset],
+         amount: asset.totalNum
       })))
 
    return (
       <Card>
          <CardHeader>
-            <CardTitle>Share of rewards</CardTitle>
+            <CardTitle>Allocation</CardTitle>
          </CardHeader>
          <CardContent className="space-y-3">
             <Donut
                slices={slices}
-               emptyText="Nothing to chart: none of the rewarded assets could be valued in USD." />
+               emptyText="Nothing to chart: none of the assets held could be valued in USD." />
          </CardContent>
       </Card>
    )

--- a/src/views/components/kraken/balance-filters.jsx
+++ b/src/views/components/kraken/balance-filters.jsx
@@ -1,0 +1,55 @@
+import { Button } from '@/components/ui/button'
+import SelectField from '../lib/select-field'
+import Input from '../lib/input'
+import Checkbox from '../lib/checkbox'
+import { ANY } from '../lib/filter-options'
+
+// Dust is hidden to begin with: a long tail of positions left over from a swap or a
+// delisting is what makes this list unreadable, and how many are hidden is spelled out
+// under the table rather than only in the checkbox.
+export const DUST_USD = 1
+
+export const defaultFilters = { placement: '', search: '', hideDust: true }
+
+// Everything here is local — the whole table is already on the page — so the search box
+// is bound straight to the filters instead of being debounced into a request.
+export default function BalanceFilters({ filters, options, onChange, onReset }) {
+
+   const update = (changes) => onChange({ ...filters, ...changes })
+
+   const isFiltered = filters.placement || filters.search
+      || filters.hideDust !== defaultFilters.hideDust
+
+   return (
+      <div className="space-y-3">
+         <div className="grid grid-cols-2 items-end gap-x-4 gap-y-3 md:grid-cols-3 lg:grid-cols-6">
+
+            <SelectField
+               name="balance-placement"
+               label="Placement"
+               value={filters.placement || ANY}
+               onValueChange={(value) => update({ placement: value === ANY ? '' : value })}
+               options={[{ value: ANY, label: 'Anywhere' }, ...(options?.placements ?? [])]} />
+
+            <Input
+               name="balance-search"
+               label="Search asset"
+               value={filters.search}
+               onChange={(e) => update({ search: e.target.value })} />
+
+            <Checkbox
+               name="balance-hide-dust"
+               className="h-9"
+               checked={filters.hideDust}
+               onChange={(e) => update({ hideDust: e.target.checked })}
+               label={`Hide under $${DUST_USD}`} />
+
+         </div>
+
+         {isFiltered &&
+            <Button variant="ghost" size="sm" type="button" onClick={onReset}>
+               Reset filters
+            </Button>}
+      </div>
+   )
+}

--- a/src/views/components/kraken/balance-placement-card.jsx
+++ b/src/views/components/kraken/balance-placement-card.jsx
@@ -1,0 +1,63 @@
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import Donut from './donut'
+import { PLACEMENT_ORDER, placementColor, placementLabel, placementOf } from './placement'
+
+// Every position, valued in USD and grouped by where it sits. Positions in an asset
+// Kraken has no USD pair for cannot be added to the others and are counted apart, so
+// that the ring never quietly omits a holding without saying so.
+export function placementTotals(assets, rates) {
+
+   const totals = new Map()
+   let unvalued = 0
+
+   for (const asset of assets ?? []) {
+      const rate = rates?.[asset.asset]
+      for (const position of asset.positions) {
+         if (rate == null) {
+            unvalued++
+            continue
+         }
+         const key = placementOf(position)
+         const total = totals.get(key) ?? { key, label: placementLabel(key, position), value: 0, positions: 0 }
+         total.value += position.amountNum * rate
+         total.positions++
+         totals.set(key, total)
+      }
+   }
+
+   const slices = [...totals.values()]
+      .toSorted((a, b) => PLACEMENT_ORDER.indexOf(a.key) - PLACEMENT_ORDER.indexOf(b.key))
+
+   return { slices, unvalued }
+}
+
+
+export default function BalancePlacementCard({ balances, rates }) {
+
+   const { slices, unvalued } = placementTotals(balances?.assets, rates)
+
+   return (
+      <Card>
+         <CardHeader>
+            <CardTitle>Where it sits</CardTitle>
+         </CardHeader>
+         <CardContent className="space-y-3">
+
+            {/* Ordered by placement rather than by size, and coloured the same way
+                wherever a placement is named, so the ring can be read against the
+                badges in the table without looking anything up. */}
+            <Donut
+               slices={slices}
+               colorFor={slice => placementColor(slice.key)}
+               emptyText="Nothing to chart: none of the assets held could be valued in USD." />
+
+            {unvalued > 0 &&
+               <p className="text-xs text-muted-foreground">
+                  {unvalued} position{unvalued === 1 ? '' : 's'} in assets with no USD pair
+                  {unvalued === 1 ? ' is' : ' are'} left out.
+               </p>}
+
+         </CardContent>
+      </Card>
+   )
+}

--- a/src/views/components/kraken/balance-summary-card.jsx
+++ b/src/views/components/kraken/balance-summary-card.jsx
@@ -41,7 +41,7 @@ export default function BalanceSummaryCard({ balances, rates, live, liveError, i
    const totalValue = valued.reduce((sum, asset) => sum + valueOf(asset), 0)
 
    // Split by whether the coins are being paid anything, which is the question the
-   // page exists to answer — not by spot against earn, since Auto Earn is both.
+   // page exists to answer — not by spot against earn, since an opted-in holding is both.
    const earningValue = valued.reduce((sum, asset) => sum + asset.positions
       .filter(position => isEarning(placementOf(position)))
       .reduce((value, position) => value + position.amountNum * rates[asset.asset], 0), 0)

--- a/src/views/components/kraken/balance-summary-card.jsx
+++ b/src/views/components/kraken/balance-summary-card.jsx
@@ -1,0 +1,126 @@
+import { Loader2Icon, RefreshCwIcon } from 'lucide-react'
+import { formatDistanceToNow } from 'date-fns'
+import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import Field from '../lib/field'
+import { asCount } from '../lib/filter-options'
+import { asDollarAmount, asPercentage } from '../../../utils/format'
+import { isEarning, placementOf } from './placement'
+
+// Kraken and the ledger agree to far more digits than this; the tolerance is relative
+// so that it means the same thing for a fraction of a bitcoin and for 300 million PEPE.
+const TOLERANCE = 1e-6
+
+// Which assets the stored ledger no longer agrees with Kraken about. Anything here
+// means the ledger is behind — the sync is incremental and the page cannot tell on its
+// own that something happened after the last one.
+export function compareToLive(assets, live) {
+
+   if (!live?.assets) return null
+
+   const ledger = new Map((assets ?? []).map(asset => [asset.asset, asset.totalNum]))
+   const remote = new Map(live.assets.map(asset => [asset.asset, asset.totalNum]))
+
+   return [...new Set([...ledger.keys(), ...remote.keys()])]
+      .map(asset => ({ asset, ledger: ledger.get(asset) ?? 0, live: remote.get(asset) ?? 0 }))
+      .filter(({ ledger, live }) => {
+         const scale = Math.max(Math.abs(ledger), Math.abs(live))
+         return scale > 0 && Math.abs(ledger - live) / scale > TOLERANCE
+      })
+      .toSorted((a, b) => a.asset.localeCompare(b.asset))
+}
+
+
+export default function BalanceSummaryCard({ balances, rates, live, liveError, isLoading, isLoadingRates, isLoadingLive, onRefreshLive }) {
+
+   const assets = balances?.assets ?? []
+   const valueOf = asset => rates?.[asset.asset] == null ? null : asset.totalNum * rates[asset.asset]
+
+   const valued = assets.filter(asset => valueOf(asset) != null)
+   const totalValue = valued.reduce((sum, asset) => sum + valueOf(asset), 0)
+
+   // Split by whether the coins are being paid anything, which is the question the
+   // page exists to answer — not by spot against earn, since Auto Earn is both.
+   const earningValue = valued.reduce((sum, asset) => sum + asset.positions
+      .filter(position => isEarning(placementOf(position)))
+      .reduce((value, position) => value + position.amountNum * rates[asset.asset], 0), 0)
+
+   const holdValue = (live?.assets ?? [])
+      .filter(asset => rates?.[asset.asset] != null)
+      .reduce((sum, asset) => sum + asset.holdNum * rates[asset.asset], 0)
+
+   const drifted = compareToLive(assets, live)
+
+   return (
+      <Card>
+         <CardHeader>
+            <CardTitle>Portfolio</CardTitle>
+            <CardAction>
+               {isLoading
+                  ? <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
+                  : <Badge variant="outline">{asCount(balances?.positions, 'position')}</Badge>}
+            </CardAction>
+         </CardHeader>
+         <CardContent className="space-y-4">
+
+            <div className="grid grid-cols-2 gap-x-6 gap-y-6">
+               <Field
+                  label="Worth today"
+                  title={valued.length < assets.length
+                     ? `${assets.length - valued.length} asset(s) have no USD pair and are not counted`
+                     : undefined}>
+                  {isLoadingRates
+                     ? <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
+                     : rates ? asDollarAmount(totalValue) : '—'}
+               </Field>
+               <Field label="Assets held">{assets.length.toLocaleString('en-GB')}</Field>
+               <Field label="Earning">
+                  {isLoadingRates
+                     ? <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
+                     : rates
+                        ? <>
+                           {asDollarAmount(earningValue)}
+                           {totalValue > 0 &&
+                              <span className="ml-2 text-xs text-muted-foreground">
+                                 {asPercentage(earningValue / totalValue)}
+                              </span>}
+                        </>
+                        : '—'}
+               </Field>
+               <Field
+                  label="In open orders"
+                  title="Reserved by orders still on the book, read from Kraken — the ledger only learns about an order once it fills.">
+                  {isLoadingLive
+                     ? <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
+                     : live ? asDollarAmount(holdValue) : '—'}
+               </Field>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-t border-border pt-3 text-xs">
+
+               <span className="text-muted-foreground">
+                  {isLoadingLive ? 'Checking against Kraken…'
+                     : liveError ? `Could not reach Kraken: ${liveError}`
+                        : !live ? 'Not checked against Kraken.'
+                           : drifted.length === 0
+                              ? `Matches Kraken exactly, checked ${formatDistanceToNow(live.fetchedAt)} ago.`
+                              : `${asCount(drifted.length, 'asset')} ${drifted.length === 1 ? 'differs' : 'differ'} from Kraken — sync the ledger to catch up: ${drifted.slice(0, 3).map(entry => entry.asset).join(', ')}${drifted.length > 3 ? '…' : ''}`}
+               </span>
+
+               <Button
+                  variant="ghost"
+                  size="xs"
+                  className="ml-auto"
+                  disabled={isLoadingLive}
+                  onClick={onRefreshLive}>
+                  <RefreshCwIcon className="size-3.5" />
+                  Check Kraken
+               </Button>
+
+            </div>
+
+         </CardContent>
+      </Card>
+   )
+}

--- a/src/views/components/kraken/balance-table.jsx
+++ b/src/views/components/kraken/balance-table.jsx
@@ -1,0 +1,306 @@
+import { useState } from 'react'
+import { ArrowDownIcon, ArrowUpDownIcon, ArrowUpIcon, ChevronDownIcon, ChevronRightIcon, Loader2Icon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Table, TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell } from '@/components/ui/table'
+import BalanceFilters, { DUST_USD } from './balance-filters'
+import { PLACEMENT_ORDER, isEarning, placementColor, placementDescription, placementLabel, placementOf } from './placement'
+import { asCount } from '../lib/filter-options'
+import { asAssetAmount, asDollarAmount, asPercentage } from '../../../utils/format'
+
+// An asset Kraken has no USD pair for has no rate at all, which is not the same as
+// being worth nothing: it is shown as a dash, left out of the totals, and sorted last
+// whichever column is sorted on.
+const valueOf = (amount, rate) => rate == null ? null : (amount ?? 0) * rate
+
+// The names Kraken gave a position while it was staked the old way — DOT.S, ETH2.S,
+// USD.M. They are the reason a holding can read as one asset on Kraken and another
+// here, so they are shown; the plain ticker alongside them says nothing.
+const suffixedNames = position => position.rawAssets.filter(name => name.includes('.'))
+
+function SortIcon({ isActive, direction }) {
+
+   if (!isActive) return <ArrowUpDownIcon className="size-3 opacity-40" />
+
+   const Icon = direction === 'asc' ? ArrowUpIcon : ArrowDownIcon
+   return <Icon className="size-3.5" strokeWidth={3} />
+}
+
+function SortableHead({ column, sort, onSortChange, align, children }) {
+   const isActive = sort.column === column
+   return (
+      <TableHead className={align === 'right' ? 'text-right' : undefined}>
+         <button
+            type="button"
+            className={cn('inline-flex w-full items-center gap-1 hover:text-foreground',
+               align === 'right' && 'justify-end',
+               isActive && 'font-semibold text-foreground')}
+            onClick={() => onSortChange({
+               column,
+               direction: isActive && sort.direction === 'desc' ? 'asc' : 'desc'
+            })}>
+            {children}
+            <SortIcon isActive={isActive} direction={sort.direction} />
+         </button>
+      </TableHead>
+   )
+}
+
+// The badge carries the colour its slice has in the ring above, so a row can be read
+// against the chart without a legend, and its title spells out what the placement
+// actually means — which is the part Kraken never says.
+function PlacementBadge({ position }) {
+
+   const key = placementOf(position)
+
+   return (
+      <Badge
+         variant="outline"
+         className="gap-1.5 font-normal"
+         title={placementDescription(key)}>
+         <span
+            className="size-2 shrink-0 rounded-[2px]"
+            style={{ backgroundColor: placementColor(key) }} />
+         {placementLabel(key, position)}
+      </Badge>
+   )
+}
+
+
+export default function BalanceTable({ balances, rates, live, filters, onFiltersChange, onReset, isLoading }) {
+
+   // Sorting is local: every row is already on the page, so re-ordering costs no
+   // request and there is nothing to page through.
+   const [sort, setSort] = useState({ column: 'value', direction: 'desc' })
+   const [expanded, setExpanded] = useState(() => new Set())
+
+   const assets = balances?.assets ?? []
+   const rateFor = asset => rates?.[asset] ?? null
+
+   const holds = new Map((live?.assets ?? []).map(asset => [asset.asset, asset.holdNum]))
+
+   // Share is of the whole portfolio, not of what the filters left behind: an asset
+   // does not become a bigger part of the holdings because the others were hidden.
+   const portfolioValue = assets
+      .reduce((sum, asset) => sum + (valueOf(asset.totalNum, rateFor(asset.asset)) ?? 0), 0)
+
+   const search = filters.search.trim().toUpperCase()
+
+   // Filtering by placement narrows the positions themselves, so that "Earn · Locked"
+   // shows what is locked rather than every asset that happens to have some locked.
+   const rows = assets
+      .map(asset => {
+         // Ordered the way the ring above is, so a row's badges and the legend read in
+         // the same sequence rather than each by its own size.
+         const positions = asset.positions
+            .filter(position => !filters.placement || placementOf(position) === filters.placement)
+            .toSorted((a, b) => PLACEMENT_ORDER.indexOf(placementOf(a)) - PLACEMENT_ORDER.indexOf(placementOf(b)))
+         const amount = positions.reduce((sum, position) => sum + position.amountNum, 0)
+         return {
+            asset: asset.asset,
+            positions,
+            amount,
+            // The exact string Kraken wrote, kept for the cell's title: the column is
+            // rounded to stay readable, and a tenth of a bitcoin is worth seeing.
+            exact: positions.length === asset.positions.length ? asset.total
+               : positions.length === 1 ? positions[0].amount : String(amount),
+            rate: rateFor(asset.asset),
+            value: valueOf(amount, rateFor(asset.asset)),
+            hold: holds.get(asset.asset) ?? null
+         }
+      })
+      .filter(row => row.positions.length > 0)
+      .filter(row => !search || row.asset.includes(search))
+
+   // An asset with no USD pair is never dust: it cannot be valued, so there is no
+   // ground to hide it on.
+   const isDust = row => row.value != null && Math.abs(row.value) < DUST_USD
+
+   const dust = rows.filter(isDust)
+   const shown = filters.hideDust ? rows.filter(row => !isDust(row)) : rows
+
+   const sortValue = {
+      asset: row => row.asset,
+      value: row => row.value,
+      hold: row => valueOf(row.hold, row.rate)
+   }[sort.column]
+
+   const sorted = shown.toSorted((a, b) => {
+      const [left, right] = [sortValue(a), sortValue(b)]
+      if (left == null && right == null) return a.asset.localeCompare(b.asset)
+      if (left == null) return 1
+      if (right == null) return -1
+      if (left === right) return a.asset.localeCompare(b.asset)
+      const order = typeof left === 'string' ? left.localeCompare(right) : left - right
+      return sort.direction === 'desc' ? -order : order
+   })
+
+   const shownValue = sorted.reduce((sum, row) => sum + (row.value ?? 0), 0)
+
+   const toggle = asset => setExpanded(current => {
+      const next = new Set(current)
+      if (!next.delete(asset)) next.add(asset)
+      return next
+   })
+
+   return (
+      <Card>
+         <CardHeader>
+            <CardTitle>Holdings</CardTitle>
+            <CardAction>
+               {isLoading
+                  ? <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
+                  : <Badge variant="outline">{asCount(sorted.length, 'asset')}</Badge>}
+            </CardAction>
+         </CardHeader>
+         <CardContent className="space-y-4">
+
+            <BalanceFilters
+               filters={filters}
+               options={{ placements: placementOptions(assets) }}
+               onChange={onFiltersChange}
+               onReset={onReset} />
+
+            {assets.length === 0
+               ? <p className="text-sm text-muted-foreground">
+                  Nothing held in the stored ledger.
+               </p>
+               : sorted.length === 0
+                  ? <p className="text-sm text-muted-foreground">
+                     No asset matches the filters{dust.length > 0 && filters.hideDust
+                        ? `, though ${asCount(dust.length, 'asset')} worth under $${DUST_USD} ${dust.length === 1 ? 'is' : 'are'} hidden`
+                        : ''}.
+                  </p>
+                  : <div className="space-y-3">
+                     <Table className="tabular-nums">
+                        <TableHeader>
+                           <TableRow>
+                              <SortableHead column="asset" sort={sort} onSortChange={setSort}>Asset</SortableHead>
+                              <TableHead>Placement</TableHead>
+                              <TableHead className="text-right">Amount</TableHead>
+                              <TableHead className="text-right">Price</TableHead>
+                              <SortableHead column="value" sort={sort} onSortChange={setSort} align="right">Value</SortableHead>
+                              <TableHead className="text-right">Share</TableHead>
+                              <SortableHead column="hold" sort={sort} onSortChange={setSort} align="right">In orders</SortableHead>
+                           </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                           {sorted.map(row => {
+
+                              const isExpandable = row.positions.length > 1
+                              const isExpanded = isExpandable && expanded.has(row.asset)
+
+                              return [
+                                 <TableRow key={row.asset}>
+                                    <TableCell className="font-medium">
+                                       {isExpandable
+                                          ? <button
+                                             type="button"
+                                             className="inline-flex items-center gap-1 hover:text-foreground"
+                                             aria-expanded={isExpanded}
+                                             onClick={() => toggle(row.asset)}>
+                                             {isExpanded
+                                                ? <ChevronDownIcon className="size-3.5" />
+                                                : <ChevronRightIcon className="size-3.5" />}
+                                             {row.asset}
+                                          </button>
+                                          : <span className="pl-[1.125rem]">{row.asset}</span>}
+                                    </TableCell>
+                                    <TableCell>
+                                       <div className="flex flex-wrap gap-1">
+                                          {row.positions.map(position =>
+                                             <PlacementBadge key={position.wallet} position={position} />)}
+                                       </div>
+                                    </TableCell>
+                                    <TableCell className="text-right" title={`${row.exact} ${row.asset}`}>
+                                       {asAssetAmount(row.amount)}
+                                    </TableCell>
+                                    <TableCell className="text-right text-muted-foreground">
+                                       {row.rate == null ? '—' : asDollarAmount(row.rate)}
+                                    </TableCell>
+                                    <TableCell className="text-right font-medium">
+                                       {row.value == null ? '—' : asDollarAmount(row.value)}
+                                    </TableCell>
+                                    <TableCell className="text-right text-muted-foreground">
+                                       {row.value == null || portfolioValue <= 0 ? '—' : asPercentage(row.value / portfolioValue)}
+                                    </TableCell>
+                                    <TableCell className="text-right text-muted-foreground">
+                                       {row.hold ? asAssetAmount(row.hold) : '—'}
+                                    </TableCell>
+                                 </TableRow>,
+
+                                 ...(isExpanded ? row.positions.map(position =>
+                                    <TableRow key={`${row.asset} ${position.wallet}`} className="text-muted-foreground">
+                                       <TableCell />
+                                       <TableCell className="pl-6 text-xs">
+                                          {placementLabel(placementOf(position), position)}
+                                          {/* Only the suffixed names, which are the retired staking ones:
+                                              a DOT.S line is why an old position reads as one asset on
+                                              Kraken and another here. */}
+                                          {suffixedNames(position).length > 0 &&
+                                             <span className="ml-2 font-mono">{suffixedNames(position).join(' · ')}</span>}
+                                       </TableCell>
+                                       <TableCell className="text-right" title={`${position.amount} ${row.asset}`}>
+                                          {asAssetAmount(position.amountNum)}
+                                       </TableCell>
+                                       <TableCell />
+                                       <TableCell className="text-right">
+                                          {valueOf(position.amountNum, row.rate) == null
+                                             ? '—'
+                                             : asDollarAmount(valueOf(position.amountNum, row.rate))}
+                                       </TableCell>
+                                       <TableCell colSpan={2} className="text-right text-xs">
+                                          {isEarning(placementOf(position)) && position.lastRewardAt
+                                             ? `last paid ${new Date(position.lastRewardAt).toISOString().slice(0, 10)}`
+                                             : ''}
+                                       </TableCell>
+                                    </TableRow>) : [])
+                              ]
+                           })}
+                        </TableBody>
+                        <TableFooter>
+                           <TableRow>
+                              <TableCell colSpan={4}>Total</TableCell>
+                              <TableCell className="text-right">{asDollarAmount(shownValue)}</TableCell>
+                              <TableCell className="text-right">
+                                 {portfolioValue > 0 ? asPercentage(shownValue / portfolioValue) : '—'}
+                              </TableCell>
+                              {/* Left blank on purpose: the column holds amounts of
+                                  different coins, which cannot be added up. What they
+                                  are worth together is in the summary card. */}
+                              <TableCell />
+                           </TableRow>
+                        </TableFooter>
+                     </Table>
+
+                     <p className="text-xs text-muted-foreground">
+                        Amounts are rebuilt from the stored ledger and priced at today&apos;s market rate,
+                        so the values move with the market. An asset held in more than one place expands
+                        into a line per placement. <b>In orders</b> is what an order still on the book has
+                        reserved, read from Kraken rather than from the ledger.
+                        {filters.hideDust && dust.length > 0 &&
+                           ` ${asCount(dust.length, 'asset')} worth under $${DUST_USD} ${dust.length === 1 ? 'is' : 'are'} hidden.`}
+                     </p>
+                  </div>}
+
+         </CardContent>
+      </Card>
+   )
+}
+
+// Only the placements this account actually uses: offering "Earn · Bonded" to someone
+// who has never bonded anything is a filter that can only ever empty the table.
+function placementOptions(assets) {
+
+   const seen = new Map()
+
+   for (const asset of assets) {
+      for (const position of asset.positions) {
+         const key = placementOf(position)
+         if (!seen.has(key)) seen.set(key, { value: key, label: placementLabel(key, position) })
+      }
+   }
+
+   return [...seen.values()].toSorted((a, b) => a.label.localeCompare(b.label))
+}

--- a/src/views/components/kraken/balance-table.jsx
+++ b/src/views/components/kraken/balance-table.jsx
@@ -1,8 +1,9 @@
 import { useState } from 'react'
-import { ArrowDownIcon, ArrowUpDownIcon, ArrowUpIcon, ChevronDownIcon, ChevronRightIcon, Loader2Icon } from 'lucide-react'
+import { ArrowDownIcon, ArrowUpDownIcon, ArrowUpIcon, ChevronDownIcon, ChevronRightIcon, DownloadIcon, Loader2Icon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
 import { Table, TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell } from '@/components/ui/table'
 import BalanceFilters, { DUST_USD } from './balance-filters'
 import { PLACEMENT_ORDER, isEarning, placementColor, placementDescription, placementLabel, placementOf } from './placement'
@@ -18,6 +19,22 @@ const valueOf = (amount, rate) => rate == null ? null : (amount ?? 0) * rate
 // USD.M. They are the reason a holding can read as one asset on Kraken and another
 // here, so they are shown; the plain ticker alongside them says nothing.
 const suffixedNames = position => position.rawAssets.filter(name => name.includes('.'))
+
+// Asset and amount, semicolon-separated like the export this page used to serve from
+// the server. The amount is the exact string the ledger stores rather than the rounded,
+// thousand-separated one in the table: this file is meant to be read by something else.
+function downloadCsv(rows) {
+
+   const csv = ['asset;amount', ...rows.map(row => `${row.asset};${row.exact}`)].join('\n')
+   const url = URL.createObjectURL(new Blob([csv], { type: 'text/csv;charset=utf-8' }))
+
+   const link = document.createElement('a')
+   link.href = url
+   link.download = `kraken-balances-${new Date().toISOString().slice(0, 10)}.csv`
+   link.click()
+
+   URL.revokeObjectURL(url)
+}
 
 function SortIcon({ isActive, direction }) {
 
@@ -148,7 +165,17 @@ export default function BalanceTable({ balances, rates, live, filters, onFilters
       <Card>
          <CardHeader>
             <CardTitle>Holdings</CardTitle>
-            <CardAction>
+            <CardAction className="flex items-center gap-2">
+               {/* Exports what the table is showing, filters and sorting included: the
+                   button sits next to the count, and the count is of the same rows. */}
+               <Button
+                  variant="ghost"
+                  size="xs"
+                  disabled={sorted.length === 0}
+                  onClick={() => downloadCsv(sorted)}>
+                  <DownloadIcon className="size-3.5" />
+                  Export CSV
+               </Button>
                {isLoading
                   ? <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
                   : <Badge variant="outline">{asCount(sorted.length, 'asset')}</Badge>}

--- a/src/views/components/kraken/donut.jsx
+++ b/src/views/components/kraken/donut.jsx
@@ -1,0 +1,124 @@
+import { Cell, Pie, PieChart } from 'recharts'
+import { ChartContainer, ChartTooltip, ChartTooltipContent, ChartLegend, ChartLegendContent } from '@/components/ui/chart'
+import { asAssetAmount, asDollarAmount, asPercentage } from '../../../utils/format'
+
+// A slice thinner than this is a sliver on the ring and a line in the legend that says
+// nothing, so the whole tail is folded into one "Others" slice — the tables below still
+// break it down row by row. The cap is the backstop for a spread flat enough that
+// nothing falls under the threshold.
+const MIN_SHARE = 0.01
+const MAX_SLICES = 8
+
+export const OTHERS = 'others'
+
+// Takes slices of { key, label, value, amount? } and returns the ones worth drawing.
+// A value that cannot be worked out — an asset Kraken has no USD pair for — belongs to
+// the caller to drop before this: a slice with no size cannot be drawn either way.
+export function foldSlices(slices, othersLabel = count => `${count} others`) {
+
+   const valued = slices
+      // A holding can go negative in principle; a negative slice cannot be drawn.
+      .filter(slice => slice.value > 0)
+      .toSorted((a, b) => b.value - a.value)
+
+   const total = valued.reduce((sum, slice) => sum + slice.value, 0)
+
+   const keptByShare = valued.filter(slice => slice.value / total >= MIN_SHARE)
+   const kept = keptByShare.slice(0, MAX_SLICES - 1)
+   const others = valued.slice(kept.length)
+
+   // Folding a single slice into "Others" hides its name for nothing.
+   if (others.length <= 1) return valued
+
+   return [
+      ...kept,
+      {
+         key: OTHERS,
+         label: othersLabel(others.length),
+         value: others.reduce((sum, slice) => sum + slice.value, 0)
+      }
+   ]
+}
+
+// The USD donut every card on this page and the Rewards page draws: a ring, and a
+// legend that carries each slice's share rather than repeating it in a paragraph
+// underneath — that share is what the card is read for and it costs no height there.
+//
+// colorFor lets a caller whose slices have a fixed running order (the wallets a coin
+// can sit in) keep one colour per slice instead of colouring by rank.
+export default function Donut({ slices, colorFor, emptyText }) {
+
+   const total = slices.reduce((sum, slice) => sum + slice.value, 0)
+
+   if (slices.length === 0 || total <= 0) {
+      return <p className="text-sm text-muted-foreground">{emptyText}</p>
+   }
+
+   const colors = new Map(slices.map((slice, index) => [
+      slice.key,
+      colorFor?.(slice) ?? (slice.key === OTHERS ? 'var(--muted-foreground)' : `var(--chart-${(index % 8) + 1})`)
+   ]))
+
+   const config = Object.fromEntries(slices.map(slice =>
+      [slice.key, {
+         color: colors.get(slice.key),
+         label:
+            <span className="flex w-full items-baseline justify-between gap-3">
+               <span>{slice.label}</span>
+               <span className="tabular-nums text-muted-foreground">
+                  {asPercentage(slice.value / total)}
+               </span>
+            </span>
+      }]))
+
+   return (
+      <ChartContainer config={config} className="h-[260px] w-full">
+         <PieChart>
+            <ChartTooltip content={
+               <ChartTooltipContent
+                  hideLabel
+                  nameKey="key"
+                  formatter={(value, name, item) =>
+                     <>
+                        <div
+                           className="size-2.5 shrink-0 rounded-[2px]"
+                           style={{ backgroundColor: colors.get(name) }} />
+                        <div className="flex flex-1 items-center justify-between gap-4 leading-none">
+                           <span className="text-muted-foreground">{item?.payload?.label ?? name}</span>
+                           <span className="font-mono font-medium tabular-nums text-foreground">
+                              {asDollarAmount(value)}
+                              {item?.payload?.amount !== undefined &&
+                                 <span className="ml-2 font-normal text-muted-foreground">
+                                    {asAssetAmount(item.payload.amount)} {item.payload.key}
+                                 </span>}
+                           </span>
+                        </div>
+                     </>} />} />
+            {/* Animation is off for the same reason as the fee chart: under StrictMode
+                the sectors can stay stuck on their first frame. */}
+            <Pie
+               data={slices}
+               dataKey="value"
+               nameKey="key"
+               innerRadius={60}
+               strokeWidth={2}
+               stroke="var(--card)"
+               isAnimationActive={false}>
+               {slices.map(slice => <Cell key={slice.key} fill={colors.get(slice.key)} />)}
+            </Pie>
+            {/* itemSorter defaults to 'value', which for a pie legend is the slice name —
+                the legend would come out alphabetical while the ring runs biggest-first.
+                Null keeps both in the same order. */}
+            <ChartLegend
+               layout="vertical"
+               align="right"
+               verticalAlign="middle"
+               width={140}
+               itemSorter={null}
+               content={<ChartLegendContent
+                  nameKey="key"
+                  className="flex-col items-stretch gap-2 pt-0 pl-3" />} />
+         </PieChart>
+      </ChartContainer>
+   )
+}

--- a/src/views/components/kraken/placement.js
+++ b/src/views/components/kraken/placement.js
@@ -1,56 +1,59 @@
 // Where a holding actually sits, worked out from the wallet Kraken wrote each ledger
 // entry to. This is the whole point of reading balances from the ledger rather than
-// from BalanceEx: the API returns one number per asset, while the export says which
-// of the five wallets every movement went through.
+// from BalanceEx: the API keys earn positions under suffixes whose letters it renames
+// (a position keyed XBT.F in mid-2025 is XBT.M now) and whose names belong to its API
+// documentation rather than to its Earn screen — .M is "opt-in rewards" but is the
+// flexible position, .B is "new yield-bearing products" but is the locked one. The
+// export writes the wallet in the words the site itself uses.
 //
-// The one case the wallet alone does not settle is Auto Earn. Kraken used to move
+// The one case the wallet alone does not settle is Opt-In Rewards. Kraken used to move
 // opted-in coins into the earn wallet and write an "autoallocation" transfer pair for
-// it; since late 2025 it leaves them in spot and simply pays the rewards there. So a
-// spot position that is still being paid is an earning position, and a spot position
-// that is not is idle — a distinction the Kraken web interface does not draw at all.
+// it; since late 2025 it leaves them in the spot wallet and simply pays the rewards
+// there, with no suffix and no transfer to show for it. So a spot position that is
+// still being paid is earning, and a spot position that is not is idle.
 
-// How recently a spot position must have been paid to count as Auto Earn. Rewards land
+// How recently a spot position must have been paid to count as opted in. Rewards land
 // daily to weekly depending on the asset, so this is generous enough to survive a
 // missed payout and short enough that an asset opted out months ago drops off.
-const AUTO_EARN_WINDOW_DAYS = 45
+const OPT_IN_WINDOW_DAYS = 45
 
 export const SPOT = 'spot'
-export const AUTO_EARN = 'auto-earn'
+export const OPT_IN = 'opt-in-rewards'
 export const OTHER = 'other'
 
-// The running order every legend, chart and badge sorts by: idle first, then the earn
-// products roughly by how hard the coins are to get back out.
-export const PLACEMENT_ORDER = [SPOT, AUTO_EARN, 'earn-flexible', 'earn-liquid', 'earn-bonded', 'earn-locked', OTHER]
+// The running order every legend, chart and badge sorts by: idle first, then the
+// rewards products roughly by how hard the coins are to get back out.
+export const PLACEMENT_ORDER = [SPOT, OPT_IN, 'earn-flexible', 'earn-liquid', 'earn-bonded', 'earn-locked', OTHER]
 
 const placements = {
    [SPOT]: {
       label: 'Spot',
-      description: 'Sitting in the spot wallet, earning nothing.',
+      description: 'Sitting in your spot wallet, not earning rewards.',
       earning: false
    },
-   [AUTO_EARN]: {
-      label: 'Auto Earn',
-      description: 'Left in the spot wallet, but still being paid rewards — Kraken pays opted-in assets where they lie.',
+   [OPT_IN]: {
+      label: 'Opt-In Rewards',
+      description: 'Staying in your spot wallet and still being paid — Kraken pays opted-in assets where they lie, so the balance stays available to trade.',
       earning: true
    },
    'earn-flexible': {
       label: 'Earn · Flexible',
-      description: 'Allocated to a flexible Earn position, which can be unstaked at any time.',
+      description: 'Allocated to a flexible Earn strategy, which can be unstaked at any time.',
       earning: true
    },
    'earn-liquid': {
       label: 'Earn · Liquid',
-      description: 'Allocated to a liquid staking position, held as a wrapped token.',
+      description: 'Allocated to a liquid Earn strategy, held as a wrapped token.',
       earning: true
    },
    'earn-bonded': {
       label: 'Earn · Bonded',
-      description: 'Allocated to a bonded Earn position, with a bonding and unbonding period.',
+      description: 'Allocated to a bonded Earn strategy, with a bonding and unbonding period before the coins are available again.',
       earning: true
    },
    'earn-locked': {
       label: 'Earn · Locked',
-      description: 'Allocated to a locked Earn position for a fixed term.',
+      description: 'Allocated to a locked Earn strategy for a fixed term.',
       earning: true
    },
    [OTHER]: {
@@ -75,9 +78,9 @@ export function placementOf(position, now = Date.now()) {
    if (key !== SPOT) return key
 
    const paidWithinWindow = position?.lastRewardAt != null
-      && now - position.lastRewardAt <= AUTO_EARN_WINDOW_DAYS * 86400000
+      && now - position.lastRewardAt <= OPT_IN_WINDOW_DAYS * 86400000
 
-   return paidWithinWindow ? AUTO_EARN : SPOT
+   return paidWithinWindow ? OPT_IN : SPOT
 }
 
 // Unknown wallets keep their raw name rather than all collapsing into one "Other"

--- a/src/views/components/kraken/placement.js
+++ b/src/views/components/kraken/placement.js
@@ -1,0 +1,98 @@
+// Where a holding actually sits, worked out from the wallet Kraken wrote each ledger
+// entry to. This is the whole point of reading balances from the ledger rather than
+// from BalanceEx: the API returns one number per asset, while the export says which
+// of the five wallets every movement went through.
+//
+// The one case the wallet alone does not settle is Auto Earn. Kraken used to move
+// opted-in coins into the earn wallet and write an "autoallocation" transfer pair for
+// it; since late 2025 it leaves them in spot and simply pays the rewards there. So a
+// spot position that is still being paid is an earning position, and a spot position
+// that is not is idle — a distinction the Kraken web interface does not draw at all.
+
+// How recently a spot position must have been paid to count as Auto Earn. Rewards land
+// daily to weekly depending on the asset, so this is generous enough to survive a
+// missed payout and short enough that an asset opted out months ago drops off.
+const AUTO_EARN_WINDOW_DAYS = 45
+
+export const SPOT = 'spot'
+export const AUTO_EARN = 'auto-earn'
+export const OTHER = 'other'
+
+// The running order every legend, chart and badge sorts by: idle first, then the earn
+// products roughly by how hard the coins are to get back out.
+export const PLACEMENT_ORDER = [SPOT, AUTO_EARN, 'earn-flexible', 'earn-liquid', 'earn-bonded', 'earn-locked', OTHER]
+
+const placements = {
+   [SPOT]: {
+      label: 'Spot',
+      description: 'Sitting in the spot wallet, earning nothing.',
+      earning: false
+   },
+   [AUTO_EARN]: {
+      label: 'Auto Earn',
+      description: 'Left in the spot wallet, but still being paid rewards — Kraken pays opted-in assets where they lie.',
+      earning: true
+   },
+   'earn-flexible': {
+      label: 'Earn · Flexible',
+      description: 'Allocated to a flexible Earn position, which can be unstaked at any time.',
+      earning: true
+   },
+   'earn-liquid': {
+      label: 'Earn · Liquid',
+      description: 'Allocated to a liquid staking position, held as a wrapped token.',
+      earning: true
+   },
+   'earn-bonded': {
+      label: 'Earn · Bonded',
+      description: 'Allocated to a bonded Earn position, with a bonding and unbonding period.',
+      earning: true
+   },
+   'earn-locked': {
+      label: 'Earn · Locked',
+      description: 'Allocated to a locked Earn position for a fixed term.',
+      earning: true
+   },
+   [OTHER]: {
+      label: 'Other',
+      description: 'A wallet this page does not have a name for yet.',
+      earning: false
+   }
+}
+
+const wallets = {
+   'spot / main': SPOT,
+   'earn / flexible': 'earn-flexible',
+   'earn / liquid': 'earn-liquid',
+   'earn / bonded': 'earn-bonded',
+   'earn / locked': 'earn-locked'
+}
+
+export function placementOf(position, now = Date.now()) {
+
+   const key = wallets[position?.wallet] ?? OTHER
+
+   if (key !== SPOT) return key
+
+   const paidWithinWindow = position?.lastRewardAt != null
+      && now - position.lastRewardAt <= AUTO_EARN_WINDOW_DAYS * 86400000
+
+   return paidWithinWindow ? AUTO_EARN : SPOT
+}
+
+// Unknown wallets keep their raw name rather than all collapsing into one "Other"
+// badge: if Kraken adds a sixth wallet, it should be visible that it did.
+export function placementLabel(key, position) {
+   return key === OTHER ? (position?.wallet || 'Unknown') : placements[key].label
+}
+
+export const placementDescription = key => placements[key].description
+export const isEarning = key => placements[key].earning
+
+// One colour per placement, fixed by position in PLACEMENT_ORDER so the ring, the
+// legend and the badges agree however few of them a given account uses. Idle spot is
+// the grey one on purpose: it is the slice that is doing nothing.
+export const placementColor = key =>
+   key === SPOT
+      ? 'var(--muted-foreground)'
+      : `var(--chart-${(PLACEMENT_ORDER.indexOf(key) % 8) + 1})`

--- a/src/views/mocks/index.js
+++ b/src/views/mocks/index.js
@@ -1,7 +1,7 @@
 import { tradingPairs, orderBatch, balances, assetRates, xstocks } from './kraken'
 import {
    ledgerSync, ledgerSyncStatus, ledgerSyncCancel, ledgerClear,
-   ledgerEntries, ledgerFilters, ledgerFees, ledgerRewards
+   ledgerEntries, ledgerFilters, ledgerFees, ledgerRewards, ledgerBalances
 } from './kraken-ledger'
 import { tradeOrders, tradeFilters } from './kraken-trades'
 import { aggregateBalance } from './binance'
@@ -10,7 +10,7 @@ import { aggregateBalance } from './binance'
 const mockRoutes = {
    '/api/kraken/trading-pairs': () => tradingPairs,
    '/api/kraken/order-batch': (params) => orderBatch(params?.arg),
-   '/api/kraken/balances': () => balances,
+   '/api/kraken/balances': () => balances(),
    '/api/kraken/asset-rates': (params) => assetRates(params?.arg),
    '/api/kraken/xstocks': () => xstocks,
    '/api/kraken/ledger/sync': (params) => ledgerSync(params?.arg),
@@ -20,6 +20,7 @@ const mockRoutes = {
    '/api/kraken/ledger/filters': () => ledgerFilters(),
    '/api/kraken/ledger/fees': (params) => ledgerFees(params?.arg),
    '/api/kraken/ledger/rewards': () => ledgerRewards(),
+   '/api/kraken/ledger/balances': () => ledgerBalances(),
    '/api/kraken/ledger/clear': () => ledgerClear(),
    '/api/kraken/ledger/trades/orders': (params) => tradeOrders(params?.arg),
    '/api/kraken/ledger/trades/filters': () => tradeFilters(),

--- a/src/views/mocks/kraken-ledger.js
+++ b/src/views/mocks/kraken-ledger.js
@@ -72,7 +72,7 @@ function buildEntries() {
 
    // A tail of deterministic entries, so that every placement the Balances page can draw
    // is present whatever the random draw did: a coin in each earn wallet, a spot holding
-   // still being paid (Auto Earn), a position carrying a retired staking name alongside
+   // still being paid (Opt-In Rewards), a position carrying a retired staking name alongside
    // its current one, and one worth too little to be worth a row.
    const recently = days => Date.now() - days * 86400000
 

--- a/src/views/mocks/kraken-ledger.js
+++ b/src/views/mocks/kraken-ledger.js
@@ -27,7 +27,9 @@ function buildEntries() {
    const entries = []
    let time = Date.UTC(2023, 0, 12, 9, 30, 0)
 
-   const push = entry => entries.push({ fee: '0.00000000', subtype: '', wallet: 'spot', ...entry })
+   // Wallets are spelled the way Kraken spells them in the export, because the Balances
+   // page reads the placement of a holding out of exactly this string.
+   const push = entry => entries.push({ fee: '0.00000000', subtype: '', wallet: 'spot / main', ...entry })
 
    for (let i = 0; entries.length < 250; i++) {
 
@@ -49,11 +51,11 @@ function buildEntries() {
       }
       else if (roll < 7) {
          push({ txid: `L${i}`, refid: `RW${i}`, time, type: 'earn', subtype: 'reward',
-            asset, baseAsset, wallet: 'earn', amount: (random(20000) / 1000000).toFixed(8), balance })
+            asset, baseAsset, wallet: 'earn / flexible', amount: (random(20000) / 1000000).toFixed(8), balance })
       }
       else if (roll < 8) {
          push({ txid: `L${i}`, refid: `AL${i}`, time, type: 'earn', subtype: 'allocation',
-            asset, baseAsset, wallet: 'earn', amount: (random(100000) / 10000).toFixed(8), balance })
+            asset, baseAsset, wallet: 'earn / flexible', amount: (random(100000) / 10000).toFixed(8), balance })
       }
       else if (roll < 9) {
          // Kraken charges on some fiat funding methods, so deposits carry a fee too.
@@ -67,6 +69,54 @@ function buildEntries() {
             fee: '0.00010000', balance })
       }
    }
+
+   // A tail of deterministic entries, so that every placement the Balances page can draw
+   // is present whatever the random draw did: a coin in each earn wallet, a spot holding
+   // still being paid (Auto Earn), a position carrying a retired staking name alongside
+   // its current one, and one worth too little to be worth a row.
+   const recently = days => Date.now() - days * 86400000
+
+   // Opening deposits, so the random withdrawals above cannot take a spot wallet
+   // negative — a holding below zero is not a case the page needs to show.
+   push({ txid: 'LBTC0', refid: 'DPBTC', time: recently(700), type: 'deposit',
+      asset: 'XXBT', baseAsset: 'BTC', amount: '2.50000000', balance: '2.50000000' })
+   push({ txid: 'LETH0', refid: 'DPETH', time: recently(700), type: 'deposit',
+      asset: 'XETH', baseAsset: 'ETH', amount: '6.00000000', balance: '6.00000000' })
+   push({ txid: 'LSOL0', refid: 'DPSOL', time: recently(700), type: 'deposit',
+      asset: 'SOL', baseAsset: 'SOL', amount: '12.00000000', balance: '12.00000000' })
+
+   push({ txid: 'LDOT1', refid: 'DPDOT', time: recently(120), type: 'deposit',
+      asset: 'DOT', baseAsset: 'DOT', amount: '1200.00000000', balance: '1200.00000000' })
+   push({ txid: 'LDOT2', refid: 'RWDOT', time: recently(2), type: 'earn', subtype: 'reward',
+      asset: 'DOT', baseAsset: 'DOT', amount: '0.84210000', balance: '1200.84210000' })
+
+   push({ txid: 'LETH1', refid: 'ALETH', time: recently(300), type: 'earn', subtype: 'allocation',
+      asset: 'ETH2.S', baseAsset: 'ETH', wallet: 'earn / liquid', amount: '4.50000000', balance: '4.50000000' })
+   push({ txid: 'LETH2', refid: 'RWETH', time: recently(3), type: 'earn', subtype: 'reward',
+      asset: 'ETH2.S', baseAsset: 'ETH', wallet: 'earn / liquid', amount: '0.01120000', balance: '4.51120000' })
+
+   push({ txid: 'LBTC1', refid: 'ALBTC', time: recently(90), type: 'earn', subtype: 'allocation',
+      asset: 'XXBT', baseAsset: 'BTC', wallet: 'earn / flexible', amount: '0.35000000', balance: '0.35000000' })
+   push({ txid: 'LBTC2', refid: 'RWBTC', time: recently(5), type: 'earn', subtype: 'reward',
+      asset: 'XXBT', baseAsset: 'BTC', wallet: 'earn / flexible', amount: '0.00042000', balance: '0.35042000' })
+
+   push({ txid: 'LSOL1', refid: 'ALSOL', time: recently(200), type: 'earn', subtype: 'allocation',
+      asset: 'SOL', baseAsset: 'SOL', wallet: 'earn / bonded', amount: '38.00000000', balance: '38.00000000' })
+   push({ txid: 'LSOL2', refid: 'RWSOL', time: recently(4), type: 'earn', subtype: 'reward',
+      asset: 'SOL', baseAsset: 'SOL', wallet: 'earn / bonded', amount: '0.19000000', balance: '38.19000000' })
+
+   push({ txid: 'LADA1', refid: 'ALADA', time: recently(400), type: 'earn', subtype: 'allocation',
+      asset: 'ADA', baseAsset: 'ADA', wallet: 'earn / locked', amount: '9000.00000000', balance: '9000.00000000' })
+   push({ txid: 'LADA2', refid: 'RWADA', time: recently(6), type: 'earn', subtype: 'reward',
+      asset: 'ADA', baseAsset: 'ADA', wallet: 'earn / locked', amount: '12.40000000', balance: '9012.40000000' })
+
+   // Staked under the name Kraken has since retired, and never opted back in, so it
+   // reads as an idle spot holding with two raw names behind it.
+   push({ txid: 'LADA3', refid: 'STADA', time: Date.UTC(2023, 5, 2), type: 'staking',
+      asset: 'ADA.S', baseAsset: 'ADA', amount: '640.00000000', balance: '640.00000000' })
+
+   push({ txid: 'LLINK1', refid: 'DPLINK', time: recently(500), type: 'deposit',
+      asset: 'LINK', baseAsset: 'LINK', amount: '0.02400000', balance: '0.02400000' })
 
    return entries.toSorted((a, b) => a.time - b.time)
 }
@@ -332,6 +382,79 @@ export function ledgerRewards() {
       entries: rewards.length,
       first: rewards.length > 0 ? Math.min(...rewards.map(entry => entry.time)) : null,
       last: rewards.length > 0 ? Math.max(...rewards.map(entry => entry.time)) : null
+   }
+}
+
+// Mirrors LedgerRepository.balanceSummary: the same fold of amount - fee per asset and
+// wallet, over the same fixture, so that clearing and re-syncing empties and refills
+// the Balances page the way it does every other one.
+export function ledgerBalances() {
+
+   const excludedSubtypes = ['allocation', 'deallocation', 'autoallocation', 'migration']
+   const positions = new Map()
+
+   for (const entry of entries) {
+
+      const key = `${entry.baseAsset} ${entry.wallet}`
+      const position = positions.get(key)
+         ?? {
+            asset: entry.baseAsset, wallet: entry.wallet, amount: 0, rawAssets: new Set(),
+            entries: 0, first: entry.time, last: entry.time, lastRewardAt: null, rewardEntries: 0
+         }
+
+      position.amount += Number(entry.amount) - Number(entry.fee)
+      position.rawAssets.add(entry.asset)
+      position.entries += 1
+      position.first = Math.min(position.first, entry.time)
+      position.last = Math.max(position.last, entry.time)
+
+      if (['staking', 'earn'].includes(entry.type) && !excludedSubtypes.includes(entry.subtype)) {
+         position.lastRewardAt = Math.max(position.lastRewardAt ?? 0, entry.time)
+         position.rewardEntries += 1
+      }
+
+      positions.set(key, position)
+   }
+
+   const assets = new Map()
+
+   for (const position of positions.values()) {
+
+      // Rounded to the precision Kraken writes: the fixture adds floats, and a total of
+      // -3e-17 would otherwise pass for a holding.
+      const amount = Number(position.amount.toFixed(8))
+      if (amount === 0) continue
+
+      const asset = assets.get(position.asset) ?? { asset: position.asset, total: 0, positions: [] }
+
+      asset.total += amount
+      asset.positions.push({
+         wallet: position.wallet,
+         amount: amount.toFixed(8),
+         amountNum: amount,
+         rawAssets: [...position.rawAssets].toSorted(),
+         entries: position.entries,
+         first: position.first,
+         last: position.last,
+         lastRewardAt: position.lastRewardAt,
+         rewardEntries: position.rewardEntries
+      })
+      assets.set(position.asset, asset)
+   }
+
+   const held = [...assets.values()]
+
+   return {
+      assets: held.map(asset => ({
+         asset: asset.asset,
+         total: asset.total.toFixed(8),
+         totalNum: asset.total,
+         positions: asset.positions.toSorted((a, b) => b.amountNum - a.amountNum)
+      })),
+      positions: held.reduce((count, asset) => count + asset.positions.length, 0),
+      entries: entries.length,
+      first: entries.length > 0 ? entries[0].time : null,
+      last: entries.length > 0 ? entries.at(-1).time : null
    }
 }
 

--- a/src/views/mocks/kraken.js
+++ b/src/views/mocks/kraken.js
@@ -1,4 +1,5 @@
 import Big from 'big.js'
+import { ledgerBalances } from './kraken-ledger'
 
 const tradingPairs = {
    XBTUSD: { id: 'XBTUSD', name: 'XBT/USD', base: { name: 'XXBT', decimals: 8 }, quote: { name: 'ZUSD', decimals: 2 } },
@@ -30,18 +31,46 @@ function orderBatch(params) {
    })
 }
 
-const balances = {
-   XXBT: '1.2534000000',
-   XETH: '15.8721000000',
-   DOT: '245.0000000000',
-   ADA: '5200.0000000000',
-   SOL: '42.5600000000',
+// What BalanceEx and OpenOrders answer, which is what the Balances page asks Kraken
+// for on top of the ledger. Built from the ledger fixture so the two agree, except for
+// BTC — deliberately out of step, so the "the stored ledger is behind" path is visible
+// in mocked mode without having to break a sync.
+const balances = () => {
+
+   const ledger = ledgerBalances()
+   const holds = { BTC: 0.05, ADA: 400 }
+
+   return {
+      fetchedAt: Date.now(),
+      assets: ledger.assets.map(asset => {
+         const total = asset.totalNum + (asset.asset === 'BTC' ? 0.017 : 0)
+         return {
+            asset: asset.asset,
+            total: total.toFixed(8),
+            totalNum: total,
+            hold: (holds[asset.asset] ?? 0).toFixed(8),
+            holdNum: holds[asset.asset] ?? 0
+         }
+      }),
+      openOrders: [
+         {
+            txid: 'OQCLML-BW3P3-BUCMWZ', baseAsset: 'BTC', quoteAsset: 'USD', pairKey: 'BTC/USD',
+            type: 'sell', ordertype: 'limit', price: '71000.0', volume: '0.05000000',
+            executed: '0.00000000', opened: Date.now() - 3 * 86400000
+         },
+         {
+            txid: 'OQCLML-9XKQ2-JJTRDK', baseAsset: 'ADA', quoteAsset: 'USD', pairKey: 'ADA/USD',
+            type: 'sell', ordertype: 'limit', price: '0.9200', volume: '400.00000000',
+            executed: '0.00000000', opened: Date.now() - 11 * 3600000
+         }
+      ]
+   }
 }
 
 // Roughly the market as of the fixture's writing. SOL has no mocked rate on purpose,
 // so the "no USD pair" path stays visible in mocked mode.
 const assetRates = (params) => {
-   const known = { BTC: 62500, ETH: 3050, DOT: 6.4, ADA: 0.46, USD: 1 }
+   const known = { BTC: 62500, ETH: 3050, DOT: 6.4, ADA: 0.46, LINK: 12.5, USD: 1 }
    return {
       rates: (params?.assets ?? [])
          .filter(asset => known[asset] !== undefined)

--- a/src/views/pages/kraken/balances.jsx
+++ b/src/views/pages/kraken/balances.jsx
@@ -1,61 +1,158 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router'
+import useSWR, { useSWRConfig } from 'swr'
 import useSWRMutation from 'swr/mutation'
+import { InfoIcon } from 'lucide-react'
 import KrakenLayout from '../../components/kraken/kraken-layout'
-import { asDecimal } from '../../../utils/format'
-import { Button } from '@/components/ui/button'
+import SyncStatusStrip from '../../components/kraken/sync-status-strip'
+import BalanceSummaryCard from '../../components/kraken/balance-summary-card'
+import BalancePlacementCard from '../../components/kraken/balance-placement-card'
+import BalanceChartCard from '../../components/kraken/balance-chart-card'
+import BalanceTable from '../../components/kraken/balance-table'
+import { defaultFilters } from '../../components/kraken/balance-filters'
+import { isJobRunning } from '../../components/kraken/sync-status'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Loader2Icon } from 'lucide-react'
-import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
 
 
 export default function KrakenBalances() {
 
-   const { data, error, trigger, isMutating } = useSWRMutation('/api/kraken/balances')
-
-   const [credentials, setCredentials] = useState(() => ({
+   const [credentials] = useState(() => ({
       apiKey: (typeof window !== 'undefined' && localStorage.getItem('kraken.api.key')) || '',
       apiSecret: (typeof window !== 'undefined' && localStorage.getItem('kraken.api.secret')) || ''
    }))
 
-   let content
-   if (error) {
-      content = <Alert variant="destructive"><AlertDescription>{error}</AlertDescription></Alert>
-   }
-   else if (isMutating) {
-      content = <div className="flex items-center gap-2"><Loader2Icon className="size-4 animate-spin" /> Fetching data…</div>
-   }
-   else if (!data && !credentials.apiKey) {
-      content = <div>Generate an API key and secret on Kraken to be able to fetch your spot and staking balance.</div>
-   }
-   else if (!data) {
-      content = <Button size="sm" onClick={() => trigger({ credentials })}>
-         Fetch data
-      </Button>
-   }
-   else {
-      content = (
-         <Table>
-            <TableHeader>
-               <TableRow>
-                  <TableHead className="text-left">Asset</TableHead>
-                  <TableHead className="text-right">Balance</TableHead>
-               </TableRow>
-            </TableHeader>
-            <TableBody>
-               {Object.keys(data).map(asset =>
-                  <TableRow key={asset}>
-                     <TableCell className="pr-8">{asset}</TableCell>
-                     <TableCell className="text-right tabular-nums">{asDecimal(Number.parseFloat(data[asset]), 18)}</TableCell>
-                  </TableRow>)}
-            </TableBody>
-         </Table>
+   const [filters, setFilters] = useState(defaultFilters)
+
+   const wasRunningRef = useRef(false)
+   const { mutate } = useSWRConfig()
+
+   // The balances themselves come from the ledger the Ledger tab downloaded, so the
+   // secret is not sent with them, and the rates on top are public data.
+   const account = credentials.apiKey ? { apiKey: credentials.apiKey } : null
+
+   // A sync is started on the Ledger page but rewrites the balances read here, so the
+   // run is followed and the summary revalidated when it lands.
+   const { data: status } = useSWR(
+      account ? ['/api/kraken/ledger/sync/status', { credentials: account }] : null,
+      {
+         refreshInterval: latest => isJobRunning(latest?.job) ? 1500 : 0,
+         onSuccess: (latest) => {
+            const running = isJobRunning(latest?.job)
+            if (!running && wasRunningRef.current) {
+               mutate(key => Array.isArray(key) && key[0] === '/api/kraken/ledger/balances')
+            }
+            wasRunningRef.current = running
+         }
+      })
+
+   const { data: balances, error, isLoading } = useSWR(
+      account ? ['/api/kraken/ledger/balances', { credentials: account }] : null,
+      { keepPreviousData: true })
+
+   // Asked for separately, and only once the assets are known, so the table renders
+   // from the local database straight away and a failed rate lookup costs the amounts
+   // nothing.
+   const assets = (balances?.assets ?? []).map(asset => asset.asset)
+   const { data: rateData, isLoading: isLoadingRates } = useSWR(
+      assets.length > 0 ? ['/api/kraken/asset-rates', { assets }] : null,
+      { keepPreviousData: true })
+
+   // What Kraken says right now: the totals to check the stored ledger against, and the
+   // open orders holding part of it. This is the one call that needs the secret, so it
+   // stays a mutation — a useSWR key would put the secret in the cache key, which is why
+   // every other read on these pages sends the api key alone. Triggered on mount rather
+   // than left to a button, so the page is complete without being asked twice.
+   const { data: live, error: liveError, trigger, isMutating } = useSWRMutation('/api/kraken/balances')
+
+   const canCheckLive = Boolean(credentials.apiKey && credentials.apiSecret)
+   const checkLive = () => trigger({ credentials }).catch(() => {})
+
+   useEffect(() => {
+      if (canCheckLive) checkLive()
+   }, [canCheckLive])
+
+   if (!credentials.apiKey) {
+      return (
+         <KrakenLayout name="Balances">
+            <Alert>
+               <AlertDescription>
+                  Generate an API key and secret on Kraken and add them in Settings to sync your ledger.
+               </AlertDescription>
+            </Alert>
+         </KrakenLayout>
       )
    }
 
    return (
-      <KrakenLayout name="Balance">
-         <div className="grow text-sm space-y-6 tabular-nums">
-            {content}
+      <KrakenLayout name="Balances">
+         <div className="space-y-6">
+
+            <div className="flex items-center gap-3 rounded-lg border border-blue-300/60 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-500/25 dark:bg-blue-950/30 dark:text-blue-100">
+               <InfoIcon className="size-5 shrink-0" />
+               <p>
+                  What you hold, rebuilt from the local database the Ledger tab fills, and
+                  grouped by <b>where each coin actually sits</b> — the spot wallet, or one of
+                  Kraken&apos;s earn products. Coins left in spot that are still being paid
+                  rewards are marked <b>Auto Earn</b>, which is the distinction the Kraken
+                  interface does not draw. Totals are checked against Kraken live, which also
+                  says how much an open order has already reserved.
+               </p>
+            </div>
+
+            {error &&
+               <Alert variant="destructive">
+                  <AlertDescription>{error}</AlertDescription>
+               </Alert>}
+
+            {balances?.entries === 0 &&
+               <Alert>
+                  <AlertDescription>
+                     No ledger stored yet. Sync it on the{' '}
+                     <Link to="/kraken/ledger" className="font-medium text-foreground underline underline-offset-4">
+                        Ledger
+                     </Link>{' '}
+                     tab first, then come back.
+                  </AlertDescription>
+               </Alert>}
+
+            {!canCheckLive &&
+               <Alert>
+                  <AlertDescription>
+                     Add your API secret in Settings to check these balances against Kraken and
+                     see what your open orders have reserved.
+                  </AlertDescription>
+               </Alert>}
+
+            <SyncStatusStrip
+               state={status?.state}
+               job={status?.job}
+               isRunning={isJobRunning(status?.job)}
+               counts={`${(status?.state?.entryCount ?? 0).toLocaleString('en-GB')} ledger entries`}
+               emptyLabel="No ledger stored yet" />
+
+            <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+               <BalanceSummaryCard
+                  balances={balances}
+                  rates={rateData?.rates}
+                  live={live}
+                  liveError={liveError}
+                  isLoading={isLoading}
+                  isLoadingRates={isLoadingRates}
+                  isLoadingLive={isMutating}
+                  onRefreshLive={checkLive} />
+               <BalancePlacementCard balances={balances} rates={rateData?.rates} />
+               <BalanceChartCard balances={balances} rates={rateData?.rates} />
+            </div>
+
+            <BalanceTable
+               balances={balances}
+               rates={rateData?.rates}
+               live={live}
+               filters={filters}
+               onFiltersChange={setFilters}
+               onReset={() => setFilters(defaultFilters)}
+               isLoading={isLoading} />
+
          </div>
       </KrakenLayout>
    )

--- a/src/views/pages/kraken/balances.jsx
+++ b/src/views/pages/kraken/balances.jsx
@@ -67,8 +67,15 @@ export default function KrakenBalances() {
    const canCheckLive = Boolean(credentials.apiKey && credentials.apiSecret)
    const checkLive = () => trigger({ credentials }).catch(() => {})
 
+   // Guarded because StrictMode runs this twice in development, and each run costs two
+   // private calls against Kraken's rate limit. The button below is unaffected: it
+   // calls checkLive directly.
+   const hasCheckedRef = useRef(false)
+
    useEffect(() => {
-      if (canCheckLive) checkLive()
+      if (!canCheckLive || hasCheckedRef.current) return
+      hasCheckedRef.current = true
+      checkLive()
    }, [canCheckLive])
 
    if (!credentials.apiKey) {
@@ -91,11 +98,11 @@ export default function KrakenBalances() {
                <InfoIcon className="size-5 shrink-0" />
                <p>
                   What you hold, rebuilt from the local database the Ledger tab fills, and
-                  grouped by <b>where each coin actually sits</b> — the spot wallet, or one of
-                  Kraken&apos;s earn products. Coins left in spot that are still being paid
-                  rewards are marked <b>Auto Earn</b>, which is the distinction the Kraken
-                  interface does not draw. Totals are checked against Kraken live, which also
-                  says how much an open order has already reserved.
+                  grouped by <b>where each coin actually sits</b> — your spot wallet, or one
+                  of Kraken&apos;s Earn strategies. Coins left in spot that are still being
+                  paid are marked <b>Opt-In Rewards</b>, since they keep earning without
+                  leaving the wallet they can be traded from. Totals are checked against
+                  Kraken live, which also says how much an open order has already reserved.
                </p>
             </div>
 


### PR DESCRIPTION
Brings `/kraken/balances` onto the same shape as Ledger, Fees, Rewards, Order Batch and Closed Orders, moves it off the live API and onto the local ledger database, and answers the question the Kraken web interface leaves open: **where is each coin, and is it earning anything?**

## Why the ledger

The page used to live-call `BalanceEx` and sum `free + staking + earning + parachain` into a flat map, which throws away where each coin sits. The ledger already knows. Summing `amount - fee` per `(asset, wallet)` reproduces Kraken's own running `balance` column **exactly** — every asset in the dev database, to the last digit — and `ledger_entry.wallet` carries the placement:

| `wallet` | shown as |
|---|---|
| `spot / main` | **Spot**, or **Opt-In Rewards** if it is still being paid |
| `earn / flexible` | Earn · Flexible |
| `earn / liquid` | Earn · Liquid |
| `earn / bonded` | Earn · Bonded |
| `earn / locked` | Earn · Locked |

**Opt-In Rewards** is the one placement the wallet alone does not settle. Kraken used to move opted-in coins into the earn wallet and write an `autoallocation` transfer pair; since late 2025 it leaves them in spot and simply pays the rewards there. So a spot position with a reward inside the last 45 days is earning, and one without is idle — a distinction the Kraken site does not draw anywhere.

Because a balance gets compared with Kraken by eye, the fold is done with `Big` rather than the `REAL` mirrors the fee and reward summaries use.

## What still comes from the API

Two things the ledger cannot know, so `POST /api/kraken/balances` now returns them instead of a balance map:

- **What an open order has reserved** (`hold_trade`), plus the open orders behind it (new `OpenOrders` endpoint).
- **Whether the stored ledger is behind** — live total vs ledger total per asset, surfaced as "N assets differ from Kraken, sync to catch up".

It deliberately does *not* split the live balance by placement, and that was checked against a real response rather than assumed. `BalanceEx` **does** key earn positions separately, and accurately — every suffixed balance matches the ledger's per-wallet amount to the last digit:

| `BalanceEx` key | Kraken's name for the suffix | ledger wallet |
|---|---|---|
| `ATOM21.S`, `DOT28.S`, `SOL03.S` | staked | `earn / bonded` |
| `POL.B`, `XTZ.B` | new yield-bearing products | `earn / locked` |
| `XBT.M` | opt-in rewards | `earn / flexible` |

The breakdown is still read from the ledger for two reasons. The suffix does not name the wallet, and the vocabulary it does carry is not the one Kraken's own Earn screen uses — `.M` is "opt-in rewards" but is the flexible position, `.B` is "new yield-bearing products" but is the locked one — and the letters are not stable either, since a position keyed `XBT.F` in mid-2025 is `XBT.M` today. More decisively, **Opt-In Rewards carries no suffix at all**: Kraken pays those rewards onto the plain spot balance, so an asset earning that way is indistinguishable in `BalanceEx` from one doing nothing. Only the ledger's reward entries separate them.

This is also the only call that needs the API secret, so it stays a `useSWRMutation` triggered on mount — a `useSWR` key would put the secret in the cache key, which is the reason every other read on these pages sends the api key alone.

## The page

- Info strip → sync status → **Portfolio** / **Where it sits** / **Allocation** cards → **Holdings** table.
- One row per asset, expandable into a line per placement, with the retired staking names (`DOT.S`, `ETH2.S`) shown against the position that carries them.
- Filter by placement (which narrows to the matching positions, so "Earn · Locked" shows what is locked), search, and a dust toggle that hides sub-dollar leftovers — the dev database has ~15 of them.
- Amounts are rounded to stay readable, with the exact stored string on hover.
- The Rewards donut moved into a shared `donut.jsx` rather than being copied a third time.

## Also in here

`normalizeAsset` split on the first digit anywhere, so `AI16Z` became `AI` and `USD1` would become `USD`. It now strips only a trailing suffix. Checked against every raw asset in the dev database: `DOT28.S`→`DOT`, `MATIC04.S`→`POL`, `ETH2.S`→`ETH`, `USD.M`→`USD`, `XXBT`→`BTC`, with `1INCH`, `0G` and `AI16Z` left whole. **`base_asset` is written at sync time, so a full resync is needed for stored rows to pick this up.** The now-unused `assetCategory` went with it.

## Nonce ordering

Testing against a live account turned up a bug this PR introduced and one it did not. `BalanceEx` and `OpenOrders` were fired under `Promise.all`, and separately React's `StrictMode` fires the page's live-check effect twice — either way two private calls end up in flight at once, and Kraken rejects whichever nonce arrives out of order with `EAPI:Invalid nonce`. Two of six requests failed.

The nonce was already generated monotonically; what was missing was ordering on *arrival*. Private calls now queue behind one another in the resource layer, which covers the sync path too — a sync polling its export status overlaps anything else the same key asks for, so this was reachable without the new page. Verified in isolation: never more than one call in flight, FIFO order, and a rejected call does not poison the queue.

## Verification

- `balanceSummary()` run against the real dev database (12,873 rows): 47 assets, 52 positions, 25 ms, and every single-name position matches Kraken's running balance to within 1e-9.
- Both routes exercised through Hono: 401 without credentials, empty summary for an unknown key.
- Mocked mode walked through loading, empty, dust on and off, the placement filter, sorting, expanded rows, the drift warning, and light and dark.
- `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


