### PR TITLE
fix: bind every listening socket to 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ bun run desktop:dev
 
 `bun run dev` starts both the Vite dev server (port 3000) and the Hono API server (port 3001) concurrently. Vite proxies `/api` requests to the Hono server.
 
+### Network binding
+
+Every listening socket the app opens is bound to `127.0.0.1`, so nothing is reachable from the local network and Windows Firewall never prompts on first launch.
+
+Two of the three are ours: the Hono API in desktop mode (`src/electrobun/index.ts`) and in web mode (`src/server/index.js`, overridable with `HOST` for reverse-proxy or container deployments). The third belongs to Electrobun — it opens a WebSocket RPC server between the Bun process and the WebView on the first free port from 50000 upwards, and up to and including 1.18.1 it passes no `hostname` to `Bun.serve`, so Bun binds the wildcard address. On Windows that is what triggers *"Do you want to allow public and private networks to access this app?"* attributed to Bun (publisher Oven). `patches/electrobun@1.18.1.patch` adds the missing `hostname`; Bun applies it on `bun install` via `patchedDependencies` in `package.json`. Revisit the patch when upgrading Electrobun — 1.18.4 moves this socket into the native core, so it may become unnecessary or need reworking.
+
 ### Mocked Mode
 
 Run the frontend only with mock data (no API keys or server required):

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "electrobun@1.18.1": "patches/electrobun@1.18.1.patch",
+  },
   "packages": {
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.24", "", { "dependencies": { "@ai-sdk/provider": "4.0.4", "@ai-sdk/provider-utils": "5.0.15" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ywMZXK/uOIxUKwo2vaow0kt2XqMjIEeZWBOxif/oDka3294fUDX0gcUESUjPzd8254Fnvz1lRO70gr9LOgLkww=="],
 

--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
       "globals": "17.8.0",
       "tailwindcss": "4.3.3",
       "vite": "8.1.5"
+   },
+   "patchedDependencies": {
+      "electrobun@1.18.1": "patches/electrobun@1.18.1.patch"
    }
 }

--- a/patches/electrobun@1.18.1.patch
+++ b/patches/electrobun@1.18.1.patch
@@ -1,0 +1,12 @@
+diff --git a/dist/api/bun/core/Socket.ts b/dist/api/bun/core/Socket.ts
+index cdaa2bca0fabe577cb667056aa6f8f84211189c2..792949d6e9c9da0939301c513294e38a1f0308b9 100644
+--- a/dist/api/bun/core/Socket.ts
++++ b/dist/api/bun/core/Socket.ts
+@@ -66,6 +66,7 @@ const startRPCServer = () => {
+ 		try {
+ 			server = Bun.serve<{ webviewId: number }>({
+ 				port,
++				hostname: "127.0.0.1",
+ 				fetch(req: Request, server: Server<{ webviewId: number }>) {
+ 					const url = new URL(req.url);
+ 					//   const token = new URL(req.url).searchParams.get("token");

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -6,6 +6,7 @@ import binanceRoutes from './routes/binance.js'
 import krakenRoutes from './routes/kraken.js'
 
 const PORT = parseInt(process.env.PORT ?? '3001', 10)
+const HOST = process.env.HOST ?? '127.0.0.1'
 const IS_PROD = process.env.NODE_ENV === 'production'
 
 const app = new Hono()
@@ -54,7 +55,8 @@ if (IS_PROD) {
 
 Bun.serve({
    port: PORT,
+   hostname: HOST,
    fetch: app.fetch,
 })
 
-console.log(`✓ Server listening on http://localhost:${PORT}`)
+console.log(`✓ Server listening on http://${HOST}:${PORT}`)


### PR DESCRIPTION
## Problem

Running the app on Windows raises a Windows Firewall prompt on first launch — *"Do you want to allow public and private networks to access this app?"*, attributed to **Bun** (publisher Oven). Annoying for users, and it asks them to approve network exposure the app does not need.

Our own Hono server was never the cause: in desktop mode it has bound `127.0.0.1` explicitly since the Electrobun integration landed.

The prompt comes from Electrobun itself. `node_modules/electrobun/dist/api/bun/core/Socket.ts` runs a WebSocket RPC server between the Bun process and the WebView, started unconditionally at import time, on the first free port from 50000 upwards:

```ts
server = Bun.serve<{ webviewId: number }>({
  port,          // no hostname
  fetch(req, server) { ... }
```

With no `hostname`, Bun binds the wildcard address, and Windows sees an inbound listener on a real interface.

## Changes

- **`patches/electrobun@1.18.1.patch`** — adds the missing `hostname: "127.0.0.1"`, applied on `bun install` via `patchedDependencies`. The WebView already connects over `ws://127.0.0.1:<port>`, so nothing else changes. Release CI runs `bun install --frozen-lockfile` and `bun.lock` records the patch, so Windows builds pick it up automatically.
- **`src/server/index.js`** — the web-mode server had the same wildcard bind from the same omission. Now defaults to `127.0.0.1`, with a `HOST` override for reverse-proxy and container deployments.
- The startup log prints the address actually bound instead of always saying `localhost`. `Bun.serve` reports `server.hostname === "localhost"` even when listening on the wildcard, which made the old line actively misleading.
- **`README.md`** — a "Network binding" section under Development covering all three sockets and the reason the patch exists.

## Verification

`bunx electrobun dev`, then the live sockets:

```
bun  14272  TCP 127.0.0.1:50000 (LISTEN)    ← Electrobun RPC, was *:50000
bun  14272  TCP 127.0.0.1:3001  (LISTEN)    ← Hono API
```

Both loopback-only, and the app started normally. `bun run lint` passes.

The lockfile diff is only the three `patchedDependencies` lines — nothing else was re-resolved.

## Note for upgrades

The patch is pinned to `electrobun@1.18.1` and will need review on the next bump. 1.18.4 moves this socket into the native core (`Socket.ts` becomes a thin FFI wrapper), so the patch may become unnecessary — or need reworking if the native core binds the wildcard too.

Companion PR: nyg/qoqa-compta#100, which carries the byte-identical patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)