### PR TITLE
feat(kraken): show both sync steps on the Ledger page, add a Trades tab

### DIFF
--- a/src/server/db/ledger-repository.js
+++ b/src/server/db/ledger-repository.js
@@ -352,6 +352,8 @@ export default function LedgerRepository(accountId) {
 
    // Trades are cleared alongside the entries: they come from the same sync, for the
    // same account, and leaving them behind would show orders the ledger no longer has.
+   // Rows only — the tables and the database file stay, so another account's data
+   // survives and the next sync writes into the same schema.
    this.clearAccount = function () {
       const entries = this.countEntries()
       const trades = db.query('SELECT COUNT(*) AS count FROM trade WHERE account_id = ?')
@@ -362,6 +364,12 @@ export default function LedgerRepository(accountId) {
          db.query('DELETE FROM trade WHERE account_id = ?').run(accountId)
          db.query('DELETE FROM sync_state WHERE account_id = ?').run(accountId)
       })()
+
+      // Deleting rows only frees pages for reuse, so the file keeps its size and the
+      // sync card would still report a 40 MB database after clearing everything out
+      // of it. VACUUM rewrites the file at its real size; it cannot run inside a
+      // transaction, hence after the one above rather than in it.
+      db.exec('VACUUM')
 
       return { entries, trades }
    }

--- a/src/server/db/trade-repository.js
+++ b/src/server/db/trade-repository.js
@@ -17,6 +17,19 @@ const sortableOrderColumns = {
    price: 'CASE WHEN SUM(vol_num) > 0 THEN SUM(cost_num) / SUM(vol_num) ELSE 0 END'
 }
 
