### PR TITLE
fix: give the Scoop bin entry an alias

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,6 +303,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           mkdir -p bucket
+          # bin is given an alias: the Electrobun entry point is always named
+          # launcher.exe, so without one Scoop would shim it as `launcher` and every
+          # Electrobun app in the bucket would fight over that same name.
           jq -n \
             --arg version "$VERSION" \
             --arg url "https://github.com/nyg/crypto-tools/releases/download/v${VERSION}/crypto-tools-${VERSION}-windows-x64-scoop.zip" \
@@ -315,7 +318,7 @@ jobs:
               architecture: {
                 "64bit": {url: $url, hash: $hash}
               },
-              bin: "bin\\launcher.exe",
+              bin: [["bin\\launcher.exe", "crypto-tools"]],
               shortcuts: [["bin\\launcher.exe", "Crypto Tools"]]
             }' > bucket/crypto-tools.json
           git add bucket/crypto-tools.json


### PR DESCRIPTION
The Scoop manifest generated by `release.yml` declares `bin` as the bare path `"bin\\launcher.exe"`, so Scoop creates a shim named **`launcher`**.

Every Electrobun app uses that same entry point name, so `crypto-tools` and `qoqa-compta` currently fight over one `launcher` shim: installing both means the second overwrites the first, and neither app is reachable under its own name from the command line.

This aliases the entry to `crypto-tools`:

```diff
-  bin: "bin\\launcher.exe",
+  bin: [["bin\\launcher.exe", "crypto-tools"]],
```

`wiktionary-to-kindle` already does exactly this (its generator carries a comment explaining the alias); this brings the Electrobun apps in line. The Start menu shortcut is unchanged.

Companion PRs: nyg/qoqa-compta (same fix) and nyg/scoop-bucket#4, which corrects the already-published manifest — without this PR the next release would regenerate and overwrite it.

Verified the updated jq program emits the intended JSON and that `release.yml` still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)