### PR TITLE
fix(server): serve built assets on deep links

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -40,15 +40,21 @@ app.route('/api/kraken', krakenRoutes)
 if (IS_PROD) {
    const DIST = path.resolve('./dist')
 
-   app.get('*', (c) => {
-      const url = new URL(c.req.url)
-      const filePath = path.join(DIST, url.pathname)
+   const distFile = (pathname) => {
+      const segments = pathname.split('/').filter(Boolean)
 
-      if (existsSync(filePath) && statSync(filePath).isFile()) {
-         return new Response(Bun.file(filePath))
+      for (let start = 0; start < segments.length; start++) {
+         const candidate = path.join(DIST, ...segments.slice(start))
+         if (!candidate.startsWith(DIST + path.sep)) continue
+         if (existsSync(candidate) && statSync(candidate).isFile()) return candidate
       }
 
-      return new Response(Bun.file(path.join(DIST, 'index.html')))
+      return null
+   }
+
+   app.get('*', (c) => {
+      const file = distFile(new URL(c.req.url).pathname)
+      return new Response(Bun.file(file ?? path.join(DIST, 'index.html')))
    })
 }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,9 @@ export default defineConfig({
    // Relative base so assets resolve correctly under views:// (Electrobun's
    // custom scheme). Absolute /assets/... paths fail when loaded from
    // views://main/index.html because they resolve to the scheme root, not
-   // views://main/assets/. Has no effect in web/dev mode.
+   // views://main/assets/. Dev is unaffected, but a deep link in the web build
+   // resolves them against the route instead of the root, which the production
+   // server in src/server/index.js compensates for.
    base: './',
    plugins: [react(), tailwindcss()],
    resolve: {


### PR DESCRIPTION
## The bug

Opening a route directly in the production web server (`bun run start`) returned a **blank page**. Only `/` worked — typing `/kraken/xstocks`, refreshing it, or following a bookmark produced an empty document.

Dev mode and the desktop app were never affected, so this only ever hit the self-hosted web build.

## Why

`dist/index.html` references its assets **relatively**, so the same build can also load from `views://` in the desktop app, where an absolute `/assets/…` would resolve against the scheme root rather than the bundle:

```html
<script type="module" src="./assets/index-BHyw8fYl.js">
```

Relative means *relative to the current folder in the URL*:

| Opened | Browser requested | Result |
|---|---|---|
| `/` | `/assets/index-….js` | correct file, app boots |
| `/kraken/xstocks` | `/kraken/assets/index-….js` | no such file |

That second path doesn't exist, so the SPA fallback ("any unknown path → `index.html`", which is what makes route refreshes work at all) answered with **HTML**. The browser asked for a module and got a document, refused to execute it, and React never mounted.

The favicons and `apple-touch-icon.png` are referenced the same way and broke identically — an assets-only fix would have missed them.

## The fix

The static handler now drops leading route segments one at a time before giving up, so `/kraken/assets/index-….js` resolves to `dist/assets/index-….js` while `/kraken/xstocks` still falls through to `index.html`.

Candidates are also confined to `dist`, so a path climbing out with `..` can no longer reach the filesystem above it. The previous version passed the raw pathname straight to `path.join` with no such check.

## Verified

Against a real production build:

| Request | Before | After |
|---|---|---|
| `/assets/index-….js` | `text/javascript` | `text/javascript` |
| `/kraken/assets/index-….js` | **`text/html`** | `text/javascript` |
| `/kraken/xstocks/assets/index-….js` | **`text/html`** | `text/javascript` |
| `/kraken/favicon.svg` | **`text/html`** | `image/svg+xml` |
| `/kraken/apple-touch-icon.png` | **`text/html`** | `image/png` |
| `/`, `/settings`, `/does/not/exist` | `text/html` | `text/html` |
| `/kraken/../../package.json` | — | `text/html` (not the file) |

And in a headless browser on `/kraken/xstocks`: `rootChildren: 0` and a blank title before, `rootChildren: 1` with title `Crypto Tools — Kraken xStocks` and no console exceptions after.

## Scope

Only `src/server/index.js`, the standalone web server, changes. `src/server/app.js` — the entry the desktop app uses — serves no static files, so Electrobun behaviour is untouched and no rebuild of the desktop bundle is implied.

The comment in `vite.config.js` claimed the relative base has "no effect in web/dev mode". That was true for dev and wrong for the web build; it now says what actually happens and points at the compensating code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
