### PR TITLE
feat(desktop): remember window geometry and open without the maximize animation

### DIFF
--- a/src/electrobun/index.ts
+++ b/src/electrobun/index.ts
@@ -2,6 +2,7 @@
 import { ApplicationMenu, BrowserWindow, Utils, app } from 'electrobun/bun'
 import { createApp } from '../server/app.js'
 import { systemLocales } from './locale'
+import { resolveInitialWindowState, trackWindowState } from './window-state'
 
 const PORT = 3001
 const DEV_SERVER_URL = 'http://localhost:3000'
@@ -36,10 +37,16 @@ async function main() {
    const locales = systemLocales()
    const preload = locales.length ? `window.__LOCALES__ = ${JSON.stringify(locales)};` : null
 
-   const win = new BrowserWindow({ title: 'Crypto Tools', url, preload, frame: { x: 0, y: 0, width: 1280, height: 900 } })
-
-   // Launch maximized; the 1280x900 frame above is the restored (un-maximized) size.
-   win.maximize();
+   // Created hidden so the geometry is applied before the window is ever drawn; the frame
+   // is the restored (un-maximized) size, the maximized rectangle is left to the OS.
+   const initialWindowState = resolveInitialWindowState()
+   const win = new BrowserWindow({
+      title: 'Crypto Tools',
+      url,
+      preload,
+      frame: initialWindowState.frame,
+      hidden: true,
+   });
 
    // Open target="_blank" links in the default system browser instead of the WebView.
    (win.webview as any).on('new-window-open', (event: any) => {
@@ -49,6 +56,19 @@ async function main() {
          Utils.openExternal(href)
       }
    })
+
+   trackWindowState(win, initialWindowState)
+
+   try {
+      if (initialWindowState.maximized && !win.isMaximized()) {
+         win.maximize()
+      }
+   }
+   catch (error) {
+      console.error('✗ Could not restore the maximized window state:', error)
+   }
+
+   win.show()
 
    ApplicationMenu.setApplicationMenu([
       {

--- a/src/electrobun/window-state.ts
+++ b/src/electrobun/window-state.ts
@@ -1,0 +1,272 @@
+/// <reference types="bun-types" />
+import { readFileSync, renameSync, writeFileSync } from 'fs'
+import path from 'path'
+import { Screen, app } from 'electrobun/bun'
+import type { BrowserWindow } from 'electrobun/bun'
+import { resolveDataDir } from '../server/db/paths.js'
+
+const STATE_VERSION = 1
+const STATE_FILE = 'window-state.json'
+const DEFAULT_WIDTH = 1280
+const DEFAULT_HEIGHT = 900
+const MIN_WIDTH = 800
+const MIN_HEIGHT = 600
+const MIN_VISIBLE = 120
+const MAX_DIMENSION = 20000
+const WRITE_DEBOUNCE_MS = 400
+const STARTUP_SETTLE_MS = 600
+const OFFSCREEN_SENTINEL = -30000
+
+export interface WindowBounds {
+   x: number
+   y: number
+   width: number
+   height: number
+}
+
+export interface InitialWindowState {
+   frame: WindowBounds
+   maximized: boolean
+}
+
+interface PersistedWindowState {
+   version: number
+   bounds: WindowBounds
+   maximized: boolean
+   displays: string
+}
+
+let lastWritten: string | null = null
+
+function statePath(): string {
+   return path.join(resolveDataDir(), STATE_FILE)
+}
+
+function displayFingerprint(): string {
+   try {
+      return Screen.getAllDisplays()
+         .map(display => `${display.id}:${display.bounds.x},${display.bounds.y},${display.bounds.width}x${display.bounds.height}`)
+         .sort()
+         .join(';')
+   }
+   catch {
+      return ''
+   }
+}
+
+function primaryWorkArea(): WindowBounds {
+   try {
+      return Screen.getPrimaryDisplay().workArea
+   }
+   catch {
+      return { x: 0, y: 0, width: 0, height: 0 }
+   }
+}
+
+function centeredDefault(width: number, height: number): WindowBounds {
+   const workArea = primaryWorkArea()
+   if (workArea.width < MIN_WIDTH || workArea.height < MIN_HEIGHT) {
+      return { x: 0, y: 0, width, height }
+   }
+   const fittedWidth = Math.min(width, workArea.width)
+   const fittedHeight = Math.min(height, workArea.height)
+   return {
+      x: Math.round(workArea.x + (workArea.width - fittedWidth) / 2),
+      y: Math.round(workArea.y + (workArea.height - fittedHeight) / 2),
+      width: fittedWidth,
+      height: fittedHeight,
+   }
+}
+
+function readState(): PersistedWindowState | null {
+   try {
+      const parsed = JSON.parse(readFileSync(statePath(), 'utf-8'))
+      if (parsed?.version !== STATE_VERSION
+         || typeof parsed.maximized !== 'boolean'
+         || typeof parsed.displays !== 'string'
+         || !parsed.bounds
+         || !Number.isFinite(parsed.bounds.x)
+         || !Number.isFinite(parsed.bounds.y)
+         || !Number.isFinite(parsed.bounds.width)
+         || !Number.isFinite(parsed.bounds.height)) {
+         return null
+      }
+      return parsed as PersistedWindowState
+   }
+   catch {
+      return null
+   }
+}
+
+function writeState(state: PersistedWindowState): void {
+   const serialized = JSON.stringify(state, null, 2)
+   if (lastWritten === null) {
+      try {
+         lastWritten = readFileSync(statePath(), 'utf-8')
+      }
+      catch {
+         lastWritten = ''
+      }
+   }
+   if (serialized === lastWritten) {
+      return
+   }
+   try {
+      const target = statePath()
+      const temporary = `${target}.tmp`
+      writeFileSync(temporary, serialized, 'utf-8')
+      renameSync(temporary, target)
+      lastWritten = serialized
+   }
+   catch {
+      // Losing the window layout must never take the app down with it
+   }
+}
+
+function displayBounds(): WindowBounds[] {
+   try {
+      return Screen.getAllDisplays().map(display => display.bounds)
+   }
+   catch {
+      return []
+   }
+}
+
+function clampSize(bounds: WindowBounds): WindowBounds {
+   const displays = displayBounds()
+   const maxWidth = displays.length
+      ? displays.reduce((total, display) => total + display.width, 0)
+      : MAX_DIMENSION
+   const maxHeight = displays.length
+      ? Math.max(...displays.map(display => display.height))
+      : MAX_DIMENSION
+   return {
+      x: bounds.x,
+      y: bounds.y,
+      width: Math.max(MIN_WIDTH, Math.min(bounds.width, maxWidth)),
+      height: Math.max(MIN_HEIGHT, Math.min(bounds.height, maxHeight)),
+   }
+}
+
+function isSanePosition(bounds: WindowBounds): boolean {
+   const displays = displayBounds()
+   if (displays.length === 0) {
+      return true
+   }
+   const minX = Math.min(...displays.map(display => display.x))
+   const maxX = Math.max(...displays.map(display => display.x + display.width))
+   const spanY = Math.max(...displays.map(display => Math.abs(display.y) + display.height))
+   const horizontallyVisible = bounds.x + bounds.width - MIN_VISIBLE > minX && bounds.x + MIN_VISIBLE < maxX
+   const verticallyPlausible = bounds.y > -spanY && bounds.y < spanY + bounds.height
+   return horizontallyVisible && verticallyPlausible
+}
+
+function isPlausibleLiveFrame(frame: WindowBounds): boolean {
+   return Number.isFinite(frame.x)
+      && Number.isFinite(frame.y)
+      && Number.isFinite(frame.width)
+      && Number.isFinite(frame.height)
+      && frame.width >= 1
+      && frame.height >= 1
+      && frame.x > OFFSCREEN_SENTINEL
+      && frame.y > OFFSCREEN_SENTINEL
+}
+
+function measureFrameOverhead(win: BrowserWindow, requested: WindowBounds): WindowBounds {
+   try {
+      const frame = win.getFrame()
+      if (!isPlausibleLiveFrame(frame)) {
+         return { x: 0, y: 0, width: 0, height: 0 }
+      }
+      return {
+         x: frame.x - requested.x,
+         y: frame.y - requested.y,
+         width: frame.width - requested.width,
+         height: frame.height - requested.height,
+      }
+   }
+   catch {
+      return { x: 0, y: 0, width: 0, height: 0 }
+   }
+}
+
+export function resolveInitialWindowState(): InitialWindowState {
+   const saved = readState()
+   if (!saved) {
+      return { frame: centeredDefault(DEFAULT_WIDTH, DEFAULT_HEIGHT), maximized: true }
+   }
+   const sized = clampSize(saved.bounds)
+   if (saved.displays !== displayFingerprint() || !isSanePosition(sized)) {
+      return { frame: centeredDefault(sized.width, sized.height), maximized: saved.maximized }
+   }
+   return { frame: sized, maximized: saved.maximized }
+}
+
+export function trackWindowState(win: BrowserWindow, initial: InitialWindowState): void {
+   const overhead = measureFrameOverhead(win, initial.frame)
+   const current: PersistedWindowState = {
+      version: STATE_VERSION,
+      bounds: initial.frame,
+      maximized: initial.maximized,
+      displays: displayFingerprint(),
+   }
+   let timer: ReturnType<typeof setTimeout> | null = null
+   const settleUntil = Date.now() + STARTUP_SETTLE_MS
+
+   const captureLiveFrame = () => {
+      if (Date.now() < settleUntil) {
+         return
+      }
+      try {
+         if (win.isMinimized() || win.isFullScreen()) {
+            return
+         }
+         const frame = win.getFrame()
+         if (!isPlausibleLiveFrame(frame)) {
+            return
+         }
+         current.maximized = win.isMaximized()
+         current.displays = displayFingerprint()
+         if (!current.maximized) {
+            current.bounds = {
+               x: frame.x - overhead.x,
+               y: frame.y - overhead.y,
+               width: frame.width - overhead.width,
+               height: frame.height - overhead.height,
+            }
+         }
+      }
+      catch {
+         // A window that can no longer be queried keeps whatever was captured last
+      }
+   }
+
+   const scheduleWrite = () => {
+      if (Date.now() < settleUntil) {
+         return
+      }
+      if (timer) {
+         clearTimeout(timer)
+      }
+      timer = setTimeout(() => {
+         timer = null
+         captureLiveFrame()
+         writeState(current)
+      }, WRITE_DEBOUNCE_MS)
+      timer.unref?.()
+   }
+
+   const flushWrite = () => {
+      if (timer) {
+         clearTimeout(timer)
+         timer = null
+      }
+      captureLiveFrame()
+      writeState(current)
+   }
+
+   win.on('resize', scheduleWrite)
+   win.on('move', scheduleWrite)
+   win.on('close', flushWrite)
+   app.on('before-quit', flushWrite)
+}


### PR DESCRIPTION
## What

The window was created at a fixed `1280x900` at `(0, 0)` and then maximized while already on screen, so every launch showed it visibly animating to maximized, and nothing about its size or position survived a quit.

It is now created with `hidden: true`, restored (or maximized) while still invisible, and only then shown — the first frame the user sees is already the final one. Size, position and maximized state persist across restarts.

New module `src/electrobun/window-state.ts` exposes `resolveInitialWindowState()` and `trackWindowState()`; `src/electrobun/index.ts` is rewired around them. No new dependencies. This is the same change as nyg/qoqa-compta#103, adapted to this repo's `resolveDataDir()` and style.

## Design notes for the reviewer

**Storage.** `window-state.json` in the existing application data directory, reusing `resolveDataDir()` from `src/server/db/paths.js`. Unlike the database it is not split dev/prod — geometry is disposable, and a wrong window position is self-correcting in a way a wrong ledger is not.

**Persistence timing.** Geometry is tracked in memory from the `resize`/`move` events, written debounced at 400ms, and flushed synchronously on `close` and on the app's `before-quit`. Electrobun emits the per-window `close` event *before* the global handler that calls `quit()` (deliberate, per the comment in its source), and `getFrame()` is unusable by then because the window pointer has already been removed from `BrowserWindowMap` — hence in-memory tracking rather than a read at shutdown.

**Only the last non-maximized frame is stored as `bounds`,** so un-maximizing returns to the size the user actually chose.

**Titlebar overhead.** Window creation takes a *content* height while `getFrame()` reports an *outer* height (900 → 928 on macOS). Round-tripping that naively grew the window by 28px on every launch, so the delta is measured once at creation and subtracted before persisting. That is why the state file stores `672` for a 700px-tall window.

**Validation.** Restored bounds are checked against a fingerprint of the connected displays; on a mismatch the position is discarded and the window re-centres on the primary work area, keeping the saved size. That also sidesteps the y-axis origin question, since a centred window lands sensibly under either convention. Size is clamped to `[800x600, union of displays]`, corrupt or version-mismatched JSON falls back to first-launch behaviour, and writes go through a temp file plus rename.

**Fullscreen is deliberately not restored** — relaunching into macOS fullscreen strands users who do not know how to exit it. Capture is skipped while fullscreen so the pre-fullscreen bounds survive.

## Verification

Run against the built app with `CRYPTO_TOOLS_DATA_DIR` pointed at a scratch directory, using temporary probe instrumentation (since removed):

- Fresh launch with no state file → centred 1280x900 restore frame, already maximized (`0,38 1679x1079`) at the moment `show()` is called.
- Round-trip exact and stable: resize to `1000x700 @300,200`, quit, relaunch twice → identical geometry both times, zero drift.
- Saved `maximized: true` → relaunch maximized, with `bounds` still holding the `1000x672` un-maximize target.
- Corrupt `{` → first-launch default. Stale display fingerprint → re-centred at the saved size.
- `bun run lint` clean.

`hidden: true` being honoured natively (no window visible before `show()`) was verified in the sibling repo by inserting a 3s sleep between creation and `show()` and confirming no `focus` event fires during it; this repo pins the same Electrobun 1.18.1 and uses the same call, so that result carries over rather than being re-measured here.

Not covered: a real multi-monitor unplug (single display available) — the fingerprint-mismatch path was exercised by hand-editing the saved display id. The purely visual checks, that no animation is perceptible and that the webview paints correctly right after `show()`, need a human at the machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)