### PR TITLE
fix(format): resolve the locale instead of guessing it

### DIFF
--- a/src/electrobun/index.ts
+++ b/src/electrobun/index.ts
@@ -1,6 +1,7 @@
 /// <reference types="bun-types" />
 import { ApplicationMenu, BrowserWindow, Utils, app } from "electrobun/bun";
 import { createApp } from "../server/app.js";
+import { systemLocales } from "./locale";
 
 const PORT = 3001;
 const DEV_SERVER_URL = "http://localhost:3000";
@@ -32,7 +33,10 @@ async function main() {
 
   console.log(`✓ API server listening on http://127.0.0.1:${PORT}`);
 
-  const win = new BrowserWindow({ title: "Crypto Tools", url, frame: { x: 0, y: 0, width: 1280, height: 900 } });
+  const locales = systemLocales();
+  const preload = locales.length ? `window.__LOCALES__ = ${JSON.stringify(locales)};` : null;
+
+  const win = new BrowserWindow({ title: "Crypto Tools", url, preload, frame: { x: 0, y: 0, width: 1280, height: 900 } });
 
   // Launch maximized; the 1280x900 frame above is the restored (un-maximized) size.
   win.maximize();

--- a/src/electrobun/locale.ts
+++ b/src/electrobun/locale.ts
@@ -1,0 +1,75 @@
+/// <reference types="bun-types" />
+
+function run(command: string[]): string {
+  try {
+    const { stdout, exitCode } = Bun.spawnSync(command);
+    return exitCode === 0 ? new TextDecoder().decode(stdout).trim() : "";
+  } catch {
+    return "";
+  }
+}
+
+function regionOf(tag: string): string | undefined {
+  try {
+    return new Intl.Locale(tag).region;
+  } catch {
+    return undefined;
+  }
+}
+
+function withRegion(languages: string[], region: string | undefined): string[] {
+  if (languages.length === 0 || !region) {
+    return languages;
+  }
+  try {
+    const preferred = new Intl.Locale(languages[0], { region }).toString();
+    return preferred === languages[0] ? languages : [preferred, ...languages];
+  } catch {
+    return languages;
+  }
+}
+
+function macosLocales(): string[] {
+  const list = run(["defaults", "read", "-g", "AppleLanguages"]);
+  const languages = list
+    .slice(list.indexOf("(") + 1, list.lastIndexOf(")"))
+    .split(",")
+    .map(entry => entry.trim().replace(/^"|"$/g, ""))
+    .filter(Boolean);
+
+  const appleLocale = run(["defaults", "read", "-g", "AppleLocale"]);
+  const override = appleLocale.match(/@.*\brg=([A-Za-z]{2})/)?.[1];
+  const region = override ?? regionOf(appleLocale.split("@")[0].replace("_", "-"));
+
+  return withRegion(languages, region?.toUpperCase());
+}
+
+function registryValue(key: string, name: string): string {
+  const line = run(["reg", "query", key, "/v", name])
+    .split(/\r?\n/)
+    .find(entry => entry.trim().startsWith(name));
+  const columns = line?.trim().split(/\s{2,}/) ?? [];
+  return columns.length >= 3 ? columns.slice(2).join(" ").trim() : "";
+}
+
+function windowsLocales(): string[] {
+  const preferred = registryValue("HKCU\\Control Panel\\Desktop", "PreferredUILanguages")
+    .split("\\0")
+    .map(entry => entry.trim())
+    .filter(Boolean);
+
+  const localeName = registryValue("HKCU\\Control Panel\\International", "LocaleName");
+  const languages = preferred.length ? preferred : [localeName].filter(Boolean);
+
+  return withRegion(languages, regionOf(localeName));
+}
+
+export function systemLocales(): string[] {
+  if (process.platform === "darwin") {
+    return macosLocales();
+  }
+  if (process.platform === "win32") {
+    return windowsLocales();
+  }
+  return [];
+}

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,12 +1,15 @@
-const locales = undefined
+import { locales } from './locale'
 
 const shortDateFormatter = new Intl.DateTimeFormat(locales, { month: 'short', day: 'numeric' })
 const longDateFormatter = new Intl.DateTimeFormat(locales, { year: 'numeric', month: 'short', day: 'numeric' })
 const monthDateFormatter = new Intl.DateTimeFormat(locales, { year: 'numeric', month: 'long' })
 const shortMonthDateFormatter = new Intl.DateTimeFormat(locales, { year: '2-digit', month: 'short' })
 const percentageFormatter = new Intl.NumberFormat(locales, { style: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 })
-const usDollarFormatter = new Intl.NumberFormat(locales, { style: 'currency', currency: 'USD', minimumFractionDigits: 2, maximumFractionDigits: 2 })
+const usDollarFormatter = new Intl.NumberFormat(locales, { style: 'currency', currency: 'USD', currencyDisplay: 'narrowSymbol', minimumFractionDigits: 2, maximumFractionDigits: 2 })
 const decimalOneFormatter = new Intl.NumberFormat(locales, { style: 'decimal', minimumFractionDigits: 1, maximumFractionDigits: 1 })
+const countFormatter = new Intl.NumberFormat(locales)
+const compactFormatter = new Intl.NumberFormat(locales, { notation: 'compact', maximumFractionDigits: 1 })
+const roundedFormatter = new Intl.NumberFormat(locales, { maximumFractionDigits: 1 })
 
 const dateFormat = (formatter, date) =>
    formatter.format(date).replace('\u00a0', ' ')
@@ -27,6 +30,18 @@ export function asAssetAmount(number) {
 
 export function asDecimalOne(number) {
    return decimalOneFormatter.format(number)
+}
+
+export function asNumber(number) {
+   return countFormatter.format(number ?? 0)
+}
+
+export function asCompact(number) {
+   return compactFormatter.format(number)
+}
+
+export function asRounded(number) {
+   return roundedFormatter.format(number)
 }
 
 export function asShortDate(timestamp) {

--- a/src/utils/locale.js
+++ b/src/utils/locale.js
@@ -1,0 +1,13 @@
+const injectedLocales = typeof window !== 'undefined' && Array.isArray(window.__LOCALES__)
+   ? window.__LOCALES__
+   : []
+
+const navigatorLocales = typeof navigator === 'undefined'
+   ? []
+   : navigator.languages?.length
+      ? [...navigator.languages]
+      : navigator.language ? [navigator.language] : []
+
+export const locales = injectedLocales.length ? injectedLocales
+   : navigatorLocales.length ? navigatorLocales
+      : ['en-US']

--- a/src/views/components/kraken/balance-summary-card.jsx
+++ b/src/views/components/kraken/balance-summary-card.jsx
@@ -5,7 +5,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import Field from '../lib/field'
 import { asCount } from '../lib/filter-options'
-import { asDollarAmount, asPercentage } from '../../../utils/format'
+import { asDollarAmount, asNumber, asPercentage } from '../../../utils/format'
 import { isEarning, placementOf } from './placement'
 
 // Kraken and the ledger agree to far more digits than this; the tolerance is relative
@@ -74,7 +74,7 @@ export default function BalanceSummaryCard({ balances, rates, live, liveError, i
                      ? <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
                      : rates ? asDollarAmount(totalValue) : '—'}
                </Field>
-               <Field label="Assets held">{assets.length.toLocaleString()}</Field>
+               <Field label="Assets held">{asNumber(assets.length)}</Field>
                <Field label="Earning">
                   {isLoadingRates
                      ? <Loader2Icon className="size-4 animate-spin text-muted-foreground" />

--- a/src/views/components/kraken/fee-breakdown-card.jsx
+++ b/src/views/components/kraken/fee-breakdown-card.jsx
@@ -1,7 +1,7 @@
 import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
-import { asAssetAmount, asPercentage } from '../../../utils/format'
+import { asAssetAmount, asNumber, asPercentage } from '../../../utils/format'
 
 // Kraken records ledger times in UTC; rendering them in the browser's zone would
 // silently shift every entry.
@@ -53,7 +53,7 @@ export default function FeeBreakdownCard({ fees, colors, asset }) {
                                  {asAssetAmount(row.total)}
                               </TableCell>
                               <TableCell className="text-right text-muted-foreground">
-                                 {row.entries.toLocaleString()}
+                                 {asNumber(row.entries)}
                               </TableCell>
                               <TableCell className="text-right text-muted-foreground">
                                  {assetTotals.get(row.asset)

--- a/src/views/components/kraken/fee-chart-card.jsx
+++ b/src/views/components/kraken/fee-chart-card.jsx
@@ -4,7 +4,7 @@ import {
    ChartContainer, ChartTooltip, ChartTooltipContent, ChartLegend, ChartLegendContent
 } from '@/components/ui/chart'
 import SelectField from '../lib/select-field'
-import { asAssetAmount, asShortMonthYearDate } from '../../../utils/format'
+import { asAssetAmount, asCompact, asRounded, asShortMonthYearDate } from '../../../utils/format'
 
 const granularities = [
    { value: 'month', label: 'Month' },
@@ -17,8 +17,8 @@ const granularities = [
 const asAxisTick = (value) => {
    const magnitude = Math.abs(value)
    if (magnitude === 0) return '0'
-   if (magnitude >= 1000) return value.toLocaleString(undefined, { notation: 'compact', maximumFractionDigits: 1 })
-   if (magnitude >= 1) return value.toLocaleString(undefined, { maximumFractionDigits: 1 })
+   if (magnitude >= 1000) return asCompact(value)
+   if (magnitude >= 1) return asRounded(value)
    return Number(value.toPrecision(2)).toString()
 }
 

--- a/src/views/components/kraken/fee-summary-card.jsx
+++ b/src/views/components/kraken/fee-summary-card.jsx
@@ -4,7 +4,7 @@ import { Badge } from '@/components/ui/badge'
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
 import LedgerFilters from './ledger-filters'
 import Field from '../lib/field'
-import { asAssetAmount, asLongDate, asPercentage } from '../../../utils/format'
+import { asAssetAmount, asNumber, asLongDate, asPercentage } from '../../../utils/format'
 
 
 export default function FeeSummaryCard({ fees, filters, filtersKey, options, isLoading, onFiltersChange, onFiltersReset }) {
@@ -19,7 +19,7 @@ export default function FeeSummaryCard({ fees, filters, filtersKey, options, isL
             <CardAction>
                {isLoading
                   ? <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
-                  : <Badge variant="outline">{entries.toLocaleString()} charged</Badge>}
+                  : <Badge variant="outline">{asNumber(entries)} charged</Badge>}
             </CardAction>
          </CardHeader>
          <CardContent className="space-y-4">
@@ -33,8 +33,8 @@ export default function FeeSummaryCard({ fees, filters, filtersKey, options, isL
                showSearch={false} />
 
             <div className="grid grid-cols-2 gap-x-6 gap-y-3 border-t border-border pt-4 md:grid-cols-4">
-               <Field label="Assets charged in">{assets.length.toLocaleString()}</Field>
-               <Field label="Fees charged">{entries.toLocaleString()}</Field>
+               <Field label="Assets charged in">{asNumber(assets.length)}</Field>
+               <Field label="Fees charged">{asNumber(entries)}</Field>
                <Field label="First fee">{fees?.first ? asLongDate(fees.first) : '—'}</Field>
                <Field label="Last fee">{fees?.last ? asLongDate(fees.last) : '—'}</Field>
             </div>
@@ -63,7 +63,7 @@ export default function FeeSummaryCard({ fees, filters, filtersKey, options, isL
                                  {asAssetAmount(asset.total)}
                               </TableCell>
                               <TableCell className="text-right text-muted-foreground">
-                                 {asset.entries.toLocaleString()}
+                                 {asNumber(asset.entries)}
                               </TableCell>
                               <TableCell className="text-right text-muted-foreground">
                                  {asPercentage(asset.entries / entries)}

--- a/src/views/components/kraken/ledger-sync-card.jsx
+++ b/src/views/components/kraken/ledger-sync-card.jsx
@@ -8,7 +8,7 @@ import Field from '../lib/field'
 import SyncSteps from './sync-steps'
 import { asCount } from '../lib/filter-options'
 import { SyncStatusBadge, phaseLabel } from './sync-status'
-import { asLongDate } from '../../../utils/format'
+import { asNumber, asLongDate } from '../../../utils/format'
 
 const asFileSize = (bytes) => {
    if (!bytes) return '—'
@@ -123,7 +123,7 @@ export default function LedgerSyncCard({ state, job, isRunning, error, isStartin
                <p className="text-xs text-muted-foreground">
                   Entries from other API keys are also stored:{' '}
                   {state.otherAccounts.map(account =>
-                     `${account.apiKeyPrefix || 'unknown'}… (${account.entryCount.toLocaleString()})`
+                     `${account.apiKeyPrefix || 'unknown'}… (${asNumber(account.entryCount)})`
                   ).join(', ')}.
                </p>}
 

--- a/src/views/components/kraken/ledger-table.jsx
+++ b/src/views/components/kraken/ledger-table.jsx
@@ -3,6 +3,7 @@ import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
+import { asNumber } from '../../../utils/format'
 
 // Kraken records ledger times in UTC; rendering them in the browser's zone would
 // silently shift every entry.
@@ -104,8 +105,8 @@ export default function LedgerTable({ entries, sort, onSortChange, onPageChange,
 
          <div className="flex items-center justify-between">
             <p className="text-sm text-muted-foreground">
-               Showing {firstRow.toLocaleString()}–{lastRow.toLocaleString()} of{' '}
-               {total.toLocaleString()}
+               Showing {asNumber(firstRow)}–{asNumber(lastRow)} of{' '}
+               {asNumber(total)}
             </p>
             <div className="flex items-center gap-1">
                <Button

--- a/src/views/components/kraken/order-table.jsx
+++ b/src/views/components/kraken/order-table.jsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
+import { asNumber } from '../../../utils/format'
 
 // Kraken records trade times in UTC; rendering them in the browser's zone would
 // silently shift every order.
@@ -120,8 +121,8 @@ export default function OrderTable({ orders, isFiltered, hasTrades, sort, onSort
 
          <div className="flex items-center justify-between">
             <p className="text-sm text-muted-foreground">
-               Showing {firstRow.toLocaleString()}–{lastRow.toLocaleString()} of{' '}
-               {total.toLocaleString()}
+               Showing {asNumber(firstRow)}–{asNumber(lastRow)} of{' '}
+               {asNumber(total)}
             </p>
             <div className="flex items-center gap-1">
                <Button

--- a/src/views/components/kraken/reward-history-card.jsx
+++ b/src/views/components/kraken/reward-history-card.jsx
@@ -3,7 +3,7 @@ import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts'
 import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart'
 import ComboboxField from '../lib/combobox-field'
-import { asAssetAmount, asDollarAmount } from '../../../utils/format'
+import { asAssetAmount, asCompact, asDollarAmount, asRounded } from '../../../utils/format'
 
 const EVERYTHING = 'ALL'
 
@@ -12,8 +12,8 @@ const EVERYTHING = 'ALL'
 const asAxisTick = (value) => {
    const magnitude = Math.abs(value)
    if (magnitude === 0) return '0'
-   if (magnitude >= 1000) return value.toLocaleString(undefined, { notation: 'compact', maximumFractionDigits: 1 })
-   if (magnitude >= 1) return value.toLocaleString(undefined, { maximumFractionDigits: 1 })
+   if (magnitude >= 1000) return asCompact(value)
+   if (magnitude >= 1) return asRounded(value)
    return Number(value.toPrecision(2)).toString()
 }
 

--- a/src/views/components/kraken/reward-summary-card.jsx
+++ b/src/views/components/kraken/reward-summary-card.jsx
@@ -3,7 +3,7 @@ import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/componen
 import { Badge } from '@/components/ui/badge'
 import Field from '../lib/field'
 import { asCount } from '../lib/filter-options'
-import { asDollarAmount, asLongDate } from '../../../utils/format'
+import { asDollarAmount, asNumber, asLongDate } from '../../../utils/format'
 
 
 export default function RewardSummaryCard({ rewards, rates, isLoading, isLoadingRates }) {
@@ -28,7 +28,7 @@ export default function RewardSummaryCard({ rewards, rates, isLoading, isLoading
             {/* Two columns rather than four: the card sits beside the charts, and the
                 stats read better stacked in a narrow column than squeezed into one row. */}
             <div className="grid grid-cols-2 gap-x-6 gap-y-6">
-               <Field label="Assets rewarded">{assets.length.toLocaleString()}</Field>
+               <Field label="Assets rewarded">{asNumber(assets.length)}</Field>
                <Field
                   label="Worth today"
                   title={valued.length < assets.length

--- a/src/views/components/kraken/sync-steps.jsx
+++ b/src/views/components/kraken/sync-steps.jsx
@@ -1,8 +1,7 @@
 import { CheckIcon, CircleIcon, Loader2Icon, MinusIcon, XIcon } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { isStepRunning, reportLabels, stepLabel } from './sync-status'
-
-const asCount = value => (value ?? 0).toLocaleString()
+import { asNumber } from '../../../utils/format'
 
 // A sync downloads two exports, one after the other. Both are shown for the whole run
 // and afterwards, so that the ledger's progress does not disappear the moment the
@@ -91,19 +90,19 @@ function StepCounts({ step, running }) {
    const { parsed, stored, inserted, skipped } = step.counts ?? {}
 
    if (step.phase === 'storing') {
-      return <span>{asCount(stored)} of {asCount(parsed)} saved</span>
+      return <span>{asNumber(stored)} of {asNumber(parsed)} saved</span>
    }
 
    if (running || step.phase === 'pending') {
-      return parsed > 0 ? <span>{asCount(parsed)} rows</span> : null
+      return parsed > 0 ? <span>{asNumber(parsed)} rows</span> : null
    }
 
    if (step.phase !== 'done') return null
 
    return (
       <span>
-         {asCount(parsed)} read · {asCount(inserted)} new
-         {skipped > 0 && <> · {asCount(skipped)} skipped</>}
+         {asNumber(parsed)} read · {asNumber(inserted)} new
+         {skipped > 0 && <> · {asNumber(skipped)} skipped</>}
       </span>
    )
 }

--- a/src/views/components/kraken/trade-table.jsx
+++ b/src/views/components/kraken/trade-table.jsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
+import { asNumber } from '../../../utils/format'
 
 // Kraken records trade times in UTC; rendering them in the browser's zone would
 // silently shift every fill.
@@ -125,8 +126,8 @@ export default function TradeTable({ trades, isFiltered, sort, onSortChange, onP
 
          <div className="flex items-center justify-between">
             <p className="text-sm text-muted-foreground">
-               Showing {firstRow.toLocaleString()}–{lastRow.toLocaleString()} of{' '}
-               {total.toLocaleString()}
+               Showing {asNumber(firstRow)}–{asNumber(lastRow)} of{' '}
+               {asNumber(total)}
             </p>
             <div className="flex items-center gap-1">
                <Button

--- a/src/views/components/lib/filter-options.js
+++ b/src/views/components/lib/filter-options.js
@@ -1,3 +1,5 @@
+import { asNumber } from '../../../utils/format'
+
 // Radix Select cannot hold an empty string as a value, so "no filter" travels as
 // this sentinel and is mapped back on the way out.
 export const ANY = 'any'
@@ -19,4 +21,4 @@ export const toDateValue = (value) => value ? Date.parse(`${value}T23:59:59Z`) :
 
 // The plural is spelled out only for the nouns an s cannot make, such as entries.
 export const asCount = (count, noun, plural) =>
-   `${(count ?? 0).toLocaleString()} ${count === 1 ? noun : plural ?? `${noun}s`}`
+   `${asNumber(count)} ${count === 1 ? noun : plural ?? `${noun}s`}`

--- a/src/views/components/ui/chart.jsx
+++ b/src/views/components/ui/chart.jsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import * as RechartsPrimitive from 'recharts'
 
 import { cn } from '@/lib/utils'
+import { asNumber } from '../../../utils/format'
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = {
@@ -211,7 +212,7 @@ function ChartTooltipContent({
                                  {item.value != null && (
                                     <span className="font-mono font-medium text-foreground tabular-nums">
                                        {typeof item.value === 'number'
-                                          ? item.value.toLocaleString()
+                                          ? asNumber(item.value)
                                           : String(item.value)}
                                     </span>
                                  )}

--- a/src/views/pages/kraken/balances.jsx
+++ b/src/views/pages/kraken/balances.jsx
@@ -10,6 +10,7 @@ import BalancePlacementCard from '../../components/kraken/balance-placement-card
 import BalanceChartCard from '../../components/kraken/balance-chart-card'
 import BalanceTable from '../../components/kraken/balance-table'
 import { defaultFilters } from '../../components/kraken/balance-filters'
+import { asCount } from '../../components/lib/filter-options'
 import { isJobRunning } from '../../components/kraken/sync-status'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 
@@ -131,7 +132,7 @@ export default function KrakenBalances() {
                state={status?.state}
                job={status?.job}
                isRunning={isJobRunning(status?.job)}
-               counts={`${(status?.state?.entryCount ?? 0).toLocaleString()} ledger entries`}
+               counts={asCount(status?.state?.entryCount, 'ledger entry', 'ledger entries')}
                emptyLabel="No ledger stored yet" />
 
             <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">

--- a/src/views/pages/kraken/rewards.jsx
+++ b/src/views/pages/kraken/rewards.jsx
@@ -9,6 +9,7 @@ import RewardChartCard from '../../components/kraken/reward-chart-card'
 import RewardHistoryCard from '../../components/kraken/reward-history-card'
 import RewardTable from '../../components/kraken/reward-table'
 import { isJobRunning } from '../../components/kraken/sync-status'
+import { asCount } from '../../components/lib/filter-options'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 
 
@@ -95,7 +96,7 @@ export default function KrakenRewards() {
                state={status?.state}
                job={status?.job}
                isRunning={isJobRunning(status?.job)}
-               counts={`${(status?.state?.entryCount ?? 0).toLocaleString()} ledger entries`}
+               counts={asCount(status?.state?.entryCount, 'ledger entry', 'ledger entries')}
                emptyLabel="No ledger stored yet" />
 
             <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">


### PR DESCRIPTION
Dates and numbers rendered differently in the macOS app than in the browser. Both surfaces were wrong, for different reasons.

`src/utils/format.js` passed `undefined` as the locale to all seven `Intl` formatters, and 23 more call sites used a bare `toLocaleString()`. All of them ask the engine for whatever locale it thinks the user has — a value each host resolves by its own mechanism, and neither matched the configured settings.

## What each side was doing

| | resolved to | short date | number |
|---|---|---|---|
| macOS app (WKWebView) | `en-US` | `8/5/2026` | `1,234,567.89` |
| Browser (Blink) | browser UI locale | `8/5/2026` | `1,234,567.89` |

- **WKWebView** exposes only `Locale.preferredLanguages[0]`, which drops the macOS **region**. A Mac set to English (US) with Region Switzerland reports `en-US`, so the app showed `8/5/2026` where `NSDateFormatter` — and every native app — shows `05.08.2026`.
- **Blink** resolves `Intl`'s default from the browser *UI* locale, not the configured `navigator.languages`. A browser whose language list leads with `fr-CH` still formatted as `en-US`.

The `-u-rg-` region-override extension is not a way out: `en-US-u-rg-chzzzz` formats as plain `en-US` in both V8 and JSC. The region has to be folded into the tag, so `en-US` + `CH` becomes `en-CH`.

## The change

`src/utils/locale.js` resolves one locale list — injected value, then `navigator.languages`, then `en-US` — and `format.js` builds every formatter from it.

`src/electrobun/locale.ts` reads the real OS settings and injects them via Electrobun's `preload` option, which runs at document start so there is no first-paint flash:

- **macOS**: `AppleLanguages` + the region from `AppleLocale` (including its `@rg=` override)
- **Windows**: `PreferredUILanguages` + the region from `Control Panel\International\LocaleName`

The bare `toLocaleString()` calls route through shared `asNumber` / `asCompact` / `asRounded` helpers, so nothing reads the ambient default any more. `asDollarAmount` gained `currencyDisplay: 'narrowSymbol'` so USD stays `$ 1 234,50` instead of `$US 1 234,50` under a French locale.

## Verified

Lint and build pass. The real modules were bundled and run in a real WKWebView and in Brave:

| | before | after |
|---|---|---|
| App (WKWebView) | `Aug 5, 2026` · `1,234,567.89` | `5 Aug 2026` · `1'234'567.89` · 24h |
| Brave | `Aug 5, 2026` · `1,234,567.89` | `5 août 2026` · `1 234 567,89` · 24h |

The running desktop app's webview reported its injected list back to a local beacon, confirming the `preload` seam works end to end.

**The Windows path is written but unverified** — there was no Windows machine to run it on. The registry parsing was checked against simulated `reg query` output, and every failure mode falls back to `navigator.languages`, i.e. today's behaviour.

## Not fixed: native date inputs

The four `<input type="date">` fields are unchanged, and they still render in the engine's own locale. Both WebKit and Blink **ignore the `lang` attribute** for date inputs (verified by rendering `lang="en-CH"`, `de-CH`, `fr-CH`, `en-GB` in each — all identical), so the format is not reachable from the page.

WebKit follows the system *language*, not the region, so on a Mac set to English (US) / Region Switzerland the picker shows `08/05/2026` while the text beside it now shows `1 Aug 2026`. Closing that gap needs either a JS-rendered picker or a change to the macOS language setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)