### PR TITLE
feat(ui): finish the design-system rollout across every page

### DIFF
--- a/src/views/components/binance/current-positions.jsx
+++ b/src/views/components/binance/current-positions.jsx
@@ -1,109 +1,44 @@
-import * as format from '../../../utils/format'
-import Big from 'big.js'
+import { asAssetAmount, asDollarAmount } from '../../../utils/format'
+import { Table, TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell } from '@/components/ui/table'
 
-
-function LabeledValue({ label, value, className }) {
-   return (
-      <span className={`flex space-x-2 text-xs leading-5 ${className}`}>
-         <span className="grow text-right font-medium">{value}</span>
-         {label && (
-            <span className="font-light uppercase">{label}</span>
-         )}
-      </span>
-   )
-}
-
-function Product({ product, spot }) {
-
-   const duration = product.info.duration
-   const apy = format.asPercentage(product.info.apy)
-
-   const productAvailable = !product.info.soldOut
-   const userQuota = Big(product.info.maxStakingAmount)
-   const userQuotaRemaining = userQuota.minus(product.info.positionsAmount)
-
-   const buildAvailability = () => {
-
-      if (productAvailable) {
-         if (spot.gt(userQuotaRemaining)) {
-            if (userQuotaRemaining.eq(0)) {
-               return <span className="text-red-600">available but user quota of {format.asDecimal(userQuota)} {product.info.asset} reached</span>
-            }
-            if (userQuotaRemaining.lt(product.info.minStakingAmount)) {
-               return <span className="text-red-600">available but remaining user quota too low</span>
-            }
-            else {
-               return <span className="text-orange-400">available but user quota remaining is {format.asDecimal(userQuotaRemaining)} {product.info.asset}</span>
-            }
-            // }
-         }
-         else {
-            return <span className="text-green-600">available</span>
-         }
-      }
-      else {
-         if (userQuotaRemaining.eq(0)) {
-            return <span className="text-red-600">sold out and user quota of {format.asDecimal(userQuota)} {product.info.asset} reached</span>
-         }
-         if (userQuotaRemaining.lt(product.info.minStakingAmount)) {
-            return <span className="text-red-600">sold out and user quota too low</span>
-         }
-         else if (spot.gt(userQuotaRemaining)) {
-            return <span className="text-red-600">sold out and user quota remaining is {format.asDecimal(userQuotaRemaining)}</span>
-         }
-         else {
-            return <span className="">sold out</span>
-         }
-      }
-   }
-
-   return (
-      <li>
-         {duration} days @ {apy} · {buildAvailability()}
-         <ul className="text-xs pl-6">
-            {product.positions.map(position => <Position key={position.id} position={position} />)}
-         </ul>
-      </li >
-   )
-}
-
-function Position({ position }) {
-
-   const amount = format.asDecimal(position.amount)
-   const apy = format.asPercentage(position.apy)
-   const daysRemaining = position.duration - position.accrualDays
-
-   return (
-      <li>{amount} @ {apy} · ends in {daysRemaining} days on {format.asLongDate(new Date(position.deliverDate))}</li>
-   )
-}
+const asAmount = value => value ? asAssetAmount(value) : '—'
 
 export default function CurrentPositions({ data }) {
 
+   const total = data.balance.reduce((sum, asset) => sum + (asset.fiatValue ?? 0), 0)
+
    return (
-      <div className="space-y-6">
-         {data.balance.map(({ asset, free, locked, staking, total, fiatValue }) => (
-            <div key={asset}>
-
-               <div className="flex py-1 px-2 border-y border-border">
-                  <span className="w-[4%] font-bold">{asset}</span>
-                  <LabeledValue className="w-[12%]" label="spot" value={format.asDecimal(free)} />
-                  <LabeledValue className="w-[12%]" label="staking" value={format.asDecimal(staking?.balance)} />
-                  <LabeledValue className="w-[12%]" label="locked" value={format.asDecimal(locked)} />
-                  <LabeledValue className="w-[12%]" label="total" value={format.asDecimal(total)} />
-                  <span className="grow"></span>
-                  <LabeledValue value={format.asDollarAmount(fiatValue)} />
-               </div>
-
-               {staking.products.length != 0 && (
-                  <div className="py-1 px-2">
-                     <ul className="space-y-2">
-                        {staking.products.map(product => <Product key={product.info.productId} product={product} spot={Big(free)} />)}
-                     </ul>
-                  </div>
+      <div className="overflow-x-auto">
+         <Table>
+            <TableHeader>
+               <TableRow>
+                  <TableHead>Asset</TableHead>
+                  <TableHead className="text-right">Spot</TableHead>
+                  <TableHead className="text-right">Staking</TableHead>
+                  <TableHead className="text-right">Locked</TableHead>
+                  <TableHead className="text-right">Total</TableHead>
+                  <TableHead className="text-right">Value</TableHead>
+               </TableRow>
+            </TableHeader>
+            <TableBody>
+               {data.balance.map(({ asset, free, locked, staking, total: assetTotal, fiatValue }) =>
+                  <TableRow key={asset}>
+                     <TableCell className="font-medium">{asset}</TableCell>
+                     <TableCell className="text-right tabular-nums">{asAmount(free)}</TableCell>
+                     <TableCell className="text-right tabular-nums">{asAmount(staking?.balance)}</TableCell>
+                     <TableCell className="text-right tabular-nums">{asAmount(locked)}</TableCell>
+                     <TableCell className="text-right tabular-nums">{asAmount(assetTotal)}</TableCell>
+                     <TableCell className="text-right tabular-nums">{asDollarAmount(fiatValue)}</TableCell>
+                  </TableRow>
                )}
-            </div>
-         ))}
+            </TableBody>
+            <TableFooter>
+               <TableRow>
+                  <TableCell colSpan={5}>Total</TableCell>
+                  <TableCell className="text-right tabular-nums">{asDollarAmount(total)}</TableCell>
+               </TableRow>
+            </TableFooter>
+         </Table>
       </div>
    )
 }

--- a/src/views/components/binance/next-redemptions.jsx
+++ b/src/views/components/binance/next-redemptions.jsx
@@ -1,35 +1,40 @@
-import * as format from '../../../utils/format'
-import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell, TableCaption } from '@/components/ui/table'
+import { asAssetAmount, asPercentage, asLongDate } from '../../../utils/format'
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
 
 
 export default function NextRedemptions({ data }) {
 
-   const positions = data.balance.flatMap(b => b.staking.positions)
+   const positions = data.balance.flatMap(asset => asset.staking.positions)
    positions.sort((p, q) => p.deliverDate - q.deliverDate)
 
+   if (positions.length === 0) {
+      return <p className="text-sm text-muted-foreground">No staking positions are currently open.</p>
+   }
+
    return (
-      <div className="w-1/3 h-32 overflow-auto">
-         <Table className="w-full">
-            <TableCaption className="caption-top mt-0 mb-2">Next redemptions</TableCaption>
+      <div className="overflow-x-auto">
+         <Table>
             <TableHeader>
                <TableRow>
-                  <TableHead className="text-left">Asset</TableHead>
+                  <TableHead>Asset</TableHead>
                   <TableHead className="text-right">Amount</TableHead>
                   <TableHead className="text-right">APY</TableHead>
-                  <TableHead className="text-right">Duration</TableHead>
+                  <TableHead className="text-right">Progress</TableHead>
                   <TableHead className="text-right">Redemption date</TableHead>
                </TableRow>
             </TableHeader>
             <TableBody>
-               {positions.map(position => (
+               {positions.map(position =>
                   <TableRow key={position.id}>
-                     <TableCell className="text-left">{position.asset}</TableCell>
-                     <TableCell className="text-right">{format.asDecimal(position.amount)}</TableCell>
-                     <TableCell className="text-right">{format.asPercentage(position.apy)}</TableCell>
-                     <TableCell className="text-right">{position.accrualDays} of {position.duration}</TableCell>
-                     <TableCell className="text-right">{format.asLongDate(position.endDate)}</TableCell>
+                     <TableCell className="font-medium">{position.asset}</TableCell>
+                     <TableCell className="text-right tabular-nums">{asAssetAmount(position.amount)}</TableCell>
+                     <TableCell className="text-right tabular-nums">{asPercentage(position.apy)}</TableCell>
+                     <TableCell className="text-right tabular-nums">
+                        {position.accrualDays} of {position.duration} days
+                     </TableCell>
+                     <TableCell className="text-right tabular-nums">{asLongDate(position.endDate)}</TableCell>
                   </TableRow>
-               ))}
+               )}
             </TableBody>
          </Table>
       </div>

--- a/src/views/components/binance/staking-products.jsx
+++ b/src/views/components/binance/staking-products.jsx
@@ -1,0 +1,91 @@
+import Big from 'big.js'
+import { asAssetAmount, asPercentage } from '../../../utils/format'
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
+import { Badge } from '@/components/ui/badge'
+
+export function availabilityOf({ soldOut, maxStakingAmount, positionsAmount, minStakingAmount, asset }, spot) {
+
+   const quota = Big(maxStakingAmount)
+   const remaining = quota.minus(positionsAmount)
+
+   if (remaining.eq(0)) {
+      return {
+         variant: 'destructive',
+         label: soldOut ? 'Sold out' : 'Quota reached',
+         detail: `your quota of ${asAssetAmount(quota.toNumber())} ${asset} is fully used`
+      }
+   }
+
+   if (remaining.lt(minStakingAmount)) {
+      return {
+         variant: 'destructive',
+         label: soldOut ? 'Sold out' : 'Quota too low',
+         detail: `${asAssetAmount(remaining.toNumber())} ${asset} left, below the ${asAssetAmount(Number(minStakingAmount))} ${asset} minimum`
+      }
+   }
+
+   if (soldOut) {
+      return { variant: 'destructive', label: 'Sold out' }
+   }
+
+   if (spot.gt(remaining)) {
+      return {
+         variant: 'secondary',
+         label: 'Limited',
+         detail: `only ${asAssetAmount(remaining.toNumber())} ${asset} of your quota left`
+      }
+   }
+
+   return { variant: 'default', label: 'Available' }
+}
+
+
+export default function StakingProducts({ data }) {
+
+   const rows = data.balance.flatMap(({ asset, free, staking }) =>
+      staking.products.map(product => ({
+         asset,
+         product,
+         held: product.positions.reduce((sum, position) => sum + position.amount, 0),
+         availability: availabilityOf(product.info, Big(free))
+      })))
+
+   if (rows.length === 0) {
+      return <p className="text-sm text-muted-foreground">No staking products offered for these assets.</p>
+   }
+
+   return (
+      <div className="overflow-x-auto">
+         <Table>
+            <TableHeader>
+               <TableRow>
+                  <TableHead>Asset</TableHead>
+                  <TableHead className="text-right">Duration</TableHead>
+                  <TableHead className="text-right">APY</TableHead>
+                  <TableHead className="text-right">Your position</TableHead>
+                  <TableHead>Availability</TableHead>
+               </TableRow>
+            </TableHeader>
+            <TableBody>
+               {rows.map(({ asset, product, held, availability }) =>
+                  <TableRow key={product.info.productId}>
+                     <TableCell className="font-medium">{asset}</TableCell>
+                     <TableCell className="text-right tabular-nums">{product.info.duration} days</TableCell>
+                     <TableCell className="text-right tabular-nums">{asPercentage(product.info.apy)}</TableCell>
+                     <TableCell className="text-right tabular-nums">
+                        {held > 0 ? asAssetAmount(held) : '—'}
+                     </TableCell>
+                     <TableCell>
+                        <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                           <Badge variant={availability.variant}>{availability.label}</Badge>
+                           {availability.detail &&
+                              <span className="text-xs text-muted-foreground">{availability.detail}</span>}
+                        </span>
+                     </TableCell>
+                  </TableRow>
+               )}
+            </TableBody>
+         </Table>
+      </div>
+   )
+}

--- a/src/views/components/kraken/xstock-section.jsx
+++ b/src/views/components/kraken/xstock-section.jsx
@@ -1,33 +1,24 @@
 import { Badge } from '@/components/ui/badge'
-import { Card, CardContent } from '@/components/ui/card'
 
-export default function Section({ title, items, icon }) {
+export default function Section({ title, items }) {
    return (
-      <div className="mb-8">
-         <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
-            <span>{icon}</span>
-            {title}
-            <span className="font-normal text-muted-foreground">({items.length})</span>
-         </h2>
+      <section className="space-y-3">
+         <h3 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+            {title} ({items.length})
+         </h3>
          <div className="space-y-3">
-            {items.map((item) => (
-               <Card key={item.name}>
-                  <CardContent className="p-4">
-                     <div className="flex items-center gap-2 mb-2">
-                        <span className="font-mono font-bold text-lg">
-                           {item.name}
-                        </span>
-                        <Badge variant="secondary">
-                           {item.type}
-                        </Badge>
-                     </div>
-                     <p className="text-muted-foreground leading-relaxed">
-                        {item.description}
-                     </p>
-                  </CardContent>
-               </Card>
-            ))}
+            {items.map(item =>
+               <div key={item.name} className="space-y-1.5 rounded-lg border border-border px-4 py-3">
+                  <div className="flex items-center gap-2">
+                     <span className="font-mono text-sm font-medium">{item.name}</span>
+                     <Badge variant="secondary">{item.type}</Badge>
+                  </div>
+                  <p className="text-sm leading-relaxed text-muted-foreground">
+                     {item.description}
+                  </p>
+               </div>
+            )}
          </div>
-      </div>
+      </section>
    )
 }

--- a/src/views/components/layout.jsx
+++ b/src/views/components/layout.jsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { Link } from 'react-router'
 import MenuLink from './lib/menu-link'
 import { Button } from '@/components/ui/button'
+import { Toaster } from '@/components/ui/sonner'
 import { groupHref } from '@/lib/tools'
 
 
@@ -46,6 +47,8 @@ export default function Layout({ children, name }) {
          <main className="w-full grow px-4 pt-5 pb-8 sm:px-6">
             {children}
          </main>
+
+         <Toaster />
 
       </div>
    )

--- a/src/views/components/lib/info-banner.jsx
+++ b/src/views/components/lib/info-banner.jsx
@@ -1,0 +1,10 @@
+import { InfoIcon } from 'lucide-react'
+
+export default function InfoBanner({ children }) {
+   return (
+      <div className="flex items-center gap-3 rounded-lg border border-blue-300/60 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-500/25 dark:bg-blue-950/30 dark:text-blue-100">
+         <InfoIcon className="size-5 shrink-0" />
+         <p>{children}</p>
+      </div>
+   )
+}

--- a/src/views/mocks/binance.js
+++ b/src/views/mocks/binance.js
@@ -92,6 +92,18 @@ const aggregateBalance = {
                   info: { productId: 'AVAX-30', asset: 'AVAX', duration: 30, apy: 0.0450, soldOut: true, maxStakingAmount: 5000, positionsAmount: 0, minStakingAmount: 5 },
                   positions: [],
                },
+               {
+                  info: { productId: 'AVAX-60', asset: 'AVAX', duration: 60, apy: 0.0510, soldOut: false, maxStakingAmount: 100, positionsAmount: 100, minStakingAmount: 5 },
+                  positions: [],
+               },
+               {
+                  info: { productId: 'AVAX-90', asset: 'AVAX', duration: 90, apy: 0.0560, soldOut: false, maxStakingAmount: 100, positionsAmount: 98, minStakingAmount: 5 },
+                  positions: [],
+               },
+               {
+                  info: { productId: 'AVAX-120', asset: 'AVAX', duration: 120, apy: 0.0605, soldOut: false, maxStakingAmount: 100, positionsAmount: 50, minStakingAmount: 5 },
+                  positions: [],
+               },
             ],
          },
          total: 85.5,

--- a/src/views/pages/binance/staking.jsx
+++ b/src/views/pages/binance/staking.jsx
@@ -1,51 +1,119 @@
+import { useState } from 'react'
+import { Link } from 'react-router'
 import useSWRMutation from 'swr/mutation'
+import { Loader2Icon, RefreshCwIcon } from 'lucide-react'
+import BinanceLayout from '../../components/binance/binance-layout'
+import InfoBanner from '../../components/lib/info-banner'
 import CurrentPositions from '../../components/binance/current-positions'
 import NextRedemptions from '../../components/binance/next-redemptions'
-import BinanceLayout from '../../components/binance/binance-layout'
+import StakingProducts from '../../components/binance/staking-products'
 import { Button } from '@/components/ui/button'
+import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Loader2Icon } from 'lucide-react'
 
 
 export default function BinanceStaking() {
 
-   const { data, error, isMutating, trigger: fetchAggregatedBalance } = useSWRMutation('/api/binance/aggregate-balance')
+   const { data, error, isMutating, trigger } = useSWRMutation('/api/binance/aggregate-balance')
 
-   const getCredentials = () => ({
-      apiKey: localStorage.getItem('binance.api.key') || '',
-      apiSecret: localStorage.getItem('binance.api.secret') || ''
-   })
+   const [credentials] = useState(() => ({
+      apiKey: (typeof window !== 'undefined' && localStorage.getItem('binance.api.key')) || '',
+      apiSecret: (typeof window !== 'undefined' && localStorage.getItem('binance.api.secret')) || ''
+   }))
 
-   const fetchDataButton = <Button size="sm" onClick={() => fetchAggregatedBalance({ credentials: getCredentials() })}>
-      Fetch data
-   </Button>
+   const fetchData = () => trigger({ credentials }).catch(() => {})
+
+   if (!credentials.apiKey || !credentials.apiSecret) {
+      return (
+         <BinanceLayout name="Staking">
+            <Alert>
+               <AlertDescription>
+                  Generate an API key and secret on Binance and add them in{' '}
+                  <Link to="/settings" className="font-medium text-foreground underline underline-offset-4">
+                     Settings
+                  </Link>{' '}
+                  to fetch your staking positions.
+               </AlertDescription>
+            </Alert>
+         </BinanceLayout>
+      )
+   }
+
+   const fetchButton = (
+      <Button size="sm" onClick={fetchData} disabled={isMutating}>
+         {isMutating
+            ? <Loader2Icon className="animate-spin" />
+            : <RefreshCwIcon />}
+         {data ? 'Refresh' : 'Fetch data'}
+      </Button>
+   )
 
    let content
-   if (error) {
-      content = <>
-         <Alert variant="destructive">
-            <AlertDescription>{error}</AlertDescription>
-         </Alert>
-         {fetchDataButton}
-      </>
-   }
-   else if (isMutating) {
-      content = <div className="flex items-center gap-2"><Loader2Icon className="size-4 animate-spin" /> Fetching data…</div>
+   if (isMutating && !data) {
+      content = (
+         <span className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2Icon className="size-4 animate-spin" />
+            Fetching from Binance…
+         </span>
+      )
    }
    else if (!data) {
-      content = fetchDataButton
+      content = (
+         <p className="text-sm text-muted-foreground">
+            Nothing fetched yet — select Fetch data to read your balances from Binance.
+         </p>
+      )
    }
    else {
-      content = <>
-         <NextRedemptions data={data} />
-         <CurrentPositions data={data} />
-      </>
+      content = <CurrentPositions data={data} />
    }
 
    return (
       <BinanceLayout name="Staking">
-         <div className="grow text-sm space-y-4 tabular-nums">
-            {content}
+         <div className="space-y-6">
+
+            <InfoBanner>
+               Your spot and staking balances, read live from Binance each time you ask for
+               them — unlike the Kraken pages there is no local database behind this one, so
+               nothing is shown until you fetch. Locked staking positions are listed with the
+               date each one is released and the products they were subscribed to.
+            </InfoBanner>
+
+            {error &&
+               <Alert variant="destructive">
+                  <AlertDescription>{error}</AlertDescription>
+               </Alert>}
+
+            <Card>
+               <CardHeader>
+                  <CardTitle>Holdings</CardTitle>
+                  <CardAction>{fetchButton}</CardAction>
+               </CardHeader>
+               <CardContent>
+                  {content}
+               </CardContent>
+            </Card>
+
+            {data &&
+               <Card>
+                  <CardHeader>
+                     <CardTitle>Next redemptions</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                     <NextRedemptions data={data} />
+                  </CardContent>
+               </Card>}
+
+            {data &&
+               <Card>
+                  <CardHeader>
+                     <CardTitle>Staking products</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                     <StakingProducts data={data} />
+                  </CardContent>
+               </Card>}
+
          </div>
       </BinanceLayout>
    )

--- a/src/views/pages/kraken/balances.jsx
+++ b/src/views/pages/kraken/balances.jsx
@@ -2,8 +2,8 @@ import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router'
 import useSWR, { useSWRConfig } from 'swr'
 import useSWRMutation from 'swr/mutation'
-import { InfoIcon } from 'lucide-react'
 import KrakenLayout from '../../components/kraken/kraken-layout'
+import InfoBanner from '../../components/lib/info-banner'
 import SyncStatusStrip from '../../components/kraken/sync-status-strip'
 import BalanceSummaryCard from '../../components/kraken/balance-summary-card'
 import BalancePlacementCard from '../../components/kraken/balance-placement-card'
@@ -94,17 +94,14 @@ export default function KrakenBalances() {
       <KrakenLayout name="Balances">
          <div className="space-y-6">
 
-            <div className="flex items-center gap-3 rounded-lg border border-blue-300/60 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-500/25 dark:bg-blue-950/30 dark:text-blue-100">
-               <InfoIcon className="size-5 shrink-0" />
-               <p>
-                  What you hold, rebuilt from the local database the Ledger tab fills, and
-                  grouped by <b>where each coin actually sits</b> — your spot wallet, or one
-                  of Kraken&apos;s Earn strategies. Coins left in spot that are still being
-                  paid are marked <b>Opt-In Rewards</b>, since they keep earning without
-                  leaving the wallet they can be traded from. Totals are checked against
-                  Kraken live, which also says how much an open order has already reserved.
-               </p>
-            </div>
+            <InfoBanner>
+               What you hold, rebuilt from the local database the Ledger tab fills, and
+               grouped by <b>where each coin actually sits</b> — your spot wallet, or one
+               of Kraken&apos;s Earn strategies. Coins left in spot that are still being
+               paid are marked <b>Opt-In Rewards</b>, since they keep earning without
+               leaving the wallet they can be traded from. Totals are checked against
+               Kraken live, which also says how much an open order has already reserved.
+            </InfoBanner>
 
             {error &&
                <Alert variant="destructive">

--- a/src/views/pages/kraken/closed-orders.jsx
+++ b/src/views/pages/kraken/closed-orders.jsx
@@ -1,8 +1,9 @@
 import { useRef, useState } from 'react'
 import { useSearchParams } from 'react-router'
 import useSWR, { useSWRConfig } from 'swr'
-import { InfoIcon, Loader2Icon } from 'lucide-react'
+import { Loader2Icon } from 'lucide-react'
 import KrakenLayout from '../../components/kraken/kraken-layout'
+import InfoBanner from '../../components/lib/info-banner'
 import SyncStatusStrip from '../../components/kraken/sync-status-strip'
 import OrderFilters, { defaultFilters } from '../../components/kraken/order-filters'
 import OrderTable from '../../components/kraken/order-table'
@@ -93,15 +94,12 @@ export default function KrakenClosedOrders() {
       <KrakenLayout name="Closed Orders">
          <div className="space-y-6">
 
-            <div className="flex items-center gap-3 rounded-lg border border-blue-300/60 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-500/25 dark:bg-blue-950/30 dark:text-blue-100">
-               <InfoIcon className="size-5 shrink-0" />
-               <p>
-                  Every order that filled, rebuilt from the trade history stored on this machine —
-                  an order filled in several trades is shown once, with its total volume and the
-                  average price it achieved. Nothing is fetched from Kraken here; sync on the Ledger
-                  page to bring it up to date.
-               </p>
-            </div>
+            <InfoBanner>
+               Every order that filled, rebuilt from the trade history stored on this machine —
+               an order filled in several trades is shown once, with its total volume and the
+               average price it achieved. Nothing is fetched from Kraken here; sync on the Ledger
+               page to bring it up to date.
+            </InfoBanner>
 
             <SyncStatusStrip
                state={status?.state}

--- a/src/views/pages/kraken/fees.jsx
+++ b/src/views/pages/kraken/fees.jsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
 import { Link } from 'react-router'
 import useSWR from 'swr'
-import { InfoIcon } from 'lucide-react'
 import KrakenLayout from '../../components/kraken/kraken-layout'
+import InfoBanner from '../../components/lib/info-banner'
 import FeeSummaryCard from '../../components/kraken/fee-summary-card'
 import FeeChartCard from '../../components/kraken/fee-chart-card'
 import FeeBreakdownCard from '../../components/kraken/fee-breakdown-card'
@@ -72,15 +72,12 @@ export default function KrakenFees() {
       <KrakenLayout name="Fees">
          <div className="space-y-6">
 
-            <div className="flex items-center gap-3 rounded-lg border border-blue-300/60 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-500/25 dark:bg-blue-950/30 dark:text-blue-100">
-               <InfoIcon className="size-5 shrink-0" />
-               <p>
-                  Everything Kraken has charged you since the account was opened — mostly trade
-                  fees, but also withdrawal fees and anything else the ledger records — read from
-                  the local database the Ledger tab fills. Fees are kept in the asset they were
-                  charged in and never converted, so each asset is totalled on its own.
-               </p>
-            </div>
+            <InfoBanner>
+               Everything Kraken has charged you since the account was opened — mostly trade
+               fees, but also withdrawal fees and anything else the ledger records — read from
+               the local database the Ledger tab fills. Fees are kept in the asset they were
+               charged in and never converted, so each asset is totalled on its own.
+            </InfoBanner>
 
             {error &&
                <Alert variant="destructive">

--- a/src/views/pages/kraken/ledger.jsx
+++ b/src/views/pages/kraken/ledger.jsx
@@ -1,8 +1,9 @@
 import { useRef, useState } from 'react'
 import useSWR, { useSWRConfig } from 'swr'
 import useSWRMutation from 'swr/mutation'
-import { InfoIcon, Loader2Icon, TriangleAlertIcon } from 'lucide-react'
+import { Loader2Icon, TriangleAlertIcon } from 'lucide-react'
 import KrakenLayout from '../../components/kraken/kraken-layout'
+import InfoBanner from '../../components/lib/info-banner'
 import LedgerSyncCard from '../../components/kraken/ledger-sync-card'
 import LedgerFilters, { defaultFilters } from '../../components/kraken/ledger-filters'
 import LedgerTable from '../../components/kraken/ledger-table'
@@ -171,15 +172,12 @@ export default function KrakenLedger() {
       <KrakenLayout name="Ledger">
          <div className="space-y-6">
 
-            <div className="flex items-center gap-3 rounded-lg border border-blue-300/60 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-500/25 dark:bg-blue-950/30 dark:text-blue-100">
-               <InfoIcon className="size-5 shrink-0" />
-               <p>
-                  Downloads two exports from Kraken — your complete ledger and your trade history —
-                  and keeps both in a database on this machine, so the other tools can use them
-                  without querying the API again. Kraken prepares each export in the background, so
-                  a first sync can take several minutes. Nothing is uploaded anywhere.
-               </p>
-            </div>
+            <InfoBanner>
+               Downloads two exports from Kraken — your complete ledger and your trade history —
+               and keeps both in a database on this machine, so the other tools can use them
+               without querying the API again. Kraken prepares each export in the background, so
+               a first sync can take several minutes. Nothing is uploaded anywhere.
+            </InfoBanner>
 
             {wasInterrupted &&
                <Alert>

--- a/src/views/pages/kraken/order-batch.jsx
+++ b/src/views/pages/kraken/order-batch.jsx
@@ -2,8 +2,9 @@ import { useState, useEffect } from 'react'
 import useSWR from 'swr'
 import useSWRMutation from 'swr/mutation'
 import Big from 'big.js'
-import { Loader2Icon, InfoIcon } from 'lucide-react'
+import { Loader2Icon } from 'lucide-react'
 import KrakenLayout from '../../components/kraken/kraken-layout'
+import InfoBanner from '../../components/lib/info-banner'
 import ExternalLink from '../../components/lib/external-link'
 import OrderBatchForm from '../../components/kraken/order-batch-params'
 import OrderBatchTable from '../../components/kraken/order-batch-table'
@@ -152,15 +153,12 @@ export default function KrakenOrderBatch() {
    return (
       <KrakenLayout name="Order Batch">
          <div className="space-y-6">
-            <div className="flex items-center gap-3 rounded-lg border border-blue-300/60 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-500/25 dark:bg-blue-950/30 dark:text-blue-100">
-               <InfoIcon className="size-5 shrink-0" />
-               <p>
-                  Create multiple limit orders for a trading pair in one go — for example a ladder of
-                  buy orders below the current price, or sell orders above it. Orders are {postLimitOrders} and
-                  the quote currency is used for fees. Depending on your verification level Kraken allows
-                  between {maxOpenOrders} across all pairs. Orders are sent in batches of 15 (Kraken API limit).
-               </p>
-            </div>
+            <InfoBanner>
+               Create multiple limit orders for a trading pair in one go — for example a ladder of
+               buy orders below the current price, or sell orders above it. Orders are {postLimitOrders} and
+               the quote currency is used for fees. Depending on your verification level Kraken allows
+               between {maxOpenOrders} across all pairs. Orders are sent in batches of 15 (Kraken API limit).
+            </InfoBanner>
 
             <Card size="sm">
                <CardHeader>

--- a/src/views/pages/kraken/rewards.jsx
+++ b/src/views/pages/kraken/rewards.jsx
@@ -1,8 +1,8 @@
 import { useRef, useState } from 'react'
 import { Link } from 'react-router'
 import useSWR, { useSWRConfig } from 'swr'
-import { InfoIcon } from 'lucide-react'
 import KrakenLayout from '../../components/kraken/kraken-layout'
+import InfoBanner from '../../components/lib/info-banner'
 import SyncStatusStrip from '../../components/kraken/sync-status-strip'
 import RewardSummaryCard from '../../components/kraken/reward-summary-card'
 import RewardChartCard from '../../components/kraken/reward-chart-card'
@@ -68,15 +68,12 @@ export default function KrakenRewards() {
       <KrakenLayout name="Rewards">
          <div className="space-y-6">
 
-            <div className="flex items-center gap-3 rounded-lg border border-blue-300/60 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-500/25 dark:bg-blue-950/30 dark:text-blue-100">
-               <InfoIcon className="size-5 shrink-0" />
-               <p>
-                  Everything Kraken has paid you for staking and earning, per asset and per
-                  year, read from the local database the Ledger tab fills. Moving coins in and
-                  out of an earn position is not income and is left out. Each amount is valued
-                  at today&apos;s market price, so the USD figures move with the market.
-               </p>
-            </div>
+            <InfoBanner>
+               Everything Kraken has paid you for staking and earning, per asset and per
+               year, read from the local database the Ledger tab fills. Moving coins in and
+               out of an earn position is not income and is left out. Each amount is valued
+               at today&apos;s market price, so the USD figures move with the market.
+            </InfoBanner>
 
             {error &&
                <Alert variant="destructive">

--- a/src/views/pages/kraken/xstocks.jsx
+++ b/src/views/pages/kraken/xstocks.jsx
@@ -1,73 +1,135 @@
 import { useState } from 'react'
+import { Link } from 'react-router'
 import useSWRMutation from 'swr/mutation'
+import { Loader2Icon } from 'lucide-react'
 import KrakenLayout from '../../components/kraken/kraken-layout'
+import InfoBanner from '../../components/lib/info-banner'
 import Section from '../../components/kraken/xstock-section'
 import Checkbox from '../../components/lib/checkbox'
-import Input from '../../components/lib/input'
+import NumericInput from '../../components/lib/numeric-input'
+import { asCount } from '../../components/lib/filter-options'
 import { Button } from '@/components/ui/button'
+import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Loader2Icon } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
 
 
-export default function KrakenETFs() {
+export default function KrakenXStocks() {
 
    const { data, error, trigger, isMutating } = useSWRMutation('/api/kraken/xstocks')
 
-   const [credentials, setCredentials] = useState(() => ({
+   const [credentials] = useState(() => ({
       apiKey: (typeof window !== 'undefined' && localStorage.getItem('anthropic.api.key')) || ''
    }))
+
+   const [etfWordCount, setEtfWordCount] = useState('60')
 
    const fetchData = event => {
       event.preventDefault()
       const formData = new FormData(event.target)
       const excludeStocks = formData.get('excludeStocks') === 'on'
-      const etfWordCount = parseInt(formData.get('etfWordCount'))
-      trigger({ credentials, excludeStocks, etfWordCount })
+      trigger({ credentials, excludeStocks, etfWordCount: parseInt(etfWordCount) }).catch(() => {})
    }
 
    if (!credentials.apiKey) {
       return (
          <KrakenLayout name="xStocks">
-            <div className="text-sm text-muted-foreground">
-               An Anthropic API key is required.
-            </div>
+            <Alert>
+               <AlertDescription>
+                  Add an Anthropic API key in{' '}
+                  <Link to="/settings" className="font-medium text-foreground underline underline-offset-4">
+                     Settings
+                  </Link>{' '}
+                  to generate these summaries.
+               </AlertDescription>
+            </Alert>
          </KrakenLayout>
       )
    }
+
+   const etfs = (data?.output ?? []).filter(item => item.type === 'etf')
+   const stocks = (data?.output ?? []).filter(item => item.type === 'stock')
 
    let resultContent
    if (error) {
       resultContent = <Alert variant="destructive"><AlertDescription>{error}</AlertDescription></Alert>
    }
    else if (isMutating) {
-      resultContent = <div className="flex items-center gap-2"><Loader2Icon className="size-4 animate-spin" /> Fetching data…</div>
-   }
-   else if (data) {
-      const etfs = data.output.filter(item => item.type === 'etf')
-      const stocks = data.output.filter(item => item.type === 'stock')
-      console.log(data.usage)
       resultContent = (
-         <>
-            {etfs.length > 0 && <Section title="Exchange-Traded Funds" items={etfs} icon="📊" />}
-            {stocks.length > 0 && <Section title="Stocks" items={stocks} icon="📈" />}
-            {data.output.length === 0 && <div>No data available</div>}
-         </>
+         <span className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2Icon className="size-4 animate-spin" />
+            Asking Claude…
+         </span>
+      )
+   }
+   else if (!data) {
+      resultContent = (
+         <p className="text-sm text-muted-foreground">
+            Nothing fetched yet — set the options above and select Fetch data.
+         </p>
+      )
+   }
+   else if (data.output.length === 0) {
+      resultContent = <p className="text-sm text-muted-foreground">No tokenized stocks or ETFs were returned.</p>
+   }
+   else {
+      resultContent = (
+         <div className="space-y-6">
+            {etfs.length > 0 && <Section title="Exchange-Traded Funds" items={etfs} />}
+            {stocks.length > 0 && <Section title="Stocks" items={stocks} />}
+         </div>
       )
    }
 
    return (
       <KrakenLayout name="xStocks">
-         <div className="grow text-sm space-y-6 tabular-nums max-w-5xl">
-            <form onSubmit={fetchData}>
-               <div className="flex items-end gap-4">
-                  <Input name="etfWordCount" type="number" label="ETF description word count" defaultValue="60" />
-                  <Checkbox name="excludeStocks" label="Exclude stocks (ETFs only)" className="self-start" />
-                  <Button type="submit" size="sm">
-                     Fetch data
-                  </Button>
-               </div>
-            </form>
-            {resultContent}
+         <div className="space-y-6">
+
+            <InfoBanner>
+               Kraken&apos;s tokenized stocks and ETFs, each with a short summary written by Claude
+               from its own knowledge rather than from Kraken&apos;s listing text. Fetching sends a
+               request billed to your Anthropic account, so the list is only built when you ask for
+               it. The summaries are descriptive and are not investment advice.
+            </InfoBanner>
+
+            <Card size="sm">
+               <CardHeader>
+                  <CardTitle>Parameters</CardTitle>
+               </CardHeader>
+               <CardContent>
+                  <form onSubmit={fetchData} className="space-y-4">
+                     <div className="grid grid-cols-2 items-end gap-x-4 gap-y-3 md:grid-cols-3 lg:grid-cols-4">
+                        <NumericInput
+                           name="etfWordCount"
+                           label="ETF description word count"
+                           value={etfWordCount}
+                           onChange={(e) => setEtfWordCount(e.target.value)} />
+                        <Checkbox
+                           name="excludeStocks"
+                           className="h-9"
+                           label="Exclude stocks (ETFs only)" />
+                     </div>
+                     <Button type="submit" size="sm" disabled={isMutating}>
+                        Fetch data
+                     </Button>
+                  </form>
+               </CardContent>
+            </Card>
+
+            <Card>
+               <CardHeader>
+                  <CardTitle>Listings</CardTitle>
+                  <CardAction>
+                     {isMutating
+                        ? <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
+                        : data && <Badge variant="outline">{asCount(data.output.length, 'listing')}</Badge>}
+                  </CardAction>
+               </CardHeader>
+               <CardContent>
+                  {resultContent}
+               </CardContent>
+            </Card>
+
          </div>
       </KrakenLayout>
    )

--- a/src/views/pages/settings.jsx
+++ b/src/views/pages/settings.jsx
@@ -1,68 +1,105 @@
 import { useState } from 'react'
+import { toast } from 'sonner'
 import Input from '../components/lib/input'
+import InfoBanner from '../components/lib/info-banner'
 import Layout from '../components/layout'
 import { Button } from '@/components/ui/button'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
 
+const providers = [
+   {
+      id: 'binance',
+      name: 'Binance',
+      description: 'Reads your staking positions and balances. Read-only permissions are enough.',
+      hasSecret: true,
+      envKey: import.meta.env.VITE_BINANCE_API_KEY,
+      envSecret: import.meta.env.VITE_BINANCE_API_SECRET
+   },
+   {
+      id: 'kraken',
+      name: 'Kraken',
+      description: 'Syncs your ledger and trade history, and creates orders. The secret is only sent for private calls.',
+      hasSecret: true,
+      envKey: import.meta.env.VITE_KRAKEN_API_KEY,
+      envSecret: import.meta.env.VITE_KRAKEN_API_SECRET
+   },
+   {
+      id: 'anthropic',
+      name: 'Anthropic',
+      description: 'Writes the xStocks summaries. Usage is billed to your own Anthropic account.',
+      hasSecret: false,
+      envKey: import.meta.env.VITE_ANTHROPIC_API_KEY
+   }
+]
 
-export default function Settings() {
-
-   const [apiKeys, setApiKeys] = useState(() => ({
-      binance: {
-         apiKey: (typeof window !== 'undefined' && localStorage.getItem('binance.api.key')) || import.meta.env.VITE_BINANCE_API_KEY || '',
-         apiSecret: (typeof window !== 'undefined' && localStorage.getItem('binance.api.secret')) || import.meta.env.VITE_BINANCE_API_SECRET || ''
-      },
-      kraken: {
-         apiKey: (typeof window !== 'undefined' && localStorage.getItem('kraken.api.key')) || import.meta.env.VITE_KRAKEN_API_KEY || '',
-         apiSecret: (typeof window !== 'undefined' && localStorage.getItem('kraken.api.secret')) || import.meta.env.VITE_KRAKEN_API_SECRET || ''
-      },
-      anthropic: {
-         apiKey: (typeof window !== 'undefined' && localStorage.getItem('anthropic.api.key')) || import.meta.env.VITE_ANTHROPIC_API_KEY || ''
-      }
-   }))
-
-   return (
-      <Layout name="Settings">
-         <div className="grow p-3 space-y-4 text-sm">
-            <h2 className="text-base font-semibold">API Keys</h2>
-
-            <h3>Binance</h3>
-            <form method="post" onSubmit={event => saveApiKeys(event, 'binance')}>
-               <div className="flex items-end gap-x-3">
-                  <Input className="grow" name="binance-api-key" label="API Key" defaultValue={apiKeys.binance.apiKey} />
-                  <Input className="grow" name="binance-api-secret" label="API Secret" defaultValue={apiKeys.binance.apiSecret} type="password" />
-                  <Button type="submit" size="sm">Save</Button>
-               </div>
-            </form>
-
-            <h3>Kraken</h3>
-            <form method="post" onSubmit={event => saveApiKeys(event, 'kraken')}>
-               <div className="flex items-end gap-x-3">
-                  <Input className="grow" name="kraken-api-key" label="API Key" defaultValue={apiKeys.kraken.apiKey} />
-                  <Input className="grow" name="kraken-api-secret" label="API Secret" defaultValue={apiKeys.kraken.apiSecret} type="password" />
-                  <Button type="submit" size="sm">Save</Button>
-               </div>
-            </form>
-
-            <h3>Anthropic</h3>
-            <form method="post" onSubmit={event => saveApiKeys(event, 'anthropic')}>
-               <div className="flex items-end gap-x-3">
-                  <Input className="grow" name="anthropic-api-key" label="API Key" defaultValue={apiKeys.anthropic.apiKey} />
-                  <Button type="submit" size="sm">Save</Button>
-               </div>
-            </form>
-         </div>
-      </Layout>
-   )
-}
+const storedCredentials = provider => ({
+   apiKey: (typeof window !== 'undefined' && localStorage.getItem(`${provider.id}.api.key`))
+      || provider.envKey
+      || '',
+   apiSecret: provider.hasSecret
+      ? (typeof window !== 'undefined' && localStorage.getItem(`${provider.id}.api.secret`))
+         || provider.envSecret
+         || ''
+      : ''
+})
 
 const saveApiKeys = (event, provider) => {
    event.preventDefault()
 
    const formData = new FormData(event.target)
-   localStorage.setItem(`${provider}.api.key`, formData.get(`${provider}-api-key`))
-   localStorage.setItem(`${provider}.api.secret`, formData.get(`${provider}-api-secret`))
+   localStorage.setItem(`${provider.id}.api.key`, formData.get(`${provider.id}-api-key`))
 
-   const button = event.target.getElementsByTagName('button')[0]
-   button.textContent = 'Saved!'
-   setTimeout(() => button.textContent = 'Save', 1500)
+   if (provider.hasSecret) {
+      localStorage.setItem(`${provider.id}.api.secret`, formData.get(`${provider.id}-api-secret`))
+   }
+
+   toast.success(`${provider.name} API key saved`)
+}
+
+
+export default function Settings() {
+
+   const [credentials] = useState(() =>
+      Object.fromEntries(providers.map(provider => [provider.id, storedCredentials(provider)])))
+
+   return (
+      <Layout name="Settings">
+         <div className="space-y-6">
+
+            <InfoBanner>
+               The keys the other pages use to reach each exchange. They are kept in this
+               browser&apos;s local storage on this machine, never uploaded anywhere, and sent to
+               the local server only to sign the calls a page makes on your behalf. Removing a key
+               here is enough to cut a page off from its exchange.
+            </InfoBanner>
+
+            {providers.map(provider =>
+               <Card key={provider.id} size="sm">
+                  <CardHeader>
+                     <CardTitle>{provider.name}</CardTitle>
+                     <CardDescription>{provider.description}</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                     <form method="post" onSubmit={event => saveApiKeys(event, provider)} className="space-y-4">
+                        <div className="grid gap-x-4 gap-y-3 sm:grid-cols-2">
+                           <Input
+                              name={`${provider.id}-api-key`}
+                              label="API Key"
+                              defaultValue={credentials[provider.id].apiKey} />
+                           {provider.hasSecret &&
+                              <Input
+                                 name={`${provider.id}-api-secret`}
+                                 label="API Secret"
+                                 type="password"
+                                 defaultValue={credentials[provider.id].apiSecret} />}
+                        </div>
+                        <Button type="submit" size="sm">Save</Button>
+                     </form>
+                  </CardContent>
+               </Card>
+            )}
+
+         </div>
+      </Layout>
+   )
 }


### PR DESCRIPTION
Some PRs ago a common page design started being adopted, from the Ledger page (#205) onwards. Six of the ten routed pages had picked it up; this finishes the remaining three.

## Coverage before this PR

Grepping for the info banner is the sharpest marker of a converted page, and it returned exactly six: Ledger (#205), Fees (#206), Closed Orders (#207), Rewards (#209), Balances (#212) and Order Batch. Left over were **Settings**, **xStocks** and **Binance Staking**.

Home is deliberately untouched. It has no banner and uses `space-y-10` rather than `space-y-6`, which makes it look unconverted, but it is built from Card/CardDescription/Alert with semantic tokens — the same system applied to a landing page.

## What changed

**Shared `InfoBanner`.** The banner's class string was copy-pasted verbatim in all six converted pages and was about to go into three more. It now lives in one component. The six existing pages are migrated in a separate commit so the interesting diff stays readable; that commit is mechanical, with prose and the interpolated links in Order Batch and Balances unchanged.

**Settings.** A Card per provider driven by a `providers` array instead of three near-identical hand-written forms.

**xStocks.** Alert credential gate instead of bare text, Card-wrapped form and results with a count badge, and `xstock-section` no longer nests Cards inside a Card.

**Binance Staking.** The deepest change. Holdings were a flex row of hardcoded percentage widths (`w-[4%]`, `w-[12%]`…) and each staking product's availability was red, green or orange text — meaning carried in colour alone. Holdings are now a real table; availability is a Badge with the binding constraint spelled out beside it. The asset → product → position nesting flattens into two flat tables: the position detail that dropped was already shown by Next Redemptions, which itself loses the fixed `w-1/3 h-32` box that was clipping it.

## Fixes picked up along the way

- `saveApiKeys` wrote `` `${provider}.api.secret` `` unconditionally, but the Anthropic form has no secret field — so the literal string `"null"` was being stored under `anthropic.api.secret`.
- Save feedback mutated `button.textContent` and is now a toast. This needed `Toaster` mounted in `layout.jsx`: `sonner` was already a dependency with a token-styled Toaster component that was mounted nowhere, so **every `toast()` call in the app was a silent no-op**.
- Stray `console.log(data.usage)` in the xStocks render path.

## Note for review

The plan I worked from called `lib/input` and `lib/checkbox` legacy and said to replace them with `ui/input` + `ui/label`. That was wrong: `balance-filters.jsx` from the most recent redesign (#212) uses both, so Settings and xStocks build on them instead — hand-rolling would have been less consistent, not more. Only `lib/select.jsx` is genuinely dead (nothing imports it); it is left in place here.

They do carry a different label style from `numeric-input`/`select-field`/`combobox-field` (`space-y-1.5` + default Label vs `space-y-1` + `pl-2.5 text-xs`), which is visible where a filter bar mixes them. Aligning that would change already-shipped Kraken pages, so it is left out of this PR.

## Verification

`bun run lint` and `bun run build` clean. All eight Kraken/Binance pages plus Settings walked in mock mode with no console errors, in light and dark mode. The five availability Badge states were confirmed to resolve to dark-mode tokens rather than light-only colours.

The Binance mocks only reached the available and sold-out branches, leaving three of five states unverifiable, so AVAX gains products covering quota reached, quota too low and limited.

One thing that surfaced only in the browser: zeros in the holdings table rendered as `0.00000000`, because `asAssetAmount` scales precision to magnitude. They now use the `—` idiom from `balance-table`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
