### PR TITLE
fix(format): render dates in the user's locale, drop unused next-themes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,6 @@
         "hono": "4.12.34",
         "lucide-react": "1.27.0",
         "modern-dijkstra": "1.1.2",
-        "next-themes": "0.4.6",
         "qs": "6.15.3",
         "radix-ui": "1.6.7",
         "react": "19.2.8",
@@ -885,8 +884,6 @@
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
-
-    "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
     "node-releases": ["node-releases@2.0.51", "", {}, "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ=="],
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
       "hono": "4.12.34",
       "lucide-react": "1.27.0",
       "modern-dijkstra": "1.1.2",
-      "next-themes": "0.4.6",
       "qs": "6.15.3",
       "radix-ui": "1.6.7",
       "react": "19.2.8",

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,5 +1,4 @@
-// const locales = typeof navigator !== 'undefined' ? navigator.language : 'en-GB'
-const locales = 'en-GB'
+const locales = undefined
 
 const shortDateFormatter = new Intl.DateTimeFormat(locales, { month: 'short', day: 'numeric' })
 const longDateFormatter = new Intl.DateTimeFormat(locales, { year: 'numeric', month: 'short', day: 'numeric' })

--- a/src/views/components/kraken/balance-summary-card.jsx
+++ b/src/views/components/kraken/balance-summary-card.jsx
@@ -74,7 +74,7 @@ export default function BalanceSummaryCard({ balances, rates, live, liveError, i
                      ? <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
                      : rates ? asDollarAmount(totalValue) : '—'}
                </Field>
-               <Field label="Assets held">{assets.length.toLocaleString('en-GB')}</Field>
+               <Field label="Assets held">{assets.length.toLocaleString()}</Field>
                <Field label="Earning">
                   {isLoadingRates
                      ? <Loader2Icon className="size-4 animate-spin text-muted-foreground" />

--- a/src/views/components/kraken/fee-breakdown-card.jsx
+++ b/src/views/components/kraken/fee-breakdown-card.jsx
@@ -53,7 +53,7 @@ export default function FeeBreakdownCard({ fees, colors, asset }) {
                                  {asAssetAmount(row.total)}
                               </TableCell>
                               <TableCell className="text-right text-muted-foreground">
-                                 {row.entries.toLocaleString('en-GB')}
+                                 {row.entries.toLocaleString()}
                               </TableCell>
                               <TableCell className="text-right text-muted-foreground">
                                  {assetTotals.get(row.asset)

--- a/src/views/components/kraken/fee-chart-card.jsx
+++ b/src/views/components/kraken/fee-chart-card.jsx
@@ -17,8 +17,8 @@ const granularities = [
 const asAxisTick = (value) => {
    const magnitude = Math.abs(value)
    if (magnitude === 0) return '0'
-   if (magnitude >= 1000) return value.toLocaleString('en-GB', { notation: 'compact', maximumFractionDigits: 1 })
-   if (magnitude >= 1) return value.toLocaleString('en-GB', { maximumFractionDigits: 1 })
+   if (magnitude >= 1000) return value.toLocaleString(undefined, { notation: 'compact', maximumFractionDigits: 1 })
+   if (magnitude >= 1) return value.toLocaleString(undefined, { maximumFractionDigits: 1 })
    return Number(value.toPrecision(2)).toString()
 }
 

--- a/src/views/components/kraken/fee-summary-card.jsx
+++ b/src/views/components/kraken/fee-summary-card.jsx
@@ -19,7 +19,7 @@ export default function FeeSummaryCard({ fees, filters, filtersKey, options, isL
             <CardAction>
                {isLoading
                   ? <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
-                  : <Badge variant="outline">{entries.toLocaleString('en-GB')} charged</Badge>}
+                  : <Badge variant="outline">{entries.toLocaleString()} charged</Badge>}
             </CardAction>
          </CardHeader>
          <CardContent className="space-y-4">
@@ -33,8 +33,8 @@ export default function FeeSummaryCard({ fees, filters, filtersKey, options, isL
                showSearch={false} />
 
             <div className="grid grid-cols-2 gap-x-6 gap-y-3 border-t border-border pt-4 md:grid-cols-4">
-               <Field label="Assets charged in">{assets.length.toLocaleString('en-GB')}</Field>
-               <Field label="Fees charged">{entries.toLocaleString('en-GB')}</Field>
+               <Field label="Assets charged in">{assets.length.toLocaleString()}</Field>
+               <Field label="Fees charged">{entries.toLocaleString()}</Field>
                <Field label="First fee">{fees?.first ? asLongDate(fees.first) : '—'}</Field>
                <Field label="Last fee">{fees?.last ? asLongDate(fees.last) : '—'}</Field>
             </div>
@@ -63,7 +63,7 @@ export default function FeeSummaryCard({ fees, filters, filtersKey, options, isL
                                  {asAssetAmount(asset.total)}
                               </TableCell>
                               <TableCell className="text-right text-muted-foreground">
-                                 {asset.entries.toLocaleString('en-GB')}
+                                 {asset.entries.toLocaleString()}
                               </TableCell>
                               <TableCell className="text-right text-muted-foreground">
                                  {asPercentage(asset.entries / entries)}

--- a/src/views/components/kraken/ledger-sync-card.jsx
+++ b/src/views/components/kraken/ledger-sync-card.jsx
@@ -123,7 +123,7 @@ export default function LedgerSyncCard({ state, job, isRunning, error, isStartin
                <p className="text-xs text-muted-foreground">
                   Entries from other API keys are also stored:{' '}
                   {state.otherAccounts.map(account =>
-                     `${account.apiKeyPrefix || 'unknown'}… (${account.entryCount.toLocaleString('en-GB')})`
+                     `${account.apiKeyPrefix || 'unknown'}… (${account.entryCount.toLocaleString()})`
                   ).join(', ')}.
                </p>}
 

--- a/src/views/components/kraken/ledger-table.jsx
+++ b/src/views/components/kraken/ledger-table.jsx
@@ -104,8 +104,8 @@ export default function LedgerTable({ entries, sort, onSortChange, onPageChange,
 
          <div className="flex items-center justify-between">
             <p className="text-sm text-muted-foreground">
-               Showing {firstRow.toLocaleString('en-GB')}–{lastRow.toLocaleString('en-GB')} of{' '}
-               {total.toLocaleString('en-GB')}
+               Showing {firstRow.toLocaleString()}–{lastRow.toLocaleString()} of{' '}
+               {total.toLocaleString()}
             </p>
             <div className="flex items-center gap-1">
                <Button

--- a/src/views/components/kraken/order-table.jsx
+++ b/src/views/components/kraken/order-table.jsx
@@ -120,8 +120,8 @@ export default function OrderTable({ orders, isFiltered, hasTrades, sort, onSort
 
          <div className="flex items-center justify-between">
             <p className="text-sm text-muted-foreground">
-               Showing {firstRow.toLocaleString('en-GB')}–{lastRow.toLocaleString('en-GB')} of{' '}
-               {total.toLocaleString('en-GB')}
+               Showing {firstRow.toLocaleString()}–{lastRow.toLocaleString()} of{' '}
+               {total.toLocaleString()}
             </p>
             <div className="flex items-center gap-1">
                <Button

--- a/src/views/components/kraken/reward-history-card.jsx
+++ b/src/views/components/kraken/reward-history-card.jsx
@@ -12,8 +12,8 @@ const EVERYTHING = 'ALL'
 const asAxisTick = (value) => {
    const magnitude = Math.abs(value)
    if (magnitude === 0) return '0'
-   if (magnitude >= 1000) return value.toLocaleString('en-GB', { notation: 'compact', maximumFractionDigits: 1 })
-   if (magnitude >= 1) return value.toLocaleString('en-GB', { maximumFractionDigits: 1 })
+   if (magnitude >= 1000) return value.toLocaleString(undefined, { notation: 'compact', maximumFractionDigits: 1 })
+   if (magnitude >= 1) return value.toLocaleString(undefined, { maximumFractionDigits: 1 })
    return Number(value.toPrecision(2)).toString()
 }
 

--- a/src/views/components/kraken/reward-summary-card.jsx
+++ b/src/views/components/kraken/reward-summary-card.jsx
@@ -28,7 +28,7 @@ export default function RewardSummaryCard({ rewards, rates, isLoading, isLoading
             {/* Two columns rather than four: the card sits beside the charts, and the
                 stats read better stacked in a narrow column than squeezed into one row. */}
             <div className="grid grid-cols-2 gap-x-6 gap-y-6">
-               <Field label="Assets rewarded">{assets.length.toLocaleString('en-GB')}</Field>
+               <Field label="Assets rewarded">{assets.length.toLocaleString()}</Field>
                <Field
                   label="Worth today"
                   title={valued.length < assets.length

--- a/src/views/components/kraken/sync-steps.jsx
+++ b/src/views/components/kraken/sync-steps.jsx
@@ -2,7 +2,7 @@ import { CheckIcon, CircleIcon, Loader2Icon, MinusIcon, XIcon } from 'lucide-rea
 import { cn } from '@/lib/utils'
 import { isStepRunning, reportLabels, stepLabel } from './sync-status'
 
-const asCount = value => (value ?? 0).toLocaleString('en-GB')
+const asCount = value => (value ?? 0).toLocaleString()
 
 // A sync downloads two exports, one after the other. Both are shown for the whole run
 // and afterwards, so that the ledger's progress does not disappear the moment the

--- a/src/views/components/kraken/trade-table.jsx
+++ b/src/views/components/kraken/trade-table.jsx
@@ -125,8 +125,8 @@ export default function TradeTable({ trades, isFiltered, sort, onSortChange, onP
 
          <div className="flex items-center justify-between">
             <p className="text-sm text-muted-foreground">
-               Showing {firstRow.toLocaleString('en-GB')}–{lastRow.toLocaleString('en-GB')} of{' '}
-               {total.toLocaleString('en-GB')}
+               Showing {firstRow.toLocaleString()}–{lastRow.toLocaleString()} of{' '}
+               {total.toLocaleString()}
             </p>
             <div className="flex items-center gap-1">
                <Button

--- a/src/views/components/lib/filter-options.js
+++ b/src/views/components/lib/filter-options.js
@@ -19,4 +19,4 @@ export const toDateValue = (value) => value ? Date.parse(`${value}T23:59:59Z`) :
 
 // The plural is spelled out only for the nouns an s cannot make, such as entries.
 export const asCount = (count, noun, plural) =>
-   `${(count ?? 0).toLocaleString('en-GB')} ${count === 1 ? noun : plural ?? `${noun}s`}`
+   `${(count ?? 0).toLocaleString()} ${count === 1 ? noun : plural ?? `${noun}s`}`

--- a/src/views/components/ui/sonner.jsx
+++ b/src/views/components/ui/sonner.jsx
@@ -1,15 +1,12 @@
-import { useTheme } from 'next-themes'
 import { Toaster as Sonner } from 'sonner'
 import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from 'lucide-react'
 
 const Toaster = ({
    ...props
 }) => {
-   const { theme = 'system' } = useTheme()
-
    return (
       <Sonner
-         theme={theme}
+         theme="system"
          className="toaster group"
          icons={{
             success: (

--- a/src/views/pages/kraken/balances.jsx
+++ b/src/views/pages/kraken/balances.jsx
@@ -131,7 +131,7 @@ export default function KrakenBalances() {
                state={status?.state}
                job={status?.job}
                isRunning={isJobRunning(status?.job)}
-               counts={`${(status?.state?.entryCount ?? 0).toLocaleString('en-GB')} ledger entries`}
+               counts={`${(status?.state?.entryCount ?? 0).toLocaleString()} ledger entries`}
                emptyLabel="No ledger stored yet" />
 
             <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">

--- a/src/views/pages/kraken/rewards.jsx
+++ b/src/views/pages/kraken/rewards.jsx
@@ -95,7 +95,7 @@ export default function KrakenRewards() {
                state={status?.state}
                job={status?.job}
                isRunning={isJobRunning(status?.job)}
-               counts={`${(status?.state?.entryCount ?? 0).toLocaleString('en-GB')} ledger entries`}
+               counts={`${(status?.state?.entryCount ?? 0).toLocaleString()} ledger entries`}
                emptyLabel="No ledger stored yet" />
 
             <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">


### PR DESCRIPTION
Two independent changes, one commit each.

## Drop unused `next-themes`

`sonner.jsx` imported `useTheme` from `next-themes`, but no `ThemeProvider` is mounted anywhere in the app, so the hook always read an empty context and `theme` fell through to its `'system'` default. The package existed only to hand back a constant. It is replaced with the literal it already resolved to, so the value reaching Sonner is unchanged.

Every other dependency was checked by walking the module graph from each entry point (`main.jsx`, `server/index.js`, `electrobun/index.ts`, the vite/eslint/electrobun configs, `scripts/`, `global.css`) rather than by grep. That is what separates this one from three that merely look dead: `concurrently` drives the `dev` script, `shadcn` arrives through an `@import` in `global.css`, and `ai` / `@ai-sdk/anthropic` / `zod` are all used by the xStocks classifier. Nothing else was removed.

## Render dates and numbers in the user's locale

Every formatted date and count was pinned to en-GB. `src/utils/format.js` hard-coded the locale, with the navigator-based line sitting commented out directly above it, and twenty-four call sites passed `'en-GB'` to `toLocaleString`. A reader in the US saw `2 Aug 2026` in a table sitting next to a native date picker showing their own regional order. `Intl` now resolves the runtime's locale, and the call sites use the no-argument form that `chart.jsx:214` already used.

**The native date pickers needed no change, and could not have been fixed from app code in any case.** Rendering the same `<input type="date">` under `lang="de-DE"`, `"en-US"`, `"en-GB"` and `"ja-JP"` produced an identical result in all four: the control follows the OS regional format and ignores both the `lang` attribute and anything the app sets. The `lang` attribute on `<html>` is therefore left alone.

The `Time (UTC)` columns keep their ISO-8601 rendering — they are explicitly labelled UTC and have to stay locale-neutral to line up with the timestamps Kraken records.

### Caveat worth knowing

The two locale sources can genuinely disagree: `navigator.language` is the browser UI language, while the picker follows the OS regional format, and the latter is not exposed to JavaScript at all. On my machine those were `en-US` and Swiss `dd.mm.yyyy` respectively, so picker and text still will not match character for character. The runtime locale is the closest signal the platform offers, and it agrees with the picker far more often than a hard-coded en-GB did — which matched neither. Perfect alignment would need an explicit user-facing date-format setting.

## Verification

`eslint src` and `vite build` both pass. Checked in the running app with mock data (Ledger, Rewards, Settings): console clean, charts and compact axis ticks render, and toasts still fire after the Toaster change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