+// The same idea for the ungrouped fills, where each column stands on its own. The
+// numeric ones read the REAL mirrors too, for the reason given above.
+const sortableTradeColumns = {
+   time: 'time',
+   pair: 'pair_key',
+   direction: 'type',
+   ordertype: 'ordertype',
+   volume: 'vol_num',
+   price: 'price_num',
+   cost: 'cost_num',
+   fee: 'fee_num'
+}
+
 const upsertStatement = `
    INSERT INTO trade (
       account_id, txid, ordertxid, order_key, pair, pair_key, base_asset, quote_asset,
@@ -129,6 +142,34 @@ export default function TradeRepository(accountId) {
          .map(row => row.orderKey)
 
       return { rows: withExactAmounts(db, accountId, orderKeys), total, page, pageSize }
+   }
+
+   // The fills themselves, ungrouped: one row per trade, the way Kraken's export
+   // wrote it and the way the sync stored it. Nothing is recomputed here — an order's
+   // totals are the derived view above, a fill is just a row.
+   this.queryTrades = function ({ filters = {}, sort = {}, page = 0, pageSize = 50 }) {
+
+      const { where, params } = buildTradeWhere(accountId, filters)
+
+      const column = sortableTradeColumns[sort.column] ?? sortableTradeColumns.time
+      const direction = sort.direction === 'asc' ? 'ASC' : 'DESC'
+
+      const total = db.query(`SELECT COUNT(*) AS count FROM trade WHERE ${where}`)
+         .get(...params).count
+
+      // txid breaks the tie for the same reason order_key does above: the fills of one
+      // order share a timestamp, and without it rows shuffle between pages.
+      const rows = db.query(`
+         SELECT txid, ordertxid AS orderId, order_key AS orderKey, time,
+                pair_key AS pair, pair AS rawPair, base_asset AS baseAsset,
+                quote_asset AS quoteAsset, type AS direction, ordertype,
+                price, cost, fee, vol AS volume, margin, misc
+         FROM trade
+         WHERE ${where}
+         ORDER BY ${column} ${direction}, txid ${direction}
+         LIMIT ? OFFSET ?`).all(...params, pageSize, page * pageSize)
+
+      return { rows, total, page, pageSize }
    }
 
    this.distinctOrderFilters = function () {

--- a/src/server/routes/kraken-trades.js
+++ b/src/server/routes/kraken-trades.js
@@ -14,6 +14,16 @@ app.post('/orders', async (c) => withAccount(c, ({ body, accountId }) =>
       pageSize: Math.min(500, Math.max(1, Number(body.pageSize) || 50))
    }))))
 
+// The stored fills, ungrouped — what the Ledger page's Trades tab browses, next to
+// the ledger entries the same sync wrote.
+app.post('/fills', async (c) => withAccount(c, ({ body, accountId }) =>
+   c.json(new TradeRepository(accountId).queryTrades({
+      filters: body.filters,
+      sort: body.sort,
+      page: Math.max(0, Number(body.page) || 0),
+      pageSize: Math.min(500, Math.max(1, Number(body.pageSize) || 50))
+   }))))
+
 app.post('/filters', async (c) => withAccount(c, ({ accountId }) =>
    c.json(new TradeRepository(accountId).distinctOrderFilters())))
 

--- a/src/server/services/kraken-ledger-sync.js
+++ b/src/server/services/kraken-ledger-sync.js
@@ -28,6 +28,10 @@ const reports = ['ledgers', 'trades']
 
 const terminalPhases = ['done', 'error', 'cancelled']
 
+// A step is over once it reaches one of these; 'pending' is the other end, before the
+// step has started. Anything in between is a step Kraken is currently working on.
+const finishedStepPhases = ['done', 'error', 'cancelled', 'skipped']
+
 const jobs = new Map()
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
@@ -60,20 +64,14 @@ export function startSync(credentials, mode = 'incremental') {
    const job = {
       accountId,
       mode,
-      phase: 'requesting',
-      report: reports[0],
+      // The run's own lifecycle. What each report is doing lives in its own step: a
+      // single shared phase could only ever describe one of the two, so the page saw
+      // the ledger's progress replaced by the trades' halfway through the run.
+      phase: 'running',
       startedAt: Date.now(),
       updatedAt: Date.now(),
       finishedAt: null,
-      // reportId is the one in flight, kept alongside the map so the status card can
-      // show what Kraken is currently preparing without knowing about either report.
-      reportId: null,
-      reportIds: { ledgers: null, trades: null },
-      reportStatus: null,
-      pollCount: 0,
-      requestedFrom: null,
-      counts: { parsed: 0, stored: 0, inserted: 0, updated: 0, skipped: 0 },
-      results: {},
+      steps: reports.map(newStep),
       error: null,
       cancelRequested: false
    }
@@ -89,8 +87,40 @@ export function startSync(credentials, mode = 'incremental') {
    return { job, alreadyRunning: false }
 }
 
+// Kept in the order the run walks them, so the page renders them in that order
+// without having to know which report comes first.
+function newStep(report) {
+   return {
+      report,
+      phase: 'pending',
+      reportId: null,
+      reportStatus: null,
+      // Whether the export has already been handed back to Kraken. The run removes
+      // each one as soon as its rows are stored, and the cleanup at the end has to
+      // know which are left rather than asking Kraken to delete a report twice.
+      reportRemoved: false,
+      requestedFrom: null,
+      startedAt: null,
+      finishedAt: null,
+      pollCount: 0,
+      counts: { parsed: 0, stored: 0, inserted: 0, updated: 0, skipped: 0 },
+      error: null
+   }
+}
+
+const stepFor = (job, report) => job.steps.find(step => step.report === report)
+
+// The step Kraken is working on: started, not finished. There is at most one.
+const activeStep = job => job.steps.find(step =>
+   step.phase !== 'pending' && !finishedStepPhases.includes(step.phase))
+
 function setPhase(job, phase) {
    job.phase = phase
+   job.updatedAt = Date.now()
+}
+
+function setStepPhase(job, step, phase) {
+   step.phase = phase
    job.updatedAt = Date.now()
 }
 
@@ -140,7 +170,6 @@ async function runSync(job, credentials) {
 
       finishTradeState(repository, tradeRepository, job.startedAt)
 
-      setPhase(job, 'cleaning')
       finishSyncState(repository)
       setPhase(job, 'done')
    }
@@ -148,64 +177,86 @@ async function runSync(job, credentials) {
       if (job.phase !== 'cancelled') {
          setPhase(job, 'error')
          job.error = String(error.cause ?? error.message ?? error)
+
+         // The failure belongs to whichever report was in flight, so that the page can
+         // show one step failed while the other still reports what it did.
+         const step = activeStep(job)
+         if (step) {
+            step.error = job.error
+            step.phase = 'error'
+         }
+
          console.error('Ledger sync failed:', job.error)
          repository.writeSyncState({ lastError: job.error })
+      }
+
+      // A report the run never reached is neither done nor failed: it was dropped
+      // because the one before it ended the run.
+      for (const step of job.steps) {
+         if (step.phase === 'pending') step.phase = 'skipped'
       }
    }
    finally {
       job.finishedAt = Date.now()
       job.updatedAt = Date.now()
 
-      // Both reports have to go, not just the one in flight when the run ended.
-      for (const reportId of Object.values(job.reportIds)) {
-         if (reportId) await safeRemoveReport(krakenAPI, reportId)
-      }
+      // Whatever the run did not already hand back: the export of a step that failed,
+      // or one Kraken was still preparing when the sync was cancelled.
+      for (const step of job.steps) await removeStepReport(krakenAPI, step)
    }
 }
 
-// Requests one export, waits for Kraken to prepare it, then reads and stores it. The
-// phase names are the same for either report so that the page can render progress
-// without knowing which one is running; `job.report` says which it is.
+// Requests one export, waits for Kraken to prepare it, then reads, stores and removes
+// it. Both reports walk the same phases, each recorded on its own step, so the page
+// can show one finished while the other is still running.
 async function runReport(job, krakenAPI, repository, { report, fromDate, read, count, upsert }) {
 
-   job.report = report
-   job.pollCount = 0
-   job.reportStatus = null
-   job.requestedFrom = fromDate
-   job.counts = { parsed: 0, stored: 0, inserted: 0, updated: 0, skipped: 0 }
+   const step = stepFor(job, report)
+   step.startedAt = Date.now()
+   step.requestedFrom = fromDate
 
-   setPhase(job, 'requesting')
+   setStepPhase(job, step, 'requesting')
    const reportId = await krakenAPI.requestExport({
       report,
       description: `${REPORT_PREFIX}${new Date().toISOString()}`,
       fromDate
    })
 
-   job.reportIds[report] = reportId
-   job.reportId = reportId
+   step.reportId = reportId
 
    // Persisted before polling so that a restart mid-run can still clean up.
    repository.writeSyncState({ lastReportId: reportId })
 
-   setPhase(job, 'waiting')
-   await waitForReport(job, krakenAPI, report)
+   setStepPhase(job, step, 'waiting')
+   await waitForReport(job, krakenAPI, step)
 
-   setPhase(job, 'downloading')
+   setStepPhase(job, step, 'downloading')
    const { rows, skipped } = await read(reportId)
 
-   setPhase(job, 'parsing')
-   job.counts.parsed = rows.length
-   job.counts.skipped = skipped
+   setStepPhase(job, step, 'parsing')
+   step.counts.parsed = rows.length
+   step.counts.skipped = skipped
 
-   setPhase(job, 'storing')
-   await storeRows(job, rows, count, upsert)
+   setStepPhase(job, step, 'storing')
+   await storeRows(job, step, rows, count, upsert)
 
-   job.results[report] = { ...job.counts }
+   // Handed back as soon as its rows are safely stored rather than at the end of the
+   // run: an export left on Kraken counts against the per-account limit for as long
+   // as it sits there, and the trades report that follows can take minutes.
+   setStepPhase(job, step, 'cleaning')
+   await removeStepReport(krakenAPI, step)
+
+   step.finishedAt = Date.now()
+   setStepPhase(job, step, 'done')
    console.log(`Kraken ${report} sync stored ${rows.length} rows`)
 }
 
 function throwIfCancelled(job) {
    if (!job.cancelRequested) return
+
+   const step = activeStep(job)
+   if (step) step.phase = 'cancelled'
+
    setPhase(job, 'cancelled')
    throw new Error('Sync cancelled.')
 }
@@ -232,35 +283,35 @@ function incrementalStart(repository, tradeRepository, report) {
    return Math.max(0, Math.min(...watermark) - OVERLAP_MS)
 }
 
-async function waitForReport(job, krakenAPI, report) {
+async function waitForReport(job, krakenAPI, step) {
 
    const deadline = Date.now() + MAX_WAIT_MS
 
    while (Date.now() < deadline) {
 
-      await delay(pollDelays[Math.min(job.pollCount, pollDelays.length - 1)])
+      await delay(pollDelays[Math.min(step.pollCount, pollDelays.length - 1)])
 
       throwIfCancelled(job)
 
-      job.pollCount++
+      step.pollCount++
       job.updatedAt = Date.now()
 
       // One call covers every report of this type, so there is no need to poll per
       // id — but it must be this type: Kraken lists one type per call, and asking
       // for the wrong one would simply never find the report.
-      const entries = await krakenAPI.fetchExportReports(report)
-      const entry = entries.find(candidate => candidate.id === job.reportId)
+      const entries = await krakenAPI.fetchExportReports(step.report)
+      const entry = entries.find(candidate => candidate.id === step.reportId)
 
       if (entry) {
-         job.reportStatus = entry.status
+         step.reportStatus = entry.status
          if (entry.status?.toLowerCase() === 'processed') return
       }
    }
 
-   throw new Error(`Kraken did not finish preparing the ${report} export within 10 minutes.`)
+   throw new Error(`Kraken did not finish preparing the ${step.report} export within 10 minutes.`)
 }
 
-async function storeRows(job, rows, count, upsert) {
+async function storeRows(job, step, rows, count, upsert) {
 
    const before = count()
 
@@ -269,14 +320,14 @@ async function storeRows(job, rows, count, upsert) {
    // the server answering and lets progress be reported.
    for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
       upsert(rows.slice(i, i + CHUNK_SIZE), Date.now())
-      job.counts.stored = Math.min(i + CHUNK_SIZE, rows.length)
+      step.counts.stored = Math.min(i + CHUNK_SIZE, rows.length)
       job.updatedAt = Date.now()
       await delay(0)
    }
 
    const after = count()
-   job.counts.inserted = after - before
-   job.counts.updated = job.counts.stored - job.counts.inserted
+   step.counts.inserted = after - before
+   step.counts.updated = step.counts.stored - step.counts.inserted
 }
 
 // The watermarks come from the data Kraken returned rather than from the local
@@ -331,7 +382,8 @@ async function removeOrphanedReports(krakenAPI) {
          for (const entry of entries) {
             if (entry.description?.startsWith(REPORT_PREFIX) && entry.createdDate < cutoff) {
                console.log('Removing orphaned Kraken export:', entry.id)
-               await safeRemoveReport(krakenAPI, entry.id)
+               await safeRemoveReport(krakenAPI, entry.id,
+                  entry.status?.toLowerCase() === 'processed' ? 'delete' : 'cancel')
             }
          }
       }
@@ -342,9 +394,22 @@ async function removeOrphanedReports(krakenAPI) {
    }
 }
 
-async function safeRemoveReport(krakenAPI, reportId) {
+async function removeStepReport(krakenAPI, step) {
+
+   if (!step.reportId || step.reportRemoved) return
+
+   // Kraken only deletes a report it has finished preparing. One still queued or
+   // processing — which is what a cancelled run leaves behind — has to be cancelled
+   // instead, and asking to delete it just fails.
+   const type = step.reportStatus?.toLowerCase() === 'processed' ? 'delete' : 'cancel'
+
+   await safeRemoveReport(krakenAPI, step.reportId, type)
+   step.reportRemoved = true
+}
+
+async function safeRemoveReport(krakenAPI, reportId, type = 'delete') {
    try {
-      await krakenAPI.removeExport(reportId)
+      await krakenAPI.removeExport(reportId, type)
    }
    catch (error) {
       // Never let a failed cleanup mask the error that actually ended the run.

--- a/src/views/components/kraken/ledger-sync-card.jsx
+++ b/src/views/components/kraken/ledger-sync-card.jsx
@@ -73,15 +73,14 @@ export default function LedgerSyncCard({ state, job, isRunning, error, isStartin
                <Button variant="secondary" size="sm" type="button" disabled={isRunning || isStarting} onClick={onFullResync}>
                   Full resync
                </Button>
-               {isRunning &&
-                  <Button variant="outline" size="sm" type="button" onClick={onCancel}>
-                     Cancel
-                  </Button>}
+               {/* Alongside the other two rather than pushed to the far edge: it is one
+                   of the three things this card does, and the destructive variant is
+                   what marks it out. */}
                <Button
-                  variant="ghost"
+                  variant="destructive"
                   size="sm"
                   type="button"
-                  className="ml-auto text-destructive hover:text-destructive"
+                  className="border-destructive/40"
                   disabled={isRunning}
                   onClick={() => {
                      if (confirmingClear) {
@@ -96,6 +95,12 @@ export default function LedgerSyncCard({ state, job, isRunning, error, isStartin
                   <Trash2Icon className="size-3.5" />
                   {confirmingClear ? 'Click again to confirm' : 'Clear data'}
                </Button>
+               {/* Last, and only while there is something to cancel, so the three
+                   buttons above never move under the pointer mid-run. */}
+               {isRunning &&
+                  <Button variant="outline" size="sm" type="button" onClick={onCancel}>
+                     Cancel
+                  </Button>}
             </div>
 
             <p className="text-xs text-muted-foreground">

--- a/src/views/components/kraken/ledger-sync-card.jsx
+++ b/src/views/components/kraken/ledger-sync-card.jsx
@@ -5,6 +5,7 @@ import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/componen
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import Field from '../lib/field'
+import SyncSteps from './sync-steps'
 import { SyncStatusBadge, phaseLabel } from './sync-status'
 import { asLongDate } from '../../../utils/format'
 
@@ -19,8 +20,8 @@ export default function LedgerSyncCard({ state, job, isRunning, error, isStartin
 
    const [confirmingClear, setConfirmingClear] = useState(false)
 
-   // While a run is in flight the phase says more than a badge would, and it has to
-   // name the report as well: the phases repeat once per export.
+   // While a run is in flight the phase says more than a badge would. Which report it
+   // belongs to is left to the step rows below, which show both at once.
    const statusIndicator = isRunning
       ? <span className="flex items-center gap-1.5 text-sm font-normal text-muted-foreground">
          <Loader2Icon className="size-4 animate-spin" />
@@ -57,19 +58,9 @@ export default function LedgerSyncCard({ state, job, isRunning, error, isStartin
                </Field>
             </div>
 
-            {isRunning &&
-               <div className="grid grid-cols-2 gap-x-6 gap-y-3 border-t border-border pt-3 md:grid-cols-4">
-                  <Field label="Report">
-                     <span className="font-mono text-xs">{job.reportId ?? '—'}</span>
-                  </Field>
-                  <Field label="Kraken status">{job.reportStatus ?? 'Queued'}</Field>
-                  <Field label="Elapsed">{Math.round((job.updatedAt - job.startedAt) / 1000)}s</Field>
-                  <Field label="Entries read">
-                     {job.counts.stored > 0
-                        ? `${job.counts.stored.toLocaleString('en-GB')} saved`
-                        : (job.counts.parsed || 0).toLocaleString('en-GB')}
-                  </Field>
-               </div>}
+            {/* Kept after the run as well: it is the only place that says how much of
+                what was downloaded was actually new. */}
+            <SyncSteps job={job} />
 
             <div className="flex flex-wrap items-center gap-2">
                <Button size="sm" type="button" disabled={isRunning || isStarting} onClick={onSync}>
@@ -105,13 +96,17 @@ export default function LedgerSyncCard({ state, job, isRunning, error, isStartin
             </div>
 
             <p className="text-xs text-muted-foreground">
-               <b>Sync</b> fetches everything since the last entry it holds, for both the ledger and
-               your trade history. <b>Full resync</b> re-reads your whole history and refreshes
-               entries Kraken has amended since — it never deletes anything. <b>Clear data</b> removes
-               the entries and the trades behind the Closed Orders page.
+               <b>Sync</b> fetches everything since the last row it holds, as two exports: your
+               ledger, then your trade history. Each export is deleted from Kraken as soon as its
+               rows are stored. <b>Full resync</b> re-reads your whole history and refreshes rows
+               Kraken has amended since — it never deletes anything. <b>Clear data</b> empties the
+               entries and the trades behind the Closed Orders page, leaving the database itself in
+               place.
             </p>
 
-            {(error || job?.error) &&
+            {/* A failure the steps already carry is not repeated here; this is for the
+                ones that belong to no step, such as the request to start being refused. */}
+            {(error || (job?.error && !job.steps?.some(step => step.error))) &&
                <Alert variant="destructive">
                   <AlertDescription>{error ?? job.error}</AlertDescription>
                </Alert>}

--- a/src/views/components/kraken/ledger-sync-card.jsx
+++ b/src/views/components/kraken/ledger-sync-card.jsx
@@ -6,6 +6,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import Field from '../lib/field'
 import SyncSteps from './sync-steps'
+import { asCount } from '../lib/filter-options'
 import { SyncStatusBadge, phaseLabel } from './sync-status'
 import { asLongDate } from '../../../utils/format'
 
@@ -41,7 +42,7 @@ export default function LedgerSyncCard({ state, job, isRunning, error, isStartin
          </CardHeader>
          <CardContent className="space-y-4">
 
-            <div className="grid grid-cols-2 gap-x-6 gap-y-3 md:grid-cols-6">
+            <div className="grid grid-cols-2 gap-x-6 gap-y-3 md:grid-cols-4">
                <Field label="Data range">{dataRange}</Field>
                <Field
                   label="Last sync"
@@ -50,16 +51,18 @@ export default function LedgerSyncCard({ state, job, isRunning, error, isStartin
                      ? `${formatDistanceToNow(state.lastSyncedAt)} ago`
                      : 'Never'}
                </Field>
-               <Field label="Entries">{(state?.entryCount ?? 0).toLocaleString('en-GB')}</Field>
-               <Field label="Trades">{(state?.tradeCount ?? 0).toLocaleString('en-GB')}</Field>
-               <Field label="Database">{asFileSize(state?.dbSizeBytes)}</Field>
-               <Field label="Account">
-                  <span className="font-mono text-xs">{state?.apiKeyPrefix ? `${state.apiKeyPrefix}…` : '—'}</span>
+               {/* One field rather than two: the split between them is what the step
+                   rows below are for, and six labels made the card read as a form. */}
+               <Field label="Stored">
+                  {asCount(state?.entryCount, 'entry', 'entries')} · {asCount(state?.tradeCount, 'trade')}
                </Field>
+               <Field label="Database">{asFileSize(state?.dbSizeBytes)}</Field>
             </div>
 
-            {/* Kept after the run as well: it is the only place that says how much of
-                what was downloaded was actually new. */}
+            {/* Full width of the card rather than a bordered box inside it, so the run
+                reads as its own band between the stored figures and the actions. Kept
+                after the run as well: it is the only place that says how much of what
+                was downloaded was actually new. */}
             <SyncSteps job={job} />
 
             <div className="flex flex-wrap items-center gap-2">

--- a/src/views/components/kraken/sync-status.jsx
+++ b/src/views/components/kraken/sync-status.jsx
@@ -41,16 +41,20 @@ export function phaseLabel(job) {
    return `${stepLabel(step)} (${reportLabels[step.report] ?? step.report})`
 }
 
-// Only states that can actually be known get a badge. Nothing here can tell whether
-// Kraken has entries newer than the last run — the watermark is what was downloaded,
-// not what exists — so a stored ledger shows no badge at all and the "last synced"
-// time next to it is left to say how old it is.
+// Only states that can actually be known get a badge, and only where nothing else
+// already says it. A run that finished used to earn a "Synced" badge, which claimed
+// more than it knew: nothing here can tell whether Kraken has rows newer than the
+// last run — the watermark is what was downloaded, not what exists — so it only ever
+// meant "the last run did not fail", which the steps and the last-synced time say
+// between them. A run that did fail is worth flagging, because nothing else does.
 export function SyncStatusBadge({ state, job, isRunning }) {
 
    if (isRunning) return <Badge variant="secondary">Syncing</Badge>
    if (job?.phase === 'error') return <Badge variant="destructive">Failed</Badge>
    if (job?.phase === 'cancelled') return <Badge variant="outline">Cancelled</Badge>
-   if (job?.phase === 'done') return <Badge>Synced</Badge>
+   // Read from the stored watermark rather than from the job, so that clearing the
+   // data goes back to "never synced" instead of staying quiet on the strength of a
+   // finished run whose rows are gone.
    if (state?.lastSyncedAt) return null
 
    return <Badge variant="outline">Never synced</Badge>

--- a/src/views/components/kraken/sync-status.jsx
+++ b/src/views/components/kraken/sync-status.jsx
@@ -2,23 +2,43 @@ import { Badge } from '@/components/ui/badge'
 
 const terminalPhases = ['done', 'error', 'cancelled']
 
+// Mirrors the server's finished step phases: 'pending' is a step that has not started,
+// anything else outside this list is one Kraken is working on.
+const finishedStepPhases = ['done', 'error', 'cancelled', 'skipped']
+
 export const isJobRunning = job => Boolean(job) && !terminalPhases.includes(job.phase)
 
-const phaseLabels = {
+export const isStepRunning = step =>
+   Boolean(step) && step.phase !== 'pending' && !finishedStepPhases.includes(step.phase)
+
+// What each report is called on screen. The server names them the way Kraken's API
+// does, which is not what the rest of the app calls them.
+export const reportLabels = { ledgers: 'Ledger entries', trades: 'Trades' }
+
+const stepLabels = {
+   pending: 'Queued',
    requesting: 'Requesting export…',
    waiting: 'Kraken is preparing the export…',
    downloading: 'Downloading export…',
-   parsing: 'Reading entries…',
-   storing: 'Saving entries…',
-   cleaning: 'Cleaning up…'
+   parsing: 'Reading rows…',
+   storing: 'Saving rows…',
+   cleaning: 'Removing the export from Kraken…',
+   done: 'Done',
+   skipped: 'Not run',
+   cancelled: 'Cancelled',
+   error: 'Failed'
 }
 
-// A run walks the same phases twice, once per report, so the label says which one is
-// in flight — otherwise the progress appears to start over halfway through.
+export const stepLabel = step => stepLabels[step?.phase] ?? 'Syncing…'
+
+export const runningStep = job => job?.steps?.find(isStepRunning) ?? null
+
+// One line for the pages that only have room for one: whichever report is in flight,
+// named, because the same phases run twice and would otherwise look like a restart.
 export function phaseLabel(job) {
-   const label = phaseLabels[job?.phase]
-   if (!label) return 'Syncing…'
-   return job?.report ? `${label} (${job.report})` : label
+   const step = runningStep(job)
+   if (!step) return 'Syncing…'
+   return `${stepLabel(step)} (${reportLabels[step.report] ?? step.report})`
 }
 
 // Only states that can actually be known get a badge. Nothing here can tell whether

--- a/src/views/components/kraken/sync-steps.jsx
+++ b/src/views/components/kraken/sync-steps.jsx
@@ -11,8 +11,11 @@ export default function SyncSteps({ job }) {
 
    if (!job?.steps?.length) return null
 
+   // Bled to the card's edges and given a tint of its own: nested inside a border it
+   // read as a box within a box, and the phases of the two reports have to line up
+   // vertically to be comparable at a glance.
    return (
-      <div className="divide-y divide-border rounded-lg border border-border">
+      <div className="-mx-4 divide-y divide-border border-y border-border bg-muted/40 group-data-[size=sm]/card:-mx-3">
          {job.steps.map(step => <SyncStep key={step.report} step={step} job={job} />)}
       </div>
    )
@@ -29,33 +32,40 @@ function SyncStep({ step, job }) {
       : null
 
    return (
-      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 px-3 py-2.5 text-sm">
+      <div className="px-4 py-2.5 text-sm group-data-[size=sm]/card:px-3">
 
-         <span className="flex items-center gap-2 font-medium">
+         {/* The report name holds a column of its own so that every phase label starts
+             at the same x, whatever the name in front of it is. */}
+         <div className="grid grid-cols-[1rem_minmax(0,1fr)] items-center gap-x-3 sm:grid-cols-[1rem_9rem_minmax(0,1fr)]">
+
             <StepIcon step={step} running={running} />
-            {reportLabels[step.report] ?? step.report}
-         </span>
 
-         <span className={cn('text-muted-foreground', step.phase === 'error' && 'text-destructive')}>
-            {stepLabel(step)}
-         </span>
+            <span className="font-medium">{reportLabels[step.report] ?? step.report}</span>
 
-         <span className="ml-auto flex items-baseline gap-3 tabular-nums text-muted-foreground">
-            <StepCounts step={step} running={running} />
-            {elapsed !== null && <span className="w-12 text-right">{elapsed}s</span>}
-         </span>
+            <div className="col-span-2 flex items-baseline justify-between gap-x-4 gap-y-1 sm:col-span-1">
+               <span className={cn('text-muted-foreground', step.phase === 'error' && 'text-destructive')}>
+                  {stepLabel(step)}
+               </span>
+               <span className="flex shrink-0 items-baseline gap-4 tabular-nums text-muted-foreground">
+                  <StepCounts step={step} running={running} />
+                  {elapsed !== null && <span className="w-10 text-right">{elapsed}s</span>}
+               </span>
+            </div>
+
+         </div>
 
          {/* The report id is what Kraken's own export page lists a run under, so it is
-             worth showing while there is still something to look up. */}
+             worth showing while there is still something to look up. Indented to the
+             name column, so it hangs off the row it belongs to. */}
          {running && step.reportId &&
-            <span className="w-full font-mono text-xs text-muted-foreground">
+            <p className="mt-1 font-mono text-xs text-muted-foreground sm:pl-[1.75rem]">
                {step.reportId}
                {step.reportStatus && <> · {step.reportStatus}</>}
                {step.pollCount > 0 && <> · checked {step.pollCount}×</>}
-            </span>}
+            </p>}
 
          {step.error &&
-            <span className="w-full text-xs text-destructive">{step.error}</span>}
+            <p className="mt-1 text-xs text-destructive sm:pl-[1.75rem]">{step.error}</p>}
 
       </div>
    )

--- a/src/views/components/kraken/sync-steps.jsx
+++ b/src/views/components/kraken/sync-steps.jsx
@@ -1,0 +1,99 @@
+import { CheckIcon, CircleIcon, Loader2Icon, MinusIcon, XIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { isStepRunning, reportLabels, stepLabel } from './sync-status'
+
+const asCount = value => (value ?? 0).toLocaleString('en-GB')
+
+// A sync downloads two exports, one after the other. Both are shown for the whole run
+// and afterwards, so that the ledger's progress does not disappear the moment the
+// trades export starts and the finished run says what each of them did.
+export default function SyncSteps({ job }) {
+
+   if (!job?.steps?.length) return null
+
+   return (
+      <div className="divide-y divide-border rounded-lg border border-border">
+         {job.steps.map(step => <SyncStep key={step.report} step={step} job={job} />)}
+      </div>
+   )
+}
+
+function SyncStep({ step, job }) {
+
+   const running = isStepRunning(step)
+
+   // A step that is still going is timed against the last status the server sent, so
+   // the number moves with the polling rather than with this browser's clock.
+   const elapsed = step.startedAt
+      ? Math.max(0, Math.round(((step.finishedAt ?? job.updatedAt) - step.startedAt) / 1000))
+      : null
+
+   return (
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 px-3 py-2.5 text-sm">
+
+         <span className="flex items-center gap-2 font-medium">
+            <StepIcon step={step} running={running} />
+            {reportLabels[step.report] ?? step.report}
+         </span>
+
+         <span className={cn('text-muted-foreground', step.phase === 'error' && 'text-destructive')}>
+            {stepLabel(step)}
+         </span>
+
+         <span className="ml-auto flex items-baseline gap-3 tabular-nums text-muted-foreground">
+            <StepCounts step={step} running={running} />
+            {elapsed !== null && <span className="w-12 text-right">{elapsed}s</span>}
+         </span>
+
+         {/* The report id is what Kraken's own export page lists a run under, so it is
+             worth showing while there is still something to look up. */}
+         {running && step.reportId &&
+            <span className="w-full font-mono text-xs text-muted-foreground">
+               {step.reportId}
+               {step.reportStatus && <> · {step.reportStatus}</>}
+               {step.pollCount > 0 && <> · checked {step.pollCount}×</>}
+            </span>}
+
+         {step.error &&
+            <span className="w-full text-xs text-destructive">{step.error}</span>}
+
+      </div>
+   )
+}
+
+function StepIcon({ step, running }) {
+
+   if (running) return <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
+   if (step.phase === 'done') return <CheckIcon className="size-4 text-emerald-600 dark:text-emerald-500" />
+   if (step.phase === 'error') return <XIcon className="size-4 text-destructive" />
+   if (step.phase === 'cancelled' || step.phase === 'skipped') {
+      return <MinusIcon className="size-4 text-muted-foreground" />
+   }
+
+   return <CircleIcon className="size-4 text-muted-foreground/40" />
+}
+
+// What the step has to say about its rows, which is a different number at every stage:
+// nothing before the download, a running total while it saves, and what changed once
+// it is over.
+function StepCounts({ step, running }) {
+
+   const { parsed, stored, inserted, skipped } = step.counts ?? {}
+
+   if (step.phase === 'storing') {
+      return <span>{asCount(stored)} of {asCount(parsed)} saved</span>
+   }
+
+   if (running || step.phase === 'pending') {
+      return parsed > 0 ? <span>{asCount(parsed)} rows</span> : null
+   }
+
+   if (step.phase !== 'done') return null
+
+   return (
+      <span>
+         {asCount(parsed)} read · {asCount(inserted)} new
+         {skipped > 0 && <> · {asCount(skipped)} skipped</>}
+      </span>
+   )
+}

--- a/src/views/components/kraken/trade-table.jsx
+++ b/src/views/components/kraken/trade-table.jsx
@@ -1,0 +1,154 @@
+import { Link } from 'react-router'
+import { ArrowUpDownIcon, ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
+
+// Kraken records trade times in UTC; rendering them in the browser's zone would
+// silently shift every fill.
+const asUtcTimestamp = (time) => new Date(time).toISOString().replace('T', ' ').slice(0, 19)
+
+function SortableHead({ column, sort, onSortChange, className, children }) {
+   const isActive = sort.column === column
+   return (
+      <TableHead className={className}>
+         <button
+            type="button"
+            className="inline-flex items-center gap-1 hover:text-foreground"
+            onClick={() => onSortChange({
+               column,
+               direction: isActive && sort.direction === 'desc' ? 'asc' : 'desc'
+            })}>
+            {children}
+            <ArrowUpDownIcon className={cn('size-3', isActive ? 'opacity-100' : 'opacity-40')} />
+         </button>
+      </TableHead>
+   )
+}
+
+// One row per fill, exactly as the trades export wrote it. Orders — several fills
+// folded into one — are what the Closed Orders page shows; this is the stored data
+// behind it, next to the ledger entries the same sync downloaded.
+export default function TradeTable({ trades, isFiltered, sort, onSortChange, onPageChange, onSearchId }) {
+
+   const rows = trades?.rows ?? []
+   const total = trades?.total ?? 0
+   const { page = 0, pageSize = 50 } = trades ?? {}
+
+   if (rows.length === 0) {
+      return (
+         <p className="text-sm text-muted-foreground">
+            {isFiltered
+               ? 'No trades match these filters.'
+               : 'No trades stored. Sync above to fetch your trade history.'}
+         </p>
+      )
+   }
+
+   const firstRow = page * pageSize + 1
+   const lastRow = Math.min(total, (page + 1) * pageSize)
+
+   return (
+      <div className="space-y-3">
+         <Table className="tabular-nums">
+            <TableHeader>
+               <TableRow>
+                  <SortableHead column="time" sort={sort} onSortChange={onSortChange}>Time (UTC)</SortableHead>
+                  <SortableHead column="pair" sort={sort} onSortChange={onSortChange}>Pair</SortableHead>
+                  <SortableHead column="direction" sort={sort} onSortChange={onSortChange}>Side</SortableHead>
+                  <SortableHead column="ordertype" sort={sort} onSortChange={onSortChange}>Type</SortableHead>
+                  <SortableHead column="volume" sort={sort} onSortChange={onSortChange} className="text-right">
+                     Volume
+                  </SortableHead>
+                  <SortableHead column="price" sort={sort} onSortChange={onSortChange} className="text-right">
+                     Price
+                  </SortableHead>
+                  <SortableHead column="cost" sort={sort} onSortChange={onSortChange} className="text-right">
+                     Cost
+                  </SortableHead>
+                  <SortableHead column="fee" sort={sort} onSortChange={onSortChange} className="text-right">
+                     Fee
+                  </SortableHead>
+                  <TableHead>Trade</TableHead>
+                  <TableHead>Order</TableHead>
+               </TableRow>
+            </TableHeader>
+            <TableBody>
+               {rows.map(trade =>
+                  <TableRow key={trade.txid}>
+                     <TableCell className="whitespace-nowrap">{asUtcTimestamp(trade.time)}</TableCell>
+                     <TableCell
+                        className="font-medium whitespace-nowrap"
+                        title={trade.rawPair && trade.rawPair !== trade.pair ? trade.rawPair : undefined}>
+                        {trade.pair || '—'}
+                     </TableCell>
+                     <TableCell>
+                        <Badge variant={trade.direction === 'sell' ? 'outline' : 'secondary'}>
+                           {trade.direction || '—'}
+                        </Badge>
+                     </TableCell>
+                     <TableCell className="text-muted-foreground">
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                           {trade.ordertype || '—'}
+                           {Number(trade.margin) !== 0 && <Badge variant="outline">margin</Badge>}
+                        </div>
+                     </TableCell>
+                     <TableCell className="text-right">{trade.volume}</TableCell>
+                     <TableCell className="text-right">{trade.price}</TableCell>
+                     <TableCell className="text-right">{trade.cost}</TableCell>
+                     <TableCell className="text-right text-muted-foreground">{trade.fee}</TableCell>
+                     <TableCell>
+                        <button
+                           type="button"
+                           title={`Show only ${trade.txid}`}
+                           className="font-mono text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+                           onClick={() => onSearchId(trade.txid)}>
+                           {trade.txid}
+                        </button>
+                     </TableCell>
+                     <TableCell>
+                        {/* The order id is the one thing this table has that the ledger
+                            export does not, so it links to where it is put to use. */}
+                        {trade.orderId
+                           ? <Link
+                              to={`/kraken/closed-orders?order=${encodeURIComponent(trade.orderId)}`}
+                              title={`Show order ${trade.orderId} in Closed Orders`}
+                              className="font-mono text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline">
+                              {trade.orderId}
+                           </Link>
+                           : <span className="text-muted-foreground">—</span>}
+                     </TableCell>
+                  </TableRow>)}
+            </TableBody>
+         </Table>
+
+         <div className="flex items-center justify-between">
+            <p className="text-sm text-muted-foreground">
+               Showing {firstRow.toLocaleString('en-GB')}–{lastRow.toLocaleString('en-GB')} of{' '}
+               {total.toLocaleString('en-GB')}
+            </p>
+            <div className="flex items-center gap-1">
+               <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  type="button"
+                  aria-label="Previous page"
+                  disabled={page === 0}
+                  onClick={() => onPageChange(page - 1)}>
+                  <ChevronLeftIcon className="size-4" />
+               </Button>
+               <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  type="button"
+                  aria-label="Next page"
+                  disabled={lastRow >= total}
+                  onClick={() => onPageChange(page + 1)}>
+                  <ChevronRightIcon className="size-4" />
+               </Button>
+            </div>
+         </div>
+      </div>
+   )
+}

--- a/src/views/components/lib/filter-options.js
+++ b/src/views/components/lib/filter-options.js
@@ -17,5 +17,6 @@ export const asDateInput = (timestamp) => timestamp
 export const fromDateValue = (value) => value ? Date.parse(`${value}T00:00:00Z`) : null
 export const toDateValue = (value) => value ? Date.parse(`${value}T23:59:59Z`) : null
 
-export const asCount = (count, noun) =>
-   `${(count ?? 0).toLocaleString('en-GB')} ${noun}${count === 1 ? '' : 's'}`
+// The plural is spelled out only for the nouns an s cannot make, such as entries.
+export const asCount = (count, noun, plural) =>
+   `${(count ?? 0).toLocaleString('en-GB')} ${count === 1 ? noun : plural ?? `${noun}s`}`

--- a/src/views/components/ui/tabs.jsx
+++ b/src/views/components/ui/tabs.jsx
@@ -1,0 +1,60 @@
+import * as React from 'react'
+import { Tabs as TabsPrimitive } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+
+function Tabs({
+   className,
+   ...props
+}) {
+   return (
+      <TabsPrimitive.Root
+         data-slot="tabs"
+         className={cn('flex flex-col gap-4', className)}
+         {...props} />
+   )
+}
+
+function TabsList({
+   className,
+   ...props
+}) {
+   return (
+      <TabsPrimitive.List
+         data-slot="tabs-list"
+         className={cn(
+            'inline-flex h-9 w-fit items-center justify-center rounded-lg bg-muted p-[3px] text-muted-foreground',
+            className
+         )}
+         {...props} />
+   )
+}
+
+function TabsTrigger({
+   className,
+   ...props
+}) {
+   return (
+      <TabsPrimitive.Trigger
+         data-slot="tabs-trigger"
+         className={cn(
+            'inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground transition-[color,box-shadow] focus-visible:outline-1 focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*=\'size-\'])]:size-4',
+            className
+         )}
+         {...props} />
+   )
+}
+
+function TabsContent({
+   className,
+   ...props
+}) {
+   return (
+      <TabsPrimitive.Content
+         data-slot="tabs-content"
+         className={cn('flex-1 outline-none', className)}
+         {...props} />
+   )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/views/mocks/index.js
+++ b/src/views/mocks/index.js
@@ -3,7 +3,7 @@ import {
    ledgerSync, ledgerSyncStatus, ledgerSyncCancel, ledgerClear,
    ledgerEntries, ledgerFilters, ledgerFees, ledgerRewards, ledgerBalances
 } from './kraken-ledger'
-import { tradeOrders, tradeFilters } from './kraken-trades'
+import { tradeOrders, tradeFills, tradeFilters } from './kraken-trades'
 import { aggregateBalance } from './binance'
 
 
@@ -23,6 +23,7 @@ const mockRoutes = {
    '/api/kraken/ledger/balances': () => ledgerBalances(),
    '/api/kraken/ledger/clear': () => ledgerClear(),
    '/api/kraken/ledger/trades/orders': (params) => tradeOrders(params?.arg),
+   '/api/kraken/ledger/trades/fills': (params) => tradeFills(params?.arg),
    '/api/kraken/ledger/trades/filters': () => tradeFilters(),
    '/api/binance/aggregate-balance': () => aggregateBalance,
 }

--- a/src/views/mocks/kraken-ledger.js
+++ b/src/views/mocks/kraken-ledger.js
@@ -138,57 +138,95 @@ let syncState = {
 }
 
 // Phases are derived from elapsed time so that mocked mode drives the real polling
-// loop and shows the whole progression rather than jumping straight to done. A run
-// walks them twice, once per export report, as the server does.
-const schedule = [
-   [0, 'requesting', 'Queued', 'ledgers'],
-   [1500, 'waiting', 'Processing', 'ledgers'],
-   [7000, 'downloading', 'Processed', 'ledgers'],
-   [8500, 'parsing', 'Processed', 'ledgers'],
-   [9500, 'storing', 'Processed', 'ledgers'],
-   [10500, 'requesting', 'Queued', 'trades'],
-   [12000, 'waiting', 'Processing', 'trades'],
-   [16000, 'downloading', 'Processed', 'trades'],
-   [17000, 'parsing', 'Processed', 'trades'],
-   [18000, 'storing', 'Processed', 'trades'],
-   [19000, 'cleaning', 'Processed', 'trades'],
-   [19500, 'done', 'Processed', 'trades']
+// loop and shows the whole progression rather than jumping straight to done. One step
+// walks these; the run walks the steps one after the other, as the server does.
+const stepSchedule = [
+   [0, 'requesting', null],
+   [1500, 'waiting', 'Queued'],
+   [3000, 'waiting', 'Processing'],
+   [7000, 'downloading', 'Processed'],
+   [8500, 'parsing', 'Processed'],
+   [9500, 'storing', 'Processed'],
+   [10000, 'cleaning', 'Processed'],
+   [10500, 'done', 'Processed']
 ]
 
-const SYNC_MS = 19500
+const STEP_MS = 10500
+const SYNC_MS = 2 * STEP_MS
+
+const reportIds = { ledgers: 'TCWJRA-2JBAB-DHZE7X', trades: 'TCWJRA-9KLMN-QRSTU' }
 
 let job = null
+
+// The step's own view of the run: `offset` is when its turn starts, so everything
+// before that reads as pending and everything after as finished.
+function stepAt(report, elapsed, offset, mode) {
+
+   const rowCount = report === 'trades' ? allTradeCount() : allEntries.length
+   const local = elapsed - offset
+
+   const base = {
+      report,
+      reportId: local >= 0 ? reportIds[report] : null,
+      reportStatus: null,
+      reportRemoved: false,
+      requestedFrom: null,
+      startedAt: local >= 0 ? job.startedAt + offset : null,
+      finishedAt: null,
+      pollCount: 0,
+      counts: { parsed: 0, stored: 0, inserted: 0, updated: 0, skipped: 0 },
+      error: null
+   }
+
+   if (local < 0) return { ...base, phase: 'pending' }
+
+   const [, phase, reportStatus] = stepSchedule.findLast(([at]) => local >= at) ?? stepSchedule[0]
+   const stored = ['storing', 'cleaning', 'done'].includes(phase)
+
+   return {
+      ...base,
+      phase,
+      reportStatus,
+      reportRemoved: phase === 'done',
+      pollCount: Math.floor(Math.min(local, 7000) / 1500),
+      finishedAt: phase === 'done' ? job.startedAt + offset + STEP_MS : null,
+      counts: {
+         parsed: ['requesting', 'waiting'].includes(phase) ? 0 : rowCount,
+         stored: stored ? rowCount : 0,
+         inserted: phase === 'done' ? (mode === 'full' ? 0 : 3) : 0,
+         updated: phase === 'done' ? rowCount - (mode === 'full' ? 0 : 3) : 0,
+         skipped: 0
+      }
+   }
+}
 
 function currentJob() {
    if (!job) return null
 
    const elapsed = Date.now() - job.startedAt
+   const steps = ['ledgers', 'trades']
+      .map((report, index) => stepAt(report, elapsed, index * STEP_MS, job.mode))
+
    if (job.cancelRequested) {
-      return { ...job, phase: 'cancelled', finishedAt: job.startedAt + elapsed }
+      return {
+         ...job,
+         phase: 'cancelled',
+         updatedAt: Date.now(),
+         finishedAt: job.startedAt + elapsed,
+         // Whichever step was in flight was cancelled with the run; one that never
+         // started was dropped, exactly as the server records it.
+         steps: steps.map(step => step.phase === 'done'
+            ? step
+            : { ...step, phase: step.phase === 'pending' ? 'skipped' : 'cancelled' })
+      }
    }
-
-   const [, phase, reportStatus, report] = schedule.findLast(([at]) => elapsed >= at) ?? schedule[0]
-
-   // Counts belong to the report in flight, so they restart when the second one does.
-   const rowCount = report === 'trades' ? allTradeCount() : allEntries.length
-   const parsed = phase === 'requesting' || phase === 'waiting' ? 0 : rowCount
 
    return {
       ...job,
-      phase,
-      report,
-      reportStatus,
-      reportIds: { ledgers: job.reportId, trades: 'TCWJRA-9KLMN-QRSTU' },
-      pollCount: Math.floor(elapsed / 1500),
+      phase: elapsed >= SYNC_MS ? 'done' : 'running',
+      steps,
       updatedAt: Date.now(),
-      finishedAt: phase === 'done' ? job.startedAt + SYNC_MS : null,
-      counts: {
-         parsed,
-         stored: ['storing', 'cleaning', 'done'].includes(phase) ? rowCount : 0,
-         inserted: phase === 'done' ? (job.mode === 'full' ? 0 : 3) : 0,
-         updated: phase === 'done' ? rowCount : 0,
-         skipped: 0
-      }
+      finishedAt: elapsed >= SYNC_MS ? job.startedAt + SYNC_MS : null
    }
 }
 
@@ -202,8 +240,6 @@ export function ledgerSync(body) {
       accountId: 'mock-account',
       mode: body?.mode === 'full' ? 'full' : 'incremental',
       startedAt: Date.now(),
-      reportId: 'TCWJRA-2JBAB-DHZE7X',
-      requestedFrom: body?.mode === 'full' ? 0 : syncState.coveredTo - 72 * 3600000,
       error: null,
       cancelRequested: false
    }

--- a/src/views/mocks/kraken-trades.js
+++ b/src/views/mocks/kraken-trades.js
@@ -185,6 +185,59 @@ export function tradeOrders(body = {}) {
    return { rows: sorted.slice(page * pageSize, (page + 1) * pageSize), total: orders.length, page, pageSize }
 }
 
+// The fills themselves, ungrouped, as the Ledger page's Trades tab reads them. A
+// filter selects a row here rather than the order behind it — nothing is folded.
+export function tradeFills(body = {}) {
+
+   const filtered = trades.filter(trade => matches(trade, body.filters))
+
+   const columns = ['time', 'pair', 'direction', 'ordertype', 'volume', 'price', 'cost', 'fee']
+   const column = columns.includes(body.sort?.column) ? body.sort.column : 'time'
+   const factor = body.sort?.direction === 'asc' ? 1 : -1
+
+   const numeric = ['volume', 'price', 'cost', 'fee'].includes(column)
+   const value = trade => {
+      if (column === 'volume') return Number(trade.vol)
+      if (column === 'pair') return trade.pairKey
+      if (column === 'direction') return trade.type
+      if (numeric) return Number(trade[column])
+      return trade[column]
+   }
+
+   const sorted = filtered.toSorted((a, b) => {
+      const [left, right] = [value(a), value(b)]
+      if (left < right) return -factor
+      if (left > right) return factor
+      return a.txid < b.txid ? -factor : factor
+   })
+
+   const page = Math.max(0, body.page ?? 0)
+   const pageSize = body.pageSize ?? 50
+
+   // The server renames columns on the way out; the fixture has to answer in the same
+   // shape or the table would render blanks under mocked data only.
+   const rows = sorted.slice(page * pageSize, (page + 1) * pageSize).map(trade => ({
+      txid: trade.txid,
+      orderId: trade.ordertxid,
+      orderKey: trade.orderKey,
+      time: trade.time,
+      pair: trade.pairKey,
+      rawPair: trade.pair,
+      baseAsset: trade.baseAsset,
+      quoteAsset: trade.quoteAsset,
+      direction: trade.type,
+      ordertype: trade.ordertype,
+      price: trade.price,
+      cost: trade.cost,
+      fee: trade.fee,
+      volume: trade.vol,
+      margin: trade.margin,
+      misc: trade.misc
+   }))
+
+   return { rows, total: filtered.length, page, pageSize }
+}
+
 export function tradeFilters() {
    const distinct = pick => [...new Set(trades.map(pick))].filter(Boolean).toSorted()
    return {

--- a/src/views/pages/kraken/closed-orders.jsx
+++ b/src/views/pages/kraken/closed-orders.jsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react'
+import { useSearchParams } from 'react-router'
 import useSWR, { useSWRConfig } from 'swr'
 import { InfoIcon, Loader2Icon } from 'lucide-react'
 import KrakenLayout from '../../components/kraken/kraken-layout'
@@ -20,7 +21,15 @@ export default function KrakenClosedOrders() {
       apiKey: (typeof window !== 'undefined' && localStorage.getItem('kraken.api.key')) || ''
    }))
 
-   const [filters, setFilters] = useState(defaultFilters)
+   // ?order=… arrives from the Ledger page's Trades tab, where a fill links to the
+   // order it belongs to. Read once as the initial filter: after that the filter bar
+   // owns the value, and rewriting it from the URL would fight with it.
+   const [searchParams] = useSearchParams()
+   const [filters, setFilters] = useState(() => {
+      const order = searchParams.get('order')
+      return order ? { ...defaultFilters, search: order } : defaultFilters
+   })
+
    const [filtersKey, setFiltersKey] = useState(0)
    const [sort, setSort] = useState({ column: 'time', direction: 'desc' })
    const [page, setPage] = useState(0)

--- a/src/views/pages/kraken/ledger.jsx
+++ b/src/views/pages/kraken/ledger.jsx
@@ -162,11 +162,10 @@ export default function KrakenLedger() {
    const isTradeFiltered = Object.keys(defaultTradeFilters)
       .some(key => tradeFilters[key] !== defaultTradeFilters[key])
 
-   // The badge counts whatever the open tab is showing. 'entry' is spelled out rather
-   // than run through asCount, which only knows how to add an s.
+   // The badge counts whatever the open tab is showing.
    const count = showTrades
       ? { isLoading: isLoadingTrades, label: asCount(trades?.total, 'trade') }
-      : { isLoading, label: `${(entries?.total ?? 0).toLocaleString('en-GB')} entries` }
+      : { isLoading, label: asCount(entries?.total, 'entry', 'entries') }
 
    return (
       <KrakenLayout name="Ledger">

--- a/src/views/pages/kraken/ledger.jsx
+++ b/src/views/pages/kraken/ledger.jsx
@@ -6,8 +6,12 @@ import KrakenLayout from '../../components/kraken/kraken-layout'
 import LedgerSyncCard from '../../components/kraken/ledger-sync-card'
 import LedgerFilters, { defaultFilters } from '../../components/kraken/ledger-filters'
 import LedgerTable from '../../components/kraken/ledger-table'
+import OrderFilters, { defaultFilters as defaultTradeFilters } from '../../components/kraken/order-filters'
+import TradeTable from '../../components/kraken/trade-table'
 import { isJobRunning } from '../../components/kraken/sync-status'
-import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
+import { asCount } from '../../components/lib/filter-options'
+import { Card, CardHeader, CardAction, CardContent } from '@/components/ui/card'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 
@@ -21,10 +25,21 @@ export default function KrakenLedger() {
       apiSecret: (typeof window !== 'undefined' && localStorage.getItem('kraken.api.secret')) || ''
    }))
 
+   // One tab per table the sync writes, so the page shows exactly what it stores.
+   const [tab, setTab] = useState('entries')
+
    const [filters, setFilters] = useState(defaultFilters)
    const [filtersKey, setFiltersKey] = useState(0)
    const [sort, setSort] = useState({ column: 'time', direction: 'desc' })
    const [page, setPage] = useState(0)
+
+   // The trades tab filters on different columns and sorts on its own, so it keeps its
+   // own state rather than sharing the ledger's and resetting it on every switch.
+   const [tradeFilters, setTradeFilters] = useState(defaultTradeFilters)
+   const [tradeFiltersKey, setTradeFiltersKey] = useState(0)
+   const [tradeSort, setTradeSort] = useState({ column: 'time', direction: 'desc' })
+   const [tradePage, setTradePage] = useState(0)
+
    const [wasInterrupted, setWasInterrupted] = useState(false)
 
    const startedRef = useRef(false)
@@ -70,6 +85,20 @@ export default function KrakenLedger() {
 
    const { data: entries, isLoading } = useSWR(
       account ? ['/api/kraken/ledger/entries', { credentials: account, filters, sort, page, pageSize: PAGE_SIZE }] : null,
+      { keepPreviousData: true })
+
+   // Fetched only once the tab is open — most visits here are to sync, not to read
+   // the fills — and kept in the cache afterwards, so switching back is instant.
+   const showTrades = tab === 'trades'
+
+   const { data: tradeFilterOptions } = useSWR(
+      account && showTrades ? ['/api/kraken/ledger/trades/filters', { credentials: account }] : null)
+
+   const { data: trades, isLoading: isLoadingTrades } = useSWR(
+      account && showTrades
+         ? ['/api/kraken/ledger/trades/fills',
+            { credentials: account, filters: tradeFilters, sort: tradeSort, page: tradePage, pageSize: PAGE_SIZE }]
+         : null,
       { keepPreviousData: true })
 
    const { trigger: startSync, isMutating, error: syncError } = useSWRMutation('/api/kraken/ledger/sync')
@@ -120,6 +149,25 @@ export default function KrakenLedger() {
       setFiltersKey(key => key + 1)
    }
 
+   const changeTradeFilters = (next) => {
+      setTradeFilters(next)
+      setTradePage(0)
+   }
+
+   const replaceTradeFilters = (next) => {
+      changeTradeFilters(next)
+      setTradeFiltersKey(key => key + 1)
+   }
+
+   const isTradeFiltered = Object.keys(defaultTradeFilters)
+      .some(key => tradeFilters[key] !== defaultTradeFilters[key])
+
+   // The badge counts whatever the open tab is showing. 'entry' is spelled out rather
+   // than run through asCount, which only knows how to add an s.
+   const count = showTrades
+      ? { isLoading: isLoadingTrades, label: asCount(trades?.total, 'trade') }
+      : { isLoading, label: `${(entries?.total ?? 0).toLocaleString('en-GB')} entries` }
+
    return (
       <KrakenLayout name="Ledger">
          <div className="space-y-6">
@@ -127,11 +175,10 @@ export default function KrakenLedger() {
             <div className="flex items-center gap-3 rounded-lg border border-blue-300/60 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-500/25 dark:bg-blue-950/30 dark:text-blue-100">
                <InfoIcon className="size-5 shrink-0" />
                <p>
-                  Downloads your complete Kraken ledger — trades, deposits, withdrawals, staking and
-                  earn rewards — along with your trade history, and keeps both in a database on this
-                  machine so other tools can use them without querying the API again. Kraken prepares
-                  each export in the background, so a first sync can take several minutes. Nothing is
-                  uploaded anywhere.
+                  Downloads two exports from Kraken — your complete ledger and your trade history —
+                  and keeps both in a database on this machine, so the other tools can use them
+                  without querying the API again. Kraken prepares each export in the background, so
+                  a first sync can take several minutes. Nothing is uploaded anywhere.
                </p>
             </div>
 
@@ -140,7 +187,7 @@ export default function KrakenLedger() {
                   <TriangleAlertIcon />
                   <AlertDescription>
                      The sync was interrupted before it finished, most likely because the server
-                     restarted. Entries saved up to that point were kept — run Sync again to fetch
+                     restarted. Rows saved up to that point were kept — run Sync again to fetch
                      the rest.
                   </AlertDescription>
                </Alert>}
@@ -156,32 +203,57 @@ export default function KrakenLedger() {
                onCancel={() => cancelSync({ credentials: account }).catch(() => {})}
                onClear={clear} />
 
-            <Card>
-               <CardHeader>
-                  <CardTitle>Entries</CardTitle>
-                  <CardAction>
-                     {isLoading
-                        ? <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
-                        : <Badge variant="outline">
-                           {(entries?.total ?? 0).toLocaleString('en-GB')} entries
-                        </Badge>}
-                  </CardAction>
-               </CardHeader>
-               <CardContent className="space-y-4">
-                  <LedgerFilters
-                     key={filtersKey}
-                     filters={filters}
-                     options={filterOptions}
-                     onChange={changeFilters}
-                     onReset={() => replaceFilters(defaultFilters)} />
-                  <LedgerTable
-                     entries={entries}
-                     sort={sort}
-                     onSortChange={(next) => { setSort(next); setPage(0) }}
-                     onPageChange={setPage}
-                     onSearchRef={(refid) => replaceFilters({ ...defaultFilters, search: refid })} />
-               </CardContent>
-            </Card>
+            <Tabs value={tab} onValueChange={setTab}>
+               <Card>
+                  <CardHeader>
+                     <TabsList>
+                        <TabsTrigger value="entries">Ledger entries</TabsTrigger>
+                        <TabsTrigger value="trades">Trades</TabsTrigger>
+                     </TabsList>
+                     <CardAction>
+                        {count.isLoading
+                           ? <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
+                           : <Badge variant="outline">{count.label}</Badge>}
+                     </CardAction>
+                  </CardHeader>
+                  <CardContent>
+
+                     <TabsContent value="entries" className="space-y-4">
+                        <LedgerFilters
+                           key={filtersKey}
+                           filters={filters}
+                           options={filterOptions}
+                           onChange={changeFilters}
+                           onReset={() => replaceFilters(defaultFilters)} />
+                        <LedgerTable
+                           entries={entries}
+                           sort={sort}
+                           onSortChange={(next) => { setSort(next); setPage(0) }}
+                           onPageChange={setPage}
+                           onSearchRef={(refid) => replaceFilters({ ...defaultFilters, search: refid })} />
+                     </TabsContent>
+
+                     {/* The fills as Kraken exported them. Grouped into orders they are the
+                         Closed Orders page; here they are what the sync actually stored. */}
+                     <TabsContent value="trades" className="space-y-4">
+                        <OrderFilters
+                           key={tradeFiltersKey}
+                           filters={tradeFilters}
+                           options={tradeFilterOptions}
+                           onChange={changeTradeFilters}
+                           onReset={() => replaceTradeFilters(defaultTradeFilters)} />
+                        <TradeTable
+                           trades={trades}
+                           isFiltered={isTradeFiltered}
+                           sort={tradeSort}
+                           onSortChange={(next) => { setTradeSort(next); setTradePage(0) }}
+                           onPageChange={setTradePage}
+                           onSearchId={(txid) => replaceTradeFilters({ ...defaultTradeFilters, search: txid })} />
+                     </TabsContent>
+
+                  </CardContent>
+               </Card>
+            </Tabs>
 
          </div>
       </KrakenLayout>


### PR DESCRIPTION
A sync downloads two exports — the ledger, then the trade history — but the job carried a single phase and the card rendered one line, so the ledger's progress was replaced by the trades' halfway through and the finished run left nothing saying what each had done.

## What changed

**Both steps are visible.** The job now holds a step per report, each with its own phase, counts, report id, Kraken status, poll count and elapsed time; `job.phase` is only the run's lifecycle (`running` / `done` / `error` / `cancelled`). The new `SyncSteps` component renders both rows for the whole run *and after it*: a finished run reports `266 read · 3 new` per report instead of disappearing, a failure is attributed to the report it belongs to, and a step the run never reached reads `Not run` rather than going blank.

**Exports are handed back sooner.** Each report is removed from Kraken as soon as its rows are stored, instead of at the end of the run — the ledger export used to sit against the per-account export limit for the whole trades phase, which can be minutes. The `finally` block is now a net for what failed or was cancelled. `RemoveExport` was also always called with `type: 'delete'`, which Kraken refuses for a report still queued or processing — exactly what a cancelled run leaves behind. It now asks to `cancel` in that case, orphan cleanup included.

**Clear data reclaims the space.** It already deleted rows rather than tables, but SQLite keeps the freed pages, so the card went on reporting the old database size and the clear read as a no-op. It vacuums afterwards; the tables and the file itself are untouched, as before.

**A Trades tab.** The page synced two tables and showed one. The data card is now tabbed, one tab per table it stores: the ledger entries as before, and the trades as the fills Kraken exported (`queryTrades` + `POST /trades/fills`, reusing the existing order filter bar and options endpoint). Fills are only fetched once the tab is opened. Grouped into orders they are the Closed Orders page, which a fill now links to — that page seeds its filter from an `?order=` parameter.

## Notes for the reviewer

- The one-line `SyncStatusStrip` on Balances, Rewards and Closed Orders is unchanged by design: it has room for one phase, and still names the report in flight.
- The mocked fixtures follow the same step model, so `bun run mocked` walks the whole progression rather than jumping to done.
- Verified in mocked mode: ledger running while trades queued, ledger done while trades still requesting, cancel leaving ledger `Done` and trades `Cancelled`, clear emptying both counts, the Trades tab and its empty state, and the `?order=` deep link. Server endpoints and the `VACUUM` were exercised against a real SQLite file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)