### PR TITLE
fix(settings): hold the API keys on the server, not in the browser

### DIFF
--- a/.env.development.local.example
+++ b/.env.development.local.example
@@ -1,10 +1,10 @@
-VITE_BINANCE_API_KEY=<Your Binance API key>
-VITE_BINANCE_API_SECRET=<Your Binance API secret>
+BINANCE_API_KEY=<Your Binance API key>
+BINANCE_API_SECRET=<Your Binance API secret>
 
-VITE_KRAKEN_API_KEY=<Your Kraken API key>
-VITE_KRAKEN_API_SECRET=<Your Kraken API secret>
+KRAKEN_API_KEY=<Your Kraken API key>
+KRAKEN_API_SECRET=<Your Kraken API secret>
 
-VITE_ANTHROPIC_API_KEY=<Your Anthropic API key>
+ANTHROPIC_API_KEY=<Your Anthropic API key>
 
 # Set to true to use mock data (no API keys or server needed)
 VITE_MOCK_DATA=false

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ irm get.scoop.sh | iex
 2. **macOS**: open the DMG, drag **Crypto Tools.app** to your **Applications** folder, then see [macOS Gatekeeper](#macos-gatekeeper) below before first launch
 3. **Windows**: extract the ZIP and run **Crypto Tools-Setup.exe** inside (installs per-user to `%LOCALAPPDATA%` — no admin rights). See [Windows SmartScreen](#windows-smartscreen) below before first launch.
 
-API keys can be configured in the app on the **Settings** page (stored in `localStorage`).
+API keys can be configured in the app on the **Settings** page (stored in `settings.json`, beside the ledger database in the app's data directory).
 
 ### macOS Gatekeeper
 
@@ -147,19 +147,29 @@ Run the frontend only with mock data (no API keys or server required):
 bun run mocked
 ```
 
-This sets `VITE_MOCK_DATA=true`, which intercepts all API calls with a mock fetcher and auto-initializes `localStorage` with fake credentials. Useful for development and demos.
+This sets `VITE_MOCK_DATA=true`, which intercepts all API calls with a mock fetcher, including the settings endpoint, so every page behaves as if credentials were configured. Nothing is written to disk. Useful for development and demos.
 
 ## Usage
 
 The home page links to every tool; the top menu bar switches between exchanges and each exchange section has sub-navigation for its specific features.
 
-API keys for Kraken, Binance, and Anthropic can be configured on the **Settings** page (stored in `localStorage`) or via environment variables (`VITE_*`).
+API keys for Kraken, Binance, and Anthropic can be configured on the **Settings** page or, in development, via environment variables (`KRAKEN_API_KEY`, `KRAKEN_API_SECRET`, and the `BINANCE_`/`ANTHROPIC_` equivalents; the older `VITE_`-prefixed names are still read). They are held by the local server rather than by the page, so they never enter browser storage and are never sent to anything but the exchange they belong to. An environment variable takes precedence over a saved key, and the Settings page says so when one is in effect.
 
 Prefer a dedicated Kraken API key for this app. Kraken requires nonces to increase on every private call for a given key, so sharing one key between two applications making concurrent requests can make either of them fail with `EAPI:Invalid nonce`.
 
-### Ledger storage
+### Stored data
 
-The Ledger page stores its data in a SQLite database in the per-user application data directory — `~/Library/Application Support/Crypto Tools` on macOS, `%APPDATA%\Crypto Tools` on Windows, `$XDG_DATA_HOME/crypto-tools` on Linux. A directory left behind by a version older than v0.1.2 (named `CryptoTools`) is moved across on first launch. Set `CRYPTO_TOOLS_DATA_DIR` to override it. `bun run dev` writes to `ledger-dev.db` so it never touches the installed app's data. Nothing is uploaded anywhere; deleting the file (or using **Clear data**) simply means the next sync downloads everything again.
+Everything the app keeps lives in the per-user application data directory — `~/Library/Application Support/Crypto Tools` on macOS, `%APPDATA%\Crypto Tools` on Windows, `$XDG_DATA_HOME/crypto-tools` on Linux. A directory left behind by a version older than v0.1.2 (named `CryptoTools`) is moved across on first launch. Set `CRYPTO_TOOLS_DATA_DIR` to override it.
+
+- `ledger.db` — the SQLite database behind the Ledger, Balances, Rewards, Fees and Closed Orders pages. Deleting it (or using **Clear data**) simply means the next sync downloads everything again.
+- `settings.json` — the API keys, written with owner-only permissions.
+- `window-state.json` — the window's last position and size.
+
+`bun run dev` writes to `ledger-dev.db` and `settings-dev.json` so it never touches the installed app's data. Nothing is uploaded anywhere.
+
+The Kraken rows are partitioned by an account id derived once, from the first key you save, and then kept: rotating your Kraken API key leaves the synced ledger where it is. Rows left behind by a key rotation from before this was the case are listed at the bottom of the sync card.
+
+The browser's `localStorage` is used only for view preferences — filters, sorting and the order-batch form. Nothing there is needed to reach an exchange, and clearing it loses nothing but those choices.
 
 ## Project Structure
 

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -4,18 +4,49 @@ import binanceRoutes from './routes/binance.js'
 import krakenRoutes from './routes/kraken.js'
 import settingsRoutes from './routes/settings.js'
 
+const allowedOrigins = ['http://localhost:3000', 'views://']
+
+// Vite's port is configurable and the browser sends Origin on same-origin writes too,
+// so pinning development to 3000 would 403 every write for anyone running it elsewhere.
+// The packaged app only ever loads from views://, so this stays out of production.
+const localhostOrigin = /^http:\/\/(localhost|127\.0\.0\.1):\d+$/
+
+const isAllowedOrigin = origin =>
+   allowedOrigins.some(allowed =>
+      allowed.endsWith('://') ? origin.startsWith(allowed) : origin === allowed)
+   || (process.env.NODE_ENV !== 'production' && localhostOrigin.test(origin))
+
+const readOnlyMethods = ['GET', 'HEAD', 'OPTIONS']
+
 export function createApp() {
    const app = new Hono()
 
    app.use('/api/*', cors({
-      origin: (origin) => {
-         const allowed = ['http://localhost:3000', 'views://']
-         if (allowed.some(o => o.endsWith('://') ? origin.startsWith(o) : origin === o)) {
-            return origin
-         }
-         return null
-      }
+      origin: (origin) => isAllowedOrigin(origin) ? origin : null
    }))
+
+   // CORS decides what a page may *read*; it does not stop the request being made.
+   // A cross-origin POST with a simple content type is sent without a preflight, and
+   // now that the server supplies the credentials, the body no longer proves who is
+   // asking — so a foreign page could start a sync, clear the database or place
+   // orders without ever seeing a response. The allowlist is therefore enforced here
+   // as well, and writes must be application/json, which cannot be sent
+   // cross-origin without a preflight the allowlist above already refuses.
+   // A request with no Origin at all is the curl or native case, not a browser.
+   app.use('/api/*', async (c, next) => {
+
+      const origin = c.req.header('origin')
+      if (origin && !isAllowedOrigin(origin)) {
+         return c.json({ error: 'Origin not allowed.' }, 403)
+      }
+
+      if (!readOnlyMethods.includes(c.req.method)
+         && !(c.req.header('content-type') ?? '').startsWith('application/json')) {
+         return c.json({ error: 'Expected a JSON request body.' }, 415)
+      }
+
+      await next()
+   })
 
    app.use('*', async (c, next) => {
       const start = Date.now()

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import binanceRoutes from './routes/binance.js'
 import krakenRoutes from './routes/kraken.js'
+import settingsRoutes from './routes/settings.js'
 
 export function createApp() {
    const app = new Hono()
@@ -28,6 +29,7 @@ export function createApp() {
 
    app.route('/api/binance', binanceRoutes)
    app.route('/api/kraken', krakenRoutes)
+   app.route('/api/settings', settingsRoutes)
 
    return app
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,40 +1,11 @@
-import { Hono } from 'hono'
-import { cors } from 'hono/cors'
 import { existsSync, statSync } from 'fs'
 import path from 'path'
-import binanceRoutes from './routes/binance.js'
-import krakenRoutes from './routes/kraken.js'
+import { createApp } from './app.js'
 
 const PORT = parseInt(process.env.PORT ?? '3001', 10)
 const IS_PROD = process.env.NODE_ENV === 'production'
 
-const app = new Hono()
-
-// CORS for Vite dev server and Electrobun WebView
-app.use('/api/*', cors({
-   origin: (origin) => {
-      const allowed = ['http://localhost:3000', 'views://']
-      if (allowed.some(o => o.endsWith('://') ? origin.startsWith(o) : origin === o)) {
-         return origin
-      }
-      return null
-   }
-}))
-
-// Request logging
-app.use('*', async (c, next) => {
-   const start = Date.now()
-   await next()
-   const ms = Date.now() - start
-   const status = c.res.status
-   const color = status >= 500 ? '\x1b[31m' : status >= 400 ? '\x1b[33m' : '\x1b[32m'
-   const reset = '\x1b[0m'
-   console.log(`${color}${c.req.method} ${new URL(c.req.url).pathname} → ${status}${reset} (${ms}ms)`)
-})
-
-// API routes
-app.route('/api/binance', binanceRoutes)
-app.route('/api/kraken', krakenRoutes)
+const app = createApp()
 
 // Static file serving with SPA fallback (production only)
 if (IS_PROD) {

--- a/src/server/routes/binance.js
+++ b/src/server/routes/binance.js
@@ -3,13 +3,11 @@ import Big from 'big.js'
 import BinanceAPI from '../adapters/binance-api/adapter.js'
 import BinanceGatewayAPI from '../adapters/binance-gateway-api/adapter.js'
 import RateFinder from '../services/rate-finder.js'
+import { withCredentials } from './with-account.js'
 
 const app = new Hono()
 
-app.post('/aggregate-balance', async (c) => {
-
-   const { credentials } = await c.req.json()
-   if (!credentials) return c.json({ error: 'No API credentials provided.' }, 401)
+app.post('/aggregate-balance', async (c) => withCredentials(c, 'binance', async ({ credentials }) => {
 
    let spotBalance, stakingPositions, stakingProducts, tradingPairs, rates, assets
    try {
@@ -87,12 +85,9 @@ app.post('/aggregate-balance', async (c) => {
    })
 
    return c.json({ balance: aggregateBalance })
-})
+}))
 
-app.post('/balances', async (c) => {
-
-   const { credentials } = await c.req.json()
-   if (!credentials) return c.json({ error: 'No API credentials provided.' }, 401)
+app.post('/balances', async (c) => withCredentials(c, 'binance', async ({ credentials }) => {
 
    const binanceAPI = new BinanceAPI(credentials)
 
@@ -114,12 +109,9 @@ app.post('/balances', async (c) => {
       }, {})
 
    return c.json(balances)
-})
+}))
 
-app.post('/deposits', async (c) => {
-
-   const { credentials, fromDate } = await c.req.json()
-   if (!credentials) return c.json({ error: 'No API credentials provided.' }, 401)
+app.post('/deposits', async (c) => withCredentials(c, 'binance', async ({ body, credentials }) => {
 
    const binanceAPI = new BinanceAPI(credentials)
 
@@ -127,7 +119,7 @@ app.post('/deposits', async (c) => {
    const delay = ms => new Promise(r => setTimeout(r, ms))
 
    let hasNext = true
-   let currentFromDate = fromDate
+   let currentFromDate = body.fromDate
    let toDate = computeToDate(currentFromDate)
    const allDeposits = []
 
@@ -143,7 +135,7 @@ app.post('/deposits', async (c) => {
    }
 
    return c.json({ deposits: allDeposits })
-})
+}))
 
 app.get('/eoy-rates', async (c) => {
 

--- a/src/server/routes/kraken-ledger.js
+++ b/src/server/routes/kraken-ledger.js
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import LedgerRepository from '../db/ledger-repository.js'
 import TradeRepository from '../db/trade-repository.js'
 import tradeRoutes from './kraken-trades.js'
-import { handleError, withAccount } from './with-account.js'
+import { withAccount, withCredentials } from './with-account.js'
 import { dbSizeBytes } from '../db/paths.js'
 import { jobFor, isRunning, requestCancel, startSync } from '../services/kraken-ledger-sync.js'
 
@@ -12,22 +12,10 @@ const app = new Hono()
 // clear — and the page's post-sync revalidation matches on this prefix.
 app.route('/trades', tradeRoutes)
 
-app.post('/sync', async (c) => {
+app.post('/sync', async (c) => withCredentials(c, 'kraken', ({ body, credentials, accountId }) =>
+   c.json(startSync(accountId, credentials, body.mode === 'full' ? 'full' : 'incremental'))))
 
-   const { credentials, mode } = await c.req.json()
-   if (!credentials?.apiKey || !credentials?.apiSecret) {
-      return c.json({ error: 'No API credentials provided.' }, 401)
-   }
-
-   try {
-      return c.json(startSync(credentials, mode === 'full' ? 'full' : 'incremental'))
-   }
-   catch (error) {
-      return handleError(c, error)
-   }
-})
-
-app.post('/sync/status', async (c) => withAccount(c, ({ accountId }) => {
+app.get('/sync/status', async (c) => withAccount(c, ({ accountId }) => {
 
    const repository = new LedgerRepository(accountId)
    const tradeRepository = new TradeRepository(accountId)
@@ -58,16 +46,16 @@ app.post('/entries', async (c) => withAccount(c, ({ body, accountId }) =>
       pageSize: Math.min(500, Math.max(1, Number(body.pageSize) || 50))
    }))))
 
-app.post('/filters', async (c) => withAccount(c, ({ accountId }) =>
+app.get('/filters', async (c) => withAccount(c, ({ accountId }) =>
    c.json(new LedgerRepository(accountId).distinctFilters())))
 
 app.post('/fees', async (c) => withAccount(c, ({ body, accountId }) =>
    c.json(new LedgerRepository(accountId).feeSummary(body.filters))))
 
-app.post('/rewards', async (c) => withAccount(c, ({ accountId }) =>
+app.get('/rewards', async (c) => withAccount(c, ({ accountId }) =>
    c.json(new LedgerRepository(accountId).rewardSummary())))
 
-app.post('/balances', async (c) => withAccount(c, ({ accountId }) =>
+app.get('/balances', async (c) => withAccount(c, ({ accountId }) =>
    c.json(new LedgerRepository(accountId).balanceSummary())))
 
 app.post('/clear', async (c) => withAccount(c, ({ accountId }) => {

--- a/src/server/routes/kraken-trades.js
+++ b/src/server/routes/kraken-trades.js
@@ -24,7 +24,7 @@ app.post('/fills', async (c) => withAccount(c, ({ body, accountId }) =>
       pageSize: Math.min(500, Math.max(1, Number(body.pageSize) || 50))
    }))))
 
-app.post('/filters', async (c) => withAccount(c, ({ accountId }) =>
+app.get('/filters', async (c) => withAccount(c, ({ accountId }) =>
    c.json(new TradeRepository(accountId).distinctOrderFilters())))
 
 export default app

--- a/src/server/routes/kraken-xstocks.js
+++ b/src/server/routes/kraken-xstocks.js
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import KrakenAPI from '../adapters/kraken-api/adapter.js'
 import AnthropicAPI, { MODEL } from '../adapters/anthropic/adapter.js'
 import XStockRepository from '../db/xstock-repository.js'
-import { handleError } from './with-account.js'
+import { handleError, withCredentials } from './with-account.js'
 import seed from '../data/xstocks.json'
 
 const app = new Hono()
@@ -115,70 +115,57 @@ app.post('/listings', async (c) => {
    }
 })
 
-app.post('/classify', async (c) => {
+app.post('/classify', async (c) => withCredentials(c, 'anthropic', async ({ body, credentials }) => {
 
-   const { credentials, tickers = [] } = await c.req.json()
-   if (!credentials?.apiKey) return c.json({ error: 'No API credentials provided.' }, 401)
+   const { tickers = [] } = body
 
-   try {
-      const krakenAPI = new KrakenAPI()
-      const listings = await krakenAPI.fetchTokenizedListings()
-      const byTicker = new Map(listings.map(listing => [listing.ticker, listing]))
+   const krakenAPI = new KrakenAPI()
+   const listings = await krakenAPI.fetchTokenizedListings()
+   const byTicker = new Map(listings.map(listing => [listing.ticker, listing]))
 
-      const requested = resolveTickers(tickers, byTicker).filter(ticker => !seed.listings[ticker])
-      if (requested.length === 0) return c.json({ classified: [] })
+   const requested = resolveTickers(tickers, byTicker).filter(ticker => !seed.listings[ticker])
+   if (requested.length === 0) return c.json({ classified: [] })
 
-      const anthropicAPI = new AnthropicAPI(credentials.apiKey)
-      const returned = await anthropicAPI.classifyListings(requested)
-      const classified = reconcile(requested, returned, byTicker)
+   const anthropicAPI = new AnthropicAPI(credentials.apiKey)
+   const returned = await anthropicAPI.classifyListings(requested)
+   const classified = reconcile(requested, returned, byTicker)
 
-      new XStockRepository().upsertListings(classified, Date.now())
-      return c.json({ classified })
-   }
-   catch (error) {
-      return handleError(c, error)
-   }
-})
+   new XStockRepository().upsertListings(classified, Date.now())
+   return c.json({ classified })
+}, { secret: false }))
 
-app.post('/describe', async (c) => {
+app.post('/describe', async (c) => withCredentials(c, 'anthropic', async ({ body, credentials }) => {
 
-   const { credentials, tickers = [], wordCount: requestedWordCount } = await c.req.json()
-   if (!credentials?.apiKey) return c.json({ error: 'No API credentials provided.' }, 401)
+   const { tickers = [] } = body
+   const wordCount = asWordCount(body.wordCount)
 
-   const wordCount = asWordCount(requestedWordCount)
+   const krakenAPI = new KrakenAPI()
+   const listings = await krakenAPI.fetchTokenizedListings()
+   const byTicker = new Map(listings.map(listing => [listing.ticker, listing]))
 
-   try {
-      const krakenAPI = new KrakenAPI()
-      const listings = await krakenAPI.fetchTokenizedListings()
-      const byTicker = new Map(listings.map(listing => [listing.ticker, listing]))
+   const requested = resolveTickers(tickers, byTicker)
+   if (requested.length === 0) return c.json({ described: [], wordCount })
 
-      const requested = resolveTickers(tickers, byTicker)
-      if (requested.length === 0) return c.json({ described: [], wordCount })
+   const repository = new XStockRepository()
+   const stored = repository.findListings(requested)
 
-      const repository = new XStockRepository()
-      const stored = repository.findListings(requested)
+   const targets = requested.map(ticker => {
+      const base = seededListing(ticker) ?? stored.get(ticker)
+      return {
+         ticker,
+         name: base?.name ?? '',
+         exchange: base?.exchange ?? '',
+         type: base?.type ?? 'unknown',
+         subtype: base?.subtype ?? ''
+      }
+   })
 
-      const targets = requested.map(ticker => {
-         const base = seededListing(ticker) ?? stored.get(ticker)
-         return {
-            ticker,
-            name: base?.name ?? '',
-            exchange: base?.exchange ?? '',
-            type: base?.type ?? 'unknown',
-            subtype: base?.subtype ?? ''
-         }
-      })
+   const anthropicAPI = new AnthropicAPI(credentials.apiKey)
+   const described = (await anthropicAPI.describeListings(targets, wordCount))
+      .filter(item => item.description.trim())
 
-      const anthropicAPI = new AnthropicAPI(credentials.apiKey)
-      const described = (await anthropicAPI.describeListings(targets, wordCount))
-         .filter(item => item.description.trim())
-
-      repository.upsertDescriptions(described, wordCount, MODEL, Date.now())
-      return c.json({ described, wordCount })
-   }
-   catch (error) {
-      return handleError(c, error)
-   }
-})
+   repository.upsertDescriptions(described, wordCount, MODEL, Date.now())
+   return c.json({ described, wordCount })
+}, { secret: false }))
 
 export default app

--- a/src/server/routes/kraken.js
+++ b/src/server/routes/kraken.js
@@ -2,11 +2,10 @@ import { Hono } from 'hono'
 import KrakenAPI from '../adapters/kraken-api/adapter.js'
 import ledgerRoutes from './kraken-ledger.js'
 import xstockRoutes from './kraken-xstocks.js'
+import { handleError, withCredentials } from './with-account.js'
 
 const app = new Hono()
 
-// Mounted here rather than in the server entry points, which each declare their own
-// route table: adding it in only one of them would 404 in the other runtime.
 app.route('/ledger', ledgerRoutes)
 app.route('/xstocks', xstockRoutes)
 
@@ -14,55 +13,21 @@ app.route('/xstocks', xstockRoutes)
 // much of it an open order has already claimed. The Balances page reads everything
 // else from the database and asks for this on top, so a stale sync shows up as a
 // difference rather than as a wrong number.
-app.post('/balances', async (c) => {
+app.post('/balances', async (c) => withCredentials(c, 'kraken', async ({ credentials }) => {
 
-   const { credentials } = await c.req.json()
-   if (!credentials) return c.json({ error: 'No API credentials provided.' }, 401)
+   const krakenAPI = new KrakenAPI(credentials)
 
-   try {
-      const krakenAPI = new KrakenAPI(credentials)
+   // Sequentially rather than with Promise.all. The resource layer would queue them
+   // anyway — Kraken rejects private calls whose nonces arrive out of order — and
+   // asking for them one at a time says so at the call site.
+   const assets = await krakenAPI.fetchLiveBalances()
+   const openOrders = await krakenAPI.fetchOpenOrders()
 
-      // Sequentially rather than with Promise.all. The resource layer would queue them
-      // anyway — Kraken rejects private calls whose nonces arrive out of order — and
-      // asking for them one at a time says so at the call site.
-      const assets = await krakenAPI.fetchLiveBalances()
-      const openOrders = await krakenAPI.fetchOpenOrders()
+   return c.json({ fetchedAt: Date.now(), assets, openOrders })
+}))
 
-      return c.json({ fetchedAt: Date.now(), assets, openOrders })
-   }
-   catch (error) {
-      if (error.message === 'HTTP Requester Error') {
-         console.log('An error happened while contacting the Kraken API:', error.cause)
-         return c.json({ error: `An error happened while contacting the Kraken API: ${error.cause}` }, 500)
-      }
-      else {
-         console.error('An unexpected error happened:', error)
-         return c.json({ error: 'An unexpected error happened.' }, 500)
-      }
-   }
-})
-
-app.post('/order-batch', async (c) => {
-
-   const { credentials, ordersParams } = await c.req.json()
-   if (!credentials) return c.json({ error: 'No API credentials provided.' }, 401)
-
-   try {
-      const krakenAPI = new KrakenAPI(credentials)
-      const orders = await krakenAPI.createOrders(ordersParams)
-      return c.json(orders)
-   }
-   catch (error) {
-      if (error.message === 'HTTP Requester Error') {
-         console.log('An error happened while contacting the Kraken API:', error.cause)
-         return c.json({ error: `An error happened while contacting the Kraken API: ${error.cause}` }, 500)
-      }
-      else {
-         console.error('An unexpected error happened:', error)
-         return c.json({ error: 'An unexpected error happened.' }, 500)
-      }
-   }
-})
+app.post('/order-batch', async (c) => withCredentials(c, 'kraken', async ({ body, credentials }) =>
+   c.json(await new KrakenAPI(credentials).createOrders(body.ordersParams))))
 
 // Public data, so no credentials: the caller says which assets it holds, not who it is.
 app.post('/asset-rates', async (c) => {
@@ -74,14 +39,7 @@ app.post('/asset-rates', async (c) => {
       return c.json({ rates: await krakenAPI.fetchUsdRates(assets) })
    }
    catch (error) {
-      if (error.message === 'HTTP Requester Error') {
-         console.log('An error happened while contacting the Kraken API:', error.cause)
-         return c.json({ error: `An error happened while contacting the Kraken API: ${error.cause}` }, 500)
-      }
-      else {
-         console.error('An unexpected error happened:', error)
-         return c.json({ error: 'An unexpected error happened.' }, 500)
-      }
+      return handleError(c, error)
    }
 })
 
@@ -93,14 +51,7 @@ app.get('/trading-pairs', async (c) => {
       return c.json(tradingPairs)
    }
    catch (error) {
-      if (error.message === 'HTTP Requester Error') {
-         console.log('An error happened while contacting the Kraken API:', error.cause)
-         return c.json({ error: `An error happened while contacting the Kraken API: ${error.cause}` }, 500)
-      }
-      else {
-         console.error('An unexpected error happened:', error)
-         return c.json({ error: 'An unexpected error happened.' }, 500)
-      }
+      return handleError(c, error)
    }
 })
 

--- a/src/server/routes/settings.js
+++ b/src/server/routes/settings.js
@@ -5,16 +5,19 @@ const app = new Hono()
 
 const MASK = '*****'
 
-function maskSettings(settings) {
+// Only the Settings form has any use for the key itself; every other page reads the
+// booleans below. Withholding it by default keeps the plaintext out of the SWR cache
+// of all nine of them.
+function maskSettings(settings, { reveal = false } = {}) {
    const masked = { version: settings.version }
 
    for (const [id, { hasSecret }] of Object.entries(providers)) {
       const { apiKey, apiSecret, source } = settings[id]
 
       masked[id] = {
-         apiKey,
          source,
          hasSecret,
+         apiKey: reveal ? apiKey : (apiKey ? MASK : ''),
          apiSecret: hasSecret && apiSecret ? MASK : '',
          configured: Boolean(apiKey) && (!hasSecret || Boolean(apiSecret)),
          keyConfigured: Boolean(apiKey)
@@ -22,12 +25,12 @@ function maskSettings(settings) {
    }
 
    masked.kraken.accountId = settings.kraken.accountId
-   masked.kraken.keyPrefix = settings.kraken.apiKey.slice(0, 8)
 
    return masked
 }
 
-app.get('/', (c) => c.json(maskSettings(readSettings())))
+app.get('/', (c) =>
+   c.json(maskSettings(readSettings(), { reveal: c.req.query('reveal') === 'true' })))
 
 app.post('/', async (c) => {
    try {
@@ -38,7 +41,10 @@ app.post('/', async (c) => {
          const update = body?.[id]
          if (!update) continue
 
+         // A field still holding the mask was never edited, so saving must leave the
+         // stored value alone rather than overwrite it with the placeholder.
          updates[id] = { ...update }
+         if (updates[id].apiKey === MASK) delete updates[id].apiKey
          if (updates[id].apiSecret === MASK) delete updates[id].apiSecret
       }
 

--- a/src/server/routes/settings.js
+++ b/src/server/routes/settings.js
@@ -1,0 +1,53 @@
+import { Hono } from 'hono'
+import { providers, readSettings, writeSettings } from '../settings.js'
+
+const app = new Hono()
+
+const MASK = '*****'
+
+function maskSettings(settings) {
+   const masked = { version: settings.version }
+
+   for (const [id, { hasSecret }] of Object.entries(providers)) {
+      const { apiKey, apiSecret, source } = settings[id]
+
+      masked[id] = {
+         apiKey,
+         source,
+         hasSecret,
+         apiSecret: hasSecret && apiSecret ? MASK : '',
+         configured: Boolean(apiKey) && (!hasSecret || Boolean(apiSecret)),
+         keyConfigured: Boolean(apiKey)
+      }
+   }
+
+   masked.kraken.accountId = settings.kraken.accountId
+   masked.kraken.keyPrefix = settings.kraken.apiKey.slice(0, 8)
+
+   return masked
+}
+
+app.get('/', (c) => c.json(maskSettings(readSettings())))
+
+app.post('/', async (c) => {
+   try {
+      const body = await c.req.json()
+      const updates = {}
+
+      for (const id of Object.keys(providers)) {
+         const update = body?.[id]
+         if (!update) continue
+
+         updates[id] = { ...update }
+         if (updates[id].apiSecret === MASK) delete updates[id].apiSecret
+      }
+
+      return c.json(maskSettings(writeSettings(updates)))
+   }
+   catch (error) {
+      console.error('Could not save the settings:', error)
+      return c.json({ error: 'Could not save the settings.' }, 500)
+   }
+})
+
+export default app

--- a/src/server/routes/with-account.js
+++ b/src/server/routes/with-account.js
@@ -22,7 +22,7 @@ export async function withAccount(c, handler) {
    if (!accountId) return noCredentials(c)
 
    try {
-      return handler({ body: await readBody(c), accountId })
+      return await handler({ body: await readBody(c), accountId })
    }
    catch (error) {
       return handleError(c, error)

--- a/src/server/routes/with-account.js
+++ b/src/server/routes/with-account.js
@@ -1,4 +1,4 @@
-import { accountIdFor } from '../db/entry-key.js'
+import { credentialsFor, krakenAccountId } from '../settings.js'
 
 export function handleError(c, error) {
    if (error.message === 'HTTP Requester Error') {
@@ -9,15 +9,33 @@ export function handleError(c, error) {
    return c.json({ error: 'An unexpected error happened.' }, 500)
 }
 
-// Read endpoints never call Kraken; they only need the key to work out which
-// account's rows to read, which keeps the secret out of the SWR cache keys.
+const noCredentials = c => c.json({ error: 'No API credentials configured.' }, 401)
+
+const readBody = async c =>
+   c.req.method === 'GET' ? {} : await c.req.json().catch(() => ({}))
+
+// Read endpoints never call Kraken; they only need to know which account's rows to
+// read, and the stored settings answer that without the request carrying anything.
 export async function withAccount(c, handler) {
 
-   const body = await c.req.json()
-   if (!body.credentials?.apiKey) return c.json({ error: 'No API credentials provided.' }, 401)
+   const accountId = krakenAccountId()
+   if (!accountId) return noCredentials(c)
 
    try {
-      return handler({ body, accountId: accountIdFor(body.credentials.apiKey) })
+      return handler({ body: await readBody(c), accountId })
+   }
+   catch (error) {
+      return handleError(c, error)
+   }
+}
+
+export async function withCredentials(c, provider, handler, { secret = true } = {}) {
+
+   const credentials = credentialsFor(provider)
+   if (!credentials.apiKey || (secret && !credentials.apiSecret)) return noCredentials(c)
+
+   try {
+      return await handler({ body: await readBody(c), credentials, accountId: krakenAccountId() })
    }
    catch (error) {
       return handleError(c, error)

--- a/src/server/services/kraken-ledger-sync.js
+++ b/src/server/services/kraken-ledger-sync.js
@@ -1,7 +1,6 @@
 import KrakenAPI from '../adapters/kraken-api/adapter.js'
 import LedgerRepository from '../db/ledger-repository.js'
 import TradeRepository from '../db/trade-repository.js'
-import { accountIdFor } from '../db/entry-key.js'
 
 // Kraken can post a staking or earn entry dated a day or two in the past, so an
 // incremental sync re-reads a window behind the last entry it holds. Re-reading is
@@ -50,9 +49,8 @@ export function requestCancel(accountId) {
    return job ?? null
 }
 
-export function startSync(credentials, mode = 'incremental') {
+export function startSync(accountId, credentials, mode = 'incremental') {
 
-   const accountId = accountIdFor(credentials.apiKey)
    const existing = jobs.get(accountId)
 
    // A second request while a sync is running must not trigger another export:

--- a/src/server/settings.js
+++ b/src/server/settings.js
@@ -1,0 +1,103 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import path from 'path'
+import { resolveDataDir } from './db/paths.js'
+import { accountIdFor } from './db/entry-key.js'
+
+const SETTINGS_VERSION = 1
+
+export const providers = {
+   kraken: { hasSecret: true },
+   binance: { hasSecret: true },
+   anthropic: { hasSecret: false }
+}
+
+const defaults = () => ({
+   version: SETTINGS_VERSION,
+   kraken: { apiKey: '', apiSecret: '', accountId: '' },
+   binance: { apiKey: '', apiSecret: '' },
+   anthropic: { apiKey: '' }
+})
+
+function settingsPath() {
+   const name = process.env.NODE_ENV === 'production' ? 'settings.json' : 'settings-dev.json'
+   return path.join(resolveDataDir(), name)
+}
+
+function readStored() {
+   try {
+      const file = settingsPath()
+      if (!existsSync(file)) return {}
+      return JSON.parse(readFileSync(file, 'utf-8'))
+   }
+   catch (error) {
+      console.warn('Could not read the settings file, falling back to defaults:', error.message)
+      return {}
+   }
+}
+
+function envValue(provider, field) {
+   const name = `${provider.toUpperCase()}_${field === 'apiSecret' ? 'API_SECRET' : 'API_KEY'}`
+   return process.env[name] || process.env[`VITE_${name}`] || ''
+}
+
+export function readSettings() {
+   const stored = readStored()
+   const settings = defaults()
+   const environmentWins = process.env.NODE_ENV !== 'production'
+
+   for (const [id, { hasSecret }] of Object.entries(providers)) {
+      const saved = stored[id] ?? {}
+      const fromEnvironment = environmentWins ? envValue(id, 'apiKey') : ''
+
+      settings[id].apiKey = fromEnvironment || saved.apiKey || ''
+      settings[id].source = fromEnvironment ? 'env' : 'file'
+
+      if (hasSecret) {
+         settings[id].apiSecret = fromEnvironment
+            ? envValue(id, 'apiSecret')
+            : (saved.apiSecret || '')
+      }
+   }
+
+   settings.kraken.accountId = stored.kraken?.accountId
+      || (settings.kraken.apiKey ? accountIdFor(settings.kraken.apiKey) : '')
+
+   return settings
+}
+
+export function writeSettings(updates) {
+   const merged = { ...defaults(), ...readStored(), version: SETTINGS_VERSION }
+
+   for (const [id, { hasSecret }] of Object.entries(providers)) {
+      const update = updates?.[id]
+      if (!update) continue
+
+      merged[id] = { ...merged[id] }
+      if (typeof update.apiKey === 'string') merged[id].apiKey = update.apiKey.trim()
+      if (hasSecret && typeof update.apiSecret === 'string') merged[id].apiSecret = update.apiSecret.trim()
+   }
+
+   if (merged.kraken.apiKey && !merged.kraken.accountId) {
+      merged.kraken.accountId = accountIdFor(merged.kraken.apiKey)
+   }
+
+   const file = settingsPath()
+   mkdirSync(path.dirname(file), { recursive: true })
+   writeFileSync(file, JSON.stringify(merged, null, 3), { encoding: 'utf-8', mode: 0o600 })
+
+   return readSettings()
+}
+
+export function credentialsFor(provider) {
+   const { apiKey, apiSecret } = readSettings()[provider]
+   return { apiKey, apiSecret: apiSecret ?? '' }
+}
+
+export function hasCredentials(provider, { secret = false } = {}) {
+   const { apiKey, apiSecret } = credentialsFor(provider)
+   return Boolean(apiKey) && (!secret || Boolean(apiSecret))
+}
+
+export function krakenAccountId() {
+   return readSettings().kraken.accountId
+}

--- a/src/server/settings.js
+++ b/src/server/settings.js
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs'
 import path from 'path'
 import { resolveDataDir } from './db/paths.js'
 import { accountIdFor } from './db/entry-key.js'
@@ -47,20 +47,31 @@ export function readSettings() {
 
    for (const [id, { hasSecret }] of Object.entries(providers)) {
       const saved = stored[id] ?? {}
-      const fromEnvironment = environmentWins ? envValue(id, 'apiKey') : ''
 
-      settings[id].apiKey = fromEnvironment || saved.apiKey || ''
+      const environmentKey = environmentWins ? envValue(id, 'apiKey') : ''
+      const environmentSecret = environmentWins && hasSecret ? envValue(id, 'apiSecret') : ''
+
+      // Half a credential is not a credential. Exporting only the key would otherwise
+      // blank a secret sitting in the file and 401 every private call, while the
+      // Settings page went on showing a populated key.
+      const fromEnvironment = Boolean(environmentKey) && (!hasSecret || Boolean(environmentSecret))
+
+      settings[id].apiKey = fromEnvironment ? environmentKey : (saved.apiKey || '')
       settings[id].source = fromEnvironment ? 'env' : 'file'
 
       if (hasSecret) {
-         settings[id].apiSecret = fromEnvironment
-            ? envValue(id, 'apiSecret')
-            : (saved.apiSecret || '')
+         settings[id].apiSecret = fromEnvironment ? environmentSecret : (saved.apiSecret || '')
       }
    }
 
-   settings.kraken.accountId = stored.kraken?.accountId
-      || (settings.kraken.apiKey ? accountIdFor(settings.kraken.apiKey) : '')
+   // The stored id belongs to the stored key. A key from the environment is a
+   // different account, so it gets its own partition rather than syncing into
+   // whichever one the file happens to name.
+   settings.kraken.accountId = settings.kraken.apiKey === ''
+      ? ''
+      : settings.kraken.source === 'env'
+         ? accountIdFor(settings.kraken.apiKey)
+         : (stored.kraken?.accountId || accountIdFor(settings.kraken.apiKey))
 
    return settings
 }
@@ -81,9 +92,18 @@ export function writeSettings(updates) {
       merged.kraken.accountId = accountIdFor(merged.kraken.apiKey)
    }
 
+   // Written to a sibling and renamed over the target: a crash or a full disk part way
+   // through would otherwise truncate the file and take every provider's keys with it.
+   // The rename also carries the temp file's 0600 across, which a plain write would not
+   // — mode applies only when open(2) creates the file, so a target whose permissions
+   // had been widened elsewhere would keep them for every save after.
    const file = settingsPath()
+   const temporary = `${file}.tmp`
+
    mkdirSync(path.dirname(file), { recursive: true })
-   writeFileSync(file, JSON.stringify(merged, null, 3), { encoding: 'utf-8', mode: 0o600 })
+   writeFileSync(temporary, JSON.stringify(merged, null, 3), { encoding: 'utf-8', mode: 0o600 })
+   chmodSync(temporary, 0o600)
+   renameSync(temporary, file)
 
    return readSettings()
 }
@@ -91,11 +111,6 @@ export function writeSettings(updates) {
 export function credentialsFor(provider) {
    const { apiKey, apiSecret } = readSettings()[provider]
    return { apiKey, apiSecret: apiSecret ?? '' }
-}
-
-export function hasCredentials(provider, { secret = false } = {}) {
-   const { apiKey, apiSecret } = credentialsFor(provider)
-   return Boolean(apiKey) && (!secret || Boolean(apiSecret))
 }
 
 export function krakenAccountId() {

--- a/src/views/app.jsx
+++ b/src/views/app.jsx
@@ -19,7 +19,7 @@ export const isMockMode = import.meta.env.VITE_MOCK_DATA === 'true'
 const Router = window.location.protocol === 'views:' ? HashRouter : BrowserRouter
 // In Electrobun production, the page loads from views:// so relative /api paths won't reach
 // the Hono server. VITE_API_BASE is injected at build time by scripts/prebuild.ts.
-const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+export const API_BASE = import.meta.env.VITE_API_BASE ?? ''
 
 async function fetcher(key, params) {
 
@@ -29,16 +29,20 @@ async function fetcher(key, params) {
    const url = Array.isArray(key) ? key[0] : key
    const body = Array.isArray(key) ? key[1] : params?.arg
 
+   // A mutation is a POST even when it carries no body — triggering one with no
+   // argument still means "do this", not "read this".
+   const isMutation = params !== undefined && 'arg' in params
+
    if (isMockMode) {
       const { mockFetcher } = await import('./mocks')
-      return mockFetcher(url, body ? { arg: body } : undefined)
+      return mockFetcher(url, isMutation || body ? { arg: body } : undefined)
    }
 
    let response
-   if (body) {
+   if (isMutation || body) {
       response = await fetch(API_BASE + url, {
          method: 'POST',
-         body: JSON.stringify(body),
+         body: JSON.stringify(body ?? {}),
          headers: { 'Content-Type': 'application/json' }
       })
    }

--- a/src/views/components/lib/credentials-alert.jsx
+++ b/src/views/components/lib/credentials-alert.jsx
@@ -1,0 +1,24 @@
+import { Alert, AlertDescription } from '@/components/ui/alert'
+
+// Every page depends on the settings request now, so a server that is down must not
+// be reported as "you have no keys": that sends the user to a page which will fail
+// the same way and show empty fields for keys that are still on disk.
+export default function CredentialsAlert({ unreachable, children }) {
+
+   if (unreachable) {
+      return (
+         <Alert variant="destructive">
+            <AlertDescription>
+               Could not reach the local server, so your API keys could not be read. They are
+               still where you left them — start the app again, and this page will work.
+            </AlertDescription>
+         </Alert>
+      )
+   }
+
+   return (
+      <Alert>
+         <AlertDescription>{children}</AlertDescription>
+      </Alert>
+   )
+}

--- a/src/views/lib/migrate-credentials.js
+++ b/src/views/lib/migrate-credentials.js
@@ -31,8 +31,14 @@ export default async function migrateLegacyCredentials(apiBase = '') {
    const legacy = readLegacy()
    if (Object.keys(legacy).length === 0) return
 
+   // Bounded because main.jsx awaits this before mounting React: a server that accepts
+   // the connection but never answers would otherwise leave a blank window with nothing
+   // on screen to explain it. The legacy entries are only removed on success, so a
+   // timed-out migration simply runs again next launch.
+   const signal = AbortSignal.timeout(5000)
+
    try {
-      const response = await fetch(`${apiBase}/api/settings`)
+      const response = await fetch(`${apiBase}/api/settings`, { signal })
       if (!response.ok) return
 
       const settings = await response.json()
@@ -43,7 +49,8 @@ export default async function migrateLegacyCredentials(apiBase = '') {
          const saved = await fetch(`${apiBase}/api/settings`, {
             method: 'POST',
             body: JSON.stringify(updates),
-            headers: { 'Content-Type': 'application/json' }
+            headers: { 'Content-Type': 'application/json' },
+            signal
          })
          if (!saved.ok) return
 

--- a/src/views/lib/migrate-credentials.js
+++ b/src/views/lib/migrate-credentials.js
@@ -1,0 +1,58 @@
+const legacyEntries = {
+   binance: { apiKey: 'binance.api.key', apiSecret: 'binance.api.secret' },
+   kraken: { apiKey: 'kraken.api.key', apiSecret: 'kraken.api.secret' },
+   anthropic: { apiKey: 'anthropic.api.key' }
+}
+
+const readLegacy = () => Object.entries(legacyEntries).reduce((found, [provider, fields]) => {
+   const values = Object.entries(fields).reduce((entry, [field, key]) => {
+      const value = localStorage.getItem(key)
+      if (value) entry[field] = value
+      return entry
+   }, {})
+
+   if (values.apiKey) found[provider] = values
+   return found
+}, {})
+
+const forgetLegacy = () => Object.values(legacyEntries)
+   .flatMap(fields => Object.values(fields))
+   .forEach(key => localStorage.removeItem(key))
+
+// Keys used to live in this browser's local storage. They now belong to the server, so
+// the ones left behind are handed over once and then removed — an upgrade should not
+// cost the user their configuration, nor leave their secrets in the WebView's store.
+// A provider the server already knows about is left alone: what is on disk was entered
+// more recently than whatever this browser is still holding.
+export default async function migrateLegacyCredentials(apiBase = '') {
+
+   if (typeof window === 'undefined') return
+
+   const legacy = readLegacy()
+   if (Object.keys(legacy).length === 0) return
+
+   try {
+      const response = await fetch(`${apiBase}/api/settings`)
+      if (!response.ok) return
+
+      const settings = await response.json()
+      const updates = Object.fromEntries(Object.entries(legacy)
+         .filter(([provider]) => !settings[provider]?.keyConfigured))
+
+      if (Object.keys(updates).length > 0) {
+         const saved = await fetch(`${apiBase}/api/settings`, {
+            method: 'POST',
+            body: JSON.stringify(updates),
+            headers: { 'Content-Type': 'application/json' }
+         })
+         if (!saved.ok) return
+
+         console.log(`Moved ${Object.keys(updates).join(', ')} credentials out of local storage.`)
+      }
+
+      forgetLegacy()
+   }
+   catch (error) {
+      console.warn('Could not move the stored credentials to the server:', error.message)
+   }
+}

--- a/src/views/lib/use-persistent-state.js
+++ b/src/views/lib/use-persistent-state.js
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react'
+
+const isPlainObject = value =>
+   value !== null && typeof value === 'object' && !Array.isArray(value)
+
+// Merged over the default rather than replacing it, so a stored value written before a
+// new field existed keeps working instead of leaving that field undefined. revive runs
+// on the result either way, including when nothing was stored, so a caller can let
+// something outside storage — a URL parameter, say — have the last word.
+function read(key, defaultValue, revive) {
+   const stored = readStored(key, defaultValue)
+   return revive ? revive(stored, defaultValue) : stored
+}
+
+function readStored(key, defaultValue) {
+   if (typeof window === 'undefined') return defaultValue
+
+   try {
+      const saved = localStorage.getItem(key)
+      if (saved === null) return defaultValue
+
+      const parsed = JSON.parse(saved)
+      return isPlainObject(parsed) && isPlainObject(defaultValue)
+         ? { ...defaultValue, ...parsed }
+         : parsed
+   }
+   catch (error) {
+      console.warn(`Could not read ${key} from local storage:`, error.message)
+      return defaultValue
+   }
+}
+
+export default function usePersistentState(key, defaultValue, revive) {
+
+   const [value, setValue] = useState(() => read(key, defaultValue, revive))
+
+   useEffect(() => {
+      if (typeof window === 'undefined') return
+      try {
+         localStorage.setItem(key, JSON.stringify(value))
+      }
+      catch (error) {
+         console.warn(`Could not write ${key} to local storage:`, error.message)
+      }
+   }, [key, value])
+
+   return [value, setValue]
+}

--- a/src/views/lib/use-persistent-state.js
+++ b/src/views/lib/use-persistent-state.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 const isPlainObject = value =>
    value !== null && typeof value === 'object' && !Array.isArray(value)
@@ -33,9 +33,19 @@ function readStored(key, defaultValue) {
 export default function usePersistentState(key, defaultValue, revive) {
 
    const [value, setValue] = useState(() => read(key, defaultValue, revive))
+   const settled = useRef(false)
 
+   // Nothing is written on mount. The initial value is either what storage already
+   // holds or a default nobody has chosen, and writing it back would persist whatever
+   // revive layered on top — turning a one-off deep link into state the user has to
+   // clear by hand. Only a later change is the user's, and only that is saved.
    useEffect(() => {
+      if (!settled.current) {
+         settled.current = true
+         return
+      }
       if (typeof window === 'undefined') return
+
       try {
          localStorage.setItem(key, JSON.stringify(value))
       }

--- a/src/views/lib/use-settings.js
+++ b/src/views/lib/use-settings.js
@@ -1,0 +1,31 @@
+import useSWR from 'swr'
+
+export const SETTINGS_KEY = '/api/settings'
+
+export default function useSettings() {
+
+   const { data, error, isLoading, mutate } = useSWR(SETTINGS_KEY, { revalidateOnFocus: false })
+
+   return {
+      settings: data,
+      accountId: data?.kraken?.accountId ?? null,
+      isLoading,
+      error,
+      mutate
+   }
+}
+
+export function useProvider(provider) {
+
+   const { settings, isLoading, mutate } = useSettings()
+   const entry = settings?.[provider]
+
+   return {
+      configured: Boolean(entry?.configured),
+      keyConfigured: Boolean(entry?.keyConfigured),
+      accountId: settings?.kraken?.accountId ?? null,
+      source: entry?.source ?? 'file',
+      isLoading,
+      mutate
+   }
+}

--- a/src/views/lib/use-settings.js
+++ b/src/views/lib/use-settings.js
@@ -2,9 +2,13 @@ import useSWR from 'swr'
 
 export const SETTINGS_KEY = '/api/settings'
 
-export default function useSettings() {
+// The keys themselves are withheld unless asked for, so only the Settings form uses
+// this variant; everything else reads the booleans from the key above.
+export const SETTINGS_REVEAL_KEY = '/api/settings?reveal=true'
 
-   const { data, error, isLoading, mutate } = useSWR(SETTINGS_KEY, { revalidateOnFocus: false })
+export default function useSettings(key = SETTINGS_KEY) {
+
+   const { data, error, isLoading, mutate } = useSWR(key, { revalidateOnFocus: false })
 
    return {
       settings: data,
@@ -17,7 +21,7 @@ export default function useSettings() {
 
 export function useProvider(provider) {
 
-   const { settings, isLoading, mutate } = useSettings()
+   const { settings, error, isLoading, mutate } = useSettings()
    const entry = settings?.[provider]
 
    return {
@@ -25,6 +29,8 @@ export function useProvider(provider) {
       keyConfigured: Boolean(entry?.keyConfigured),
       accountId: settings?.kraken?.accountId ?? null,
       source: entry?.source ?? 'file',
+      unreachable: Boolean(error),
+      error,
       isLoading,
       mutate
    }

--- a/src/views/main.jsx
+++ b/src/views/main.jsx
@@ -1,10 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import App, { isMockMode } from './app'
+import App, { API_BASE, isMockMode } from './app'
+import migrateLegacyCredentials from './lib/migrate-credentials'
 
-if (isMockMode) {
-   const { initMockCredentials } = await import('./mocks')
-   initMockCredentials()
+if (!isMockMode) {
+   await migrateLegacyCredentials(API_BASE)
 }
 
 createRoot(document.getElementById('root')).render(

--- a/src/views/mocks/index.js
+++ b/src/views/mocks/index.js
@@ -31,25 +31,26 @@ const mockRoutes = {
    '/api/kraken/ledger/trades/fills': (params) => tradeFills(params?.arg),
    '/api/kraken/ledger/trades/filters': () => tradeFilters(),
    '/api/binance/aggregate-balance': () => aggregateBalance,
-   '/api/settings': () => mockSettings,
+   '/api/settings': () => mockSettings(false),
+   '/api/settings?reveal=true': () => mockSettings(true),
 }
 
-const mockSettings = {
+const mockSettings = (reveal) => ({
    version: 1,
    binance: {
-      apiKey: 'mock-binance-key', apiSecret: '*****', source: 'file',
+      apiKey: reveal ? 'mock-binance-key' : '*****', apiSecret: '*****', source: 'file',
       hasSecret: true, configured: true, keyConfigured: true
    },
    kraken: {
-      apiKey: 'mock-kraken-key', apiSecret: '*****', source: 'file',
+      apiKey: reveal ? 'mock-kraken-key' : '*****', apiSecret: '*****', source: 'file',
       hasSecret: true, configured: true, keyConfigured: true,
-      accountId: 'mock-account-id', keyPrefix: 'mock-kra'
+      accountId: 'mock-account-id'
    },
    anthropic: {
-      apiKey: 'mock-anthropic-key', apiSecret: '', source: 'file',
+      apiKey: reveal ? 'mock-anthropic-key' : '*****', apiSecret: '', source: 'file',
       hasSecret: false, configured: true, keyConfigured: true
    }
-}
+})
 
 export async function mockFetcher(url, params) {
    await new Promise(resolve => setTimeout(resolve, 300))

--- a/src/views/mocks/index.js
+++ b/src/views/mocks/index.js
@@ -31,6 +31,24 @@ const mockRoutes = {
    '/api/kraken/ledger/trades/fills': (params) => tradeFills(params?.arg),
    '/api/kraken/ledger/trades/filters': () => tradeFilters(),
    '/api/binance/aggregate-balance': () => aggregateBalance,
+   '/api/settings': () => mockSettings,
+}
+
+const mockSettings = {
+   version: 1,
+   binance: {
+      apiKey: 'mock-binance-key', apiSecret: '*****', source: 'file',
+      hasSecret: true, configured: true, keyConfigured: true
+   },
+   kraken: {
+      apiKey: 'mock-kraken-key', apiSecret: '*****', source: 'file',
+      hasSecret: true, configured: true, keyConfigured: true,
+      accountId: 'mock-account-id', keyPrefix: 'mock-kra'
+   },
+   anthropic: {
+      apiKey: 'mock-anthropic-key', apiSecret: '', source: 'file',
+      hasSecret: false, configured: true, keyConfigured: true
+   }
 }
 
 export async function mockFetcher(url, params) {
@@ -41,22 +59,4 @@ export async function mockFetcher(url, params) {
 
    console.warn(`[mock] No mock data for ${url}`)
    return {}
-}
-
-export function initMockCredentials() {
-   if (typeof window === 'undefined') return
-
-   const keys = {
-      'binance.api.key': 'mock-binance-key',
-      'binance.api.secret': 'mock-binance-secret',
-      'kraken.api.key': 'mock-kraken-key',
-      'kraken.api.secret': 'mock-kraken-secret',
-      'anthropic.api.key': 'mock-anthropic-key',
-   }
-
-   for (const [key, value] of Object.entries(keys)) {
-      if (!localStorage.getItem(key)) {
-         localStorage.setItem(key, value)
-      }
-   }
 }

--- a/src/views/pages/binance/staking.jsx
+++ b/src/views/pages/binance/staking.jsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { Link } from 'react-router'
 import useSWRMutation from 'swr/mutation'
 import { Loader2Icon, RefreshCwIcon } from 'lucide-react'
@@ -7,6 +6,7 @@ import InfoBanner from '../../components/lib/info-banner'
 import CurrentPositions from '../../components/binance/current-positions'
 import NextRedemptions from '../../components/binance/next-redemptions'
 import StakingProducts from '../../components/binance/staking-products'
+import { useProvider } from '../../lib/use-settings'
 import { Button } from '@/components/ui/button'
 import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -16,14 +16,11 @@ export default function BinanceStaking() {
 
    const { data, error, isMutating, trigger } = useSWRMutation('/api/binance/aggregate-balance')
 
-   const [credentials] = useState(() => ({
-      apiKey: (typeof window !== 'undefined' && localStorage.getItem('binance.api.key')) || '',
-      apiSecret: (typeof window !== 'undefined' && localStorage.getItem('binance.api.secret')) || ''
-   }))
+   const { configured, isLoading: isLoadingSettings } = useProvider('binance')
 
-   const fetchData = () => trigger({ credentials }).catch(() => {})
+   const fetchData = () => trigger().catch(() => {})
 
-   if (!credentials.apiKey || !credentials.apiSecret) {
+   if (!isLoadingSettings && !configured) {
       return (
          <BinanceLayout name="Staking">
             <Alert>

--- a/src/views/pages/binance/staking.jsx
+++ b/src/views/pages/binance/staking.jsx
@@ -7,6 +7,7 @@ import CurrentPositions from '../../components/binance/current-positions'
 import NextRedemptions from '../../components/binance/next-redemptions'
 import StakingProducts from '../../components/binance/staking-products'
 import { useProvider } from '../../lib/use-settings'
+import CredentialsAlert from '../../components/lib/credentials-alert'
 import { Button } from '@/components/ui/button'
 import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -16,22 +17,20 @@ export default function BinanceStaking() {
 
    const { data, error, isMutating, trigger } = useSWRMutation('/api/binance/aggregate-balance')
 
-   const { configured, isLoading: isLoadingSettings } = useProvider('binance')
+   const { configured, unreachable, isLoading: isLoadingSettings } = useProvider('binance')
 
    const fetchData = () => trigger().catch(() => {})
 
-   if (!isLoadingSettings && !configured) {
+   if (!isLoadingSettings && (unreachable || !configured)) {
       return (
          <BinanceLayout name="Staking">
-            <Alert>
-               <AlertDescription>
-                  Generate an API key and secret on Binance and add them in{' '}
-                  <Link to="/settings" className="font-medium text-foreground underline underline-offset-4">
-                     Settings
-                  </Link>{' '}
-                  to fetch your staking positions.
-               </AlertDescription>
-            </Alert>
+            <CredentialsAlert unreachable={unreachable}>
+               Generate an API key and secret on Binance and add them in{' '}
+               <Link to="/settings" className="font-medium text-foreground underline underline-offset-4">
+                  Settings
+               </Link>{' '}
+               to fetch your staking positions.
+            </CredentialsAlert>
          </BinanceLayout>
       )
    }

--- a/src/views/pages/home.jsx
+++ b/src/views/pages/home.jsx
@@ -1,16 +1,15 @@
-import { useState } from 'react'
 import { Link } from 'react-router'
 import { KeyRoundIcon } from 'lucide-react'
 import Layout from '../components/layout'
+import useSettings from '../lib/use-settings'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
 import { toolGroups } from '@/lib/tools'
 
 export default function Home() {
 
-   const [hasApiKeys] = useState(() => Boolean(
-      typeof window !== 'undefined'
-         && (localStorage.getItem('kraken.api.key') || localStorage.getItem('binance.api.key'))))
+   const { settings, isLoading } = useSettings()
+   const hasApiKeys = Boolean(settings?.kraken.keyConfigured || settings?.binance.keyConfigured)
 
    return (
       <Layout name="Home">
@@ -24,7 +23,7 @@ export default function Home() {
                </p>
             </section>
 
-            {!hasApiKeys &&
+            {!isLoading && !hasApiKeys &&
                <Alert>
                   <KeyRoundIcon />
                   <AlertDescription>

--- a/src/views/pages/kraken/balances.jsx
+++ b/src/views/pages/kraken/balances.jsx
@@ -12,42 +12,39 @@ import BalanceTable from '../../components/kraken/balance-table'
 import { defaultFilters } from '../../components/kraken/balance-filters'
 import { asCount } from '../../components/lib/filter-options'
 import { isJobRunning } from '../../components/kraken/sync-status'
+import { useProvider } from '../../lib/use-settings'
+import usePersistentState from '../../lib/use-persistent-state'
 import { Alert, AlertDescription } from '@/components/ui/alert'
+
+const BALANCES_KEY = '/api/kraken/ledger/balances'
 
 
 export default function KrakenBalances() {
 
-   const [credentials] = useState(() => ({
-      apiKey: (typeof window !== 'undefined' && localStorage.getItem('kraken.api.key')) || '',
-      apiSecret: (typeof window !== 'undefined' && localStorage.getItem('kraken.api.secret')) || ''
-   }))
+   const { configured, isLoading: isLoadingSettings } = useProvider('kraken')
 
-   const [filters, setFilters] = useState(defaultFilters)
+   const [filters, setFilters] = usePersistentState('kraken.balances.filters', defaultFilters)
 
    const wasRunningRef = useRef(false)
    const { mutate } = useSWRConfig()
 
-   // The balances themselves come from the ledger the Ledger tab downloaded, so the
-   // secret is not sent with them, and the rates on top are public data.
-   const account = credentials.apiKey ? { apiKey: credentials.apiKey } : null
-
    // A sync is started on the Ledger page but rewrites the balances read here, so the
    // run is followed and the summary revalidated when it lands.
    const { data: status } = useSWR(
-      account ? ['/api/kraken/ledger/sync/status', { credentials: account }] : null,
+      configured ? '/api/kraken/ledger/sync/status' : null,
       {
          refreshInterval: latest => isJobRunning(latest?.job) ? 1500 : 0,
          onSuccess: (latest) => {
             const running = isJobRunning(latest?.job)
             if (!running && wasRunningRef.current) {
-               mutate(key => Array.isArray(key) && key[0] === '/api/kraken/ledger/balances')
+               mutate(BALANCES_KEY)
             }
             wasRunningRef.current = running
          }
       })
 
    const { data: balances, error, isLoading } = useSWR(
-      account ? ['/api/kraken/ledger/balances', { credentials: account }] : null,
+      configured ? BALANCES_KEY : null,
       { keepPreviousData: true })
 
    // Asked for separately, and only once the assets are known, so the table renders
@@ -59,14 +56,14 @@ export default function KrakenBalances() {
       { keepPreviousData: true })
 
    // What Kraken says right now: the totals to check the stored ledger against, and the
-   // open orders holding part of it. This is the one call that needs the secret, so it
-   // stays a mutation — a useSWR key would put the secret in the cache key, which is why
-   // every other read on these pages sends the api key alone. Triggered on mount rather
-   // than left to a button, so the page is complete without being asked twice.
+   // open orders holding part of it. It stays a mutation because it is the one call here
+   // that reaches the exchange, and reaching it should be an action rather than something
+   // a revalidation can repeat. Triggered on mount rather than left to a button, so the
+   // page is complete without being asked twice.
    const { data: live, error: liveError, trigger, isMutating } = useSWRMutation('/api/kraken/balances')
 
-   const canCheckLive = Boolean(credentials.apiKey && credentials.apiSecret)
-   const checkLive = () => trigger({ credentials }).catch(() => {})
+   const canCheckLive = configured
+   const checkLive = () => trigger().catch(() => {})
 
    // Guarded because StrictMode runs this twice in development, and each run costs two
    // private calls against Kraken's rate limit. The button below is unaffected: it
@@ -79,7 +76,7 @@ export default function KrakenBalances() {
       checkLive()
    }, [canCheckLive])
 
-   if (!credentials.apiKey) {
+   if (!isLoadingSettings && !configured) {
       return (
          <KrakenLayout name="Balances">
             <Alert>

--- a/src/views/pages/kraken/balances.jsx
+++ b/src/views/pages/kraken/balances.jsx
@@ -13,6 +13,7 @@ import { defaultFilters } from '../../components/kraken/balance-filters'
 import { asCount } from '../../components/lib/filter-options'
 import { isJobRunning } from '../../components/kraken/sync-status'
 import { useProvider } from '../../lib/use-settings'
+import CredentialsAlert from '../../components/lib/credentials-alert'
 import usePersistentState from '../../lib/use-persistent-state'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 
@@ -21,7 +22,7 @@ const BALANCES_KEY = '/api/kraken/ledger/balances'
 
 export default function KrakenBalances() {
 
-   const { configured, isLoading: isLoadingSettings } = useProvider('kraken')
+   const { configured, unreachable, isLoading: isLoadingSettings } = useProvider('kraken')
 
    const [filters, setFilters] = usePersistentState('kraken.balances.filters', defaultFilters)
 
@@ -76,14 +77,12 @@ export default function KrakenBalances() {
       checkLive()
    }, [canCheckLive])
 
-   if (!isLoadingSettings && !configured) {
+   if (!isLoadingSettings && (unreachable || !configured)) {
       return (
          <KrakenLayout name="Balances">
-            <Alert>
-               <AlertDescription>
-                  Generate an API key and secret on Kraken and add them in Settings to sync your ledger.
-               </AlertDescription>
-            </Alert>
+            <CredentialsAlert unreachable={unreachable}>
+               Generate an API key and secret on Kraken and add them in Settings to sync your ledger.
+            </CredentialsAlert>
          </KrakenLayout>
       )
    }

--- a/src/views/pages/kraken/closed-orders.jsx
+++ b/src/views/pages/kraken/closed-orders.jsx
@@ -9,10 +9,10 @@ import OrderFilters, { defaultFilters } from '../../components/kraken/order-filt
 import OrderTable from '../../components/kraken/order-table'
 import { isJobRunning } from '../../components/kraken/sync-status'
 import { useProvider } from '../../lib/use-settings'
+import CredentialsAlert from '../../components/lib/credentials-alert'
 import usePersistentState from '../../lib/use-persistent-state'
 import { asCount } from '../../components/lib/filter-options'
 import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
-import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 
 const PAGE_SIZE = 20
@@ -20,19 +20,22 @@ const PAGE_SIZE = 20
 
 export default function KrakenClosedOrders() {
 
-   const { configured, accountId, isLoading: isLoadingSettings } = useProvider('kraken')
+   const { configured, accountId, unreachable, isLoading: isLoadingSettings } = useProvider('kraken')
 
    // ?order=… arrives from the Ledger page's Trades tab, where a fill links to the
-   // order it belongs to. Read once as the initial filter, taking precedence over what
-   // was remembered: after that the filter bar owns the value, and rewriting it from
-   // the URL would fight with it.
+   // order it belongs to. Read once as the initial filter: after that the filter bar
+   // owns the value, and rewriting it from the URL would fight with it. It replaces
+   // the remembered filters rather than layering over them — a remembered pair,
+   // direction or date range can exclude the very order being linked to, and the link
+   // has to resolve. usePersistentState does not write on mount, so following one link
+   // does not leave the order id sitting in the search box on every later visit.
    const [searchParams] = useSearchParams()
    const order = searchParams.get('order')
 
    const [filters, setFilters] = usePersistentState(
       'kraken.closedOrders.filters',
       defaultFilters,
-      stored => order ? { ...stored, search: order } : stored)
+      stored => order ? { ...defaultFilters, search: order } : stored)
 
    const [filtersKey, setFiltersKey] = useState(0)
    const [sort, setSort] = usePersistentState(
@@ -66,14 +69,12 @@ export default function KrakenClosedOrders() {
       configured ? ['/api/kraken/ledger/trades/orders', { accountId, filters, sort, page, pageSize: PAGE_SIZE }] : null,
       { keepPreviousData: true })
 
-   if (!isLoadingSettings && !configured) {
+   if (!isLoadingSettings && (unreachable || !configured)) {
       return (
          <KrakenLayout name="Closed Orders">
-            <Alert>
-               <AlertDescription>
-                  Generate an API key and secret on Kraken and add them in Settings to see your orders.
-               </AlertDescription>
-            </Alert>
+            <CredentialsAlert unreachable={unreachable}>
+               Generate an API key and secret on Kraken and add them in Settings to see your orders.
+            </CredentialsAlert>
          </KrakenLayout>
       )
    }

--- a/src/views/pages/kraken/closed-orders.jsx
+++ b/src/views/pages/kraken/closed-orders.jsx
@@ -8,6 +8,8 @@ import SyncStatusStrip from '../../components/kraken/sync-status-strip'
 import OrderFilters, { defaultFilters } from '../../components/kraken/order-filters'
 import OrderTable from '../../components/kraken/order-table'
 import { isJobRunning } from '../../components/kraken/sync-status'
+import { useProvider } from '../../lib/use-settings'
+import usePersistentState from '../../lib/use-persistent-state'
 import { asCount } from '../../components/lib/filter-options'
 import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -18,54 +20,53 @@ const PAGE_SIZE = 20
 
 export default function KrakenClosedOrders() {
 
-   const [credentials] = useState(() => ({
-      apiKey: (typeof window !== 'undefined' && localStorage.getItem('kraken.api.key')) || ''
-   }))
+   const { configured, accountId, isLoading: isLoadingSettings } = useProvider('kraken')
 
    // ?order=… arrives from the Ledger page's Trades tab, where a fill links to the
-   // order it belongs to. Read once as the initial filter: after that the filter bar
-   // owns the value, and rewriting it from the URL would fight with it.
+   // order it belongs to. Read once as the initial filter, taking precedence over what
+   // was remembered: after that the filter bar owns the value, and rewriting it from
+   // the URL would fight with it.
    const [searchParams] = useSearchParams()
-   const [filters, setFilters] = useState(() => {
-      const order = searchParams.get('order')
-      return order ? { ...defaultFilters, search: order } : defaultFilters
-   })
+   const order = searchParams.get('order')
+
+   const [filters, setFilters] = usePersistentState(
+      'kraken.closedOrders.filters',
+      defaultFilters,
+      stored => order ? { ...stored, search: order } : stored)
 
    const [filtersKey, setFiltersKey] = useState(0)
-   const [sort, setSort] = useState({ column: 'time', direction: 'desc' })
+   const [sort, setSort] = usePersistentState(
+      'kraken.closedOrders.sort',
+      { column: 'time', direction: 'desc' })
    const [page, setPage] = useState(0)
 
    const wasRunningRef = useRef(false)
    const { mutate } = useSWRConfig()
 
-   // Only the key is sent: these endpoints never contact Kraken, and it keeps the
-   // secret out of the SWR cache keys.
-   const account = credentials.apiKey ? { apiKey: credentials.apiKey } : null
-
    // A sync is started on the Ledger page, but it writes the trades this page reads,
    // so the run is followed here too and the orders are revalidated when it lands.
    const { data: status } = useSWR(
-      account ? ['/api/kraken/ledger/sync/status', { credentials: account }] : null,
+      configured ? '/api/kraken/ledger/sync/status' : null,
       {
          refreshInterval: latest => isJobRunning(latest?.job) ? 1500 : 0,
          onSuccess: (latest) => {
             const running = isJobRunning(latest?.job)
             if (!running && wasRunningRef.current) {
-               mutate(key => Array.isArray(key)
-                  && String(key[0]).startsWith('/api/kraken/ledger/trades/'))
+               mutate(key => String(Array.isArray(key) ? key[0] : key)
+                  .startsWith('/api/kraken/ledger/trades/'))
             }
             wasRunningRef.current = running
          }
       })
 
    const { data: filterOptions } = useSWR(
-      account ? ['/api/kraken/ledger/trades/filters', { credentials: account }] : null)
+      configured ? '/api/kraken/ledger/trades/filters' : null)
 
    const { data: orders, isLoading } = useSWR(
-      account ? ['/api/kraken/ledger/trades/orders', { credentials: account, filters, sort, page, pageSize: PAGE_SIZE }] : null,
+      configured ? ['/api/kraken/ledger/trades/orders', { accountId, filters, sort, page, pageSize: PAGE_SIZE }] : null,
       { keepPreviousData: true })
 
-   if (!credentials.apiKey) {
+   if (!isLoadingSettings && !configured) {
       return (
          <KrakenLayout name="Closed Orders">
             <Alert>

--- a/src/views/pages/kraken/fees.jsx
+++ b/src/views/pages/kraken/fees.jsx
@@ -7,6 +7,8 @@ import FeeSummaryCard from '../../components/kraken/fee-summary-card'
 import FeeChartCard from '../../components/kraken/fee-chart-card'
 import FeeBreakdownCard from '../../components/kraken/fee-breakdown-card'
 import { defaultFilters } from '../../components/kraken/ledger-filters'
+import { useProvider } from '../../lib/use-settings'
+import usePersistentState from '../../lib/use-persistent-state'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 
 const isUnfiltered = filters => Object.keys(defaultFilters)
@@ -15,27 +17,21 @@ const isUnfiltered = filters => Object.keys(defaultFilters)
 
 export default function KrakenFees() {
 
-   const [credentials] = useState(() => ({
-      apiKey: (typeof window !== 'undefined' && localStorage.getItem('kraken.api.key')) || ''
-   }))
+   const { configured, accountId, isLoading: isLoadingSettings } = useProvider('kraken')
 
-   const [filters, setFilters] = useState(defaultFilters)
+   const [filters, setFilters] = usePersistentState('kraken.fees.filters', defaultFilters)
    const [filtersKey, setFiltersKey] = useState(0)
    const [asset, setAsset] = useState(null)
-   const [granularity, setGranularity] = useState('month')
-
-   // This page never contacts Kraken — it only reads the ledger the Ledger tab
-   // already downloaded — so the secret is neither needed nor sent.
-   const account = credentials.apiKey ? { apiKey: credentials.apiKey } : null
+   const [granularity, setGranularity] = usePersistentState('kraken.fees.granularity', 'month')
 
    const { data: fees, error, isLoading } = useSWR(
-      account ? ['/api/kraken/ledger/fees', { credentials: account, filters }] : null,
+      configured ? ['/api/kraken/ledger/fees', { accountId, filters }] : null,
       { keepPreviousData: true })
 
    const { data: filterOptions } = useSWR(
-      account ? ['/api/kraken/ledger/filters', { credentials: account }] : null)
+      configured ? '/api/kraken/ledger/filters' : null)
 
-   if (!credentials.apiKey) {
+   if (!isLoadingSettings && !configured) {
       return (
          <KrakenLayout name="Fees">
             <Alert>

--- a/src/views/pages/kraken/fees.jsx
+++ b/src/views/pages/kraken/fees.jsx
@@ -8,6 +8,7 @@ import FeeChartCard from '../../components/kraken/fee-chart-card'
 import FeeBreakdownCard from '../../components/kraken/fee-breakdown-card'
 import { defaultFilters } from '../../components/kraken/ledger-filters'
 import { useProvider } from '../../lib/use-settings'
+import CredentialsAlert from '../../components/lib/credentials-alert'
 import usePersistentState from '../../lib/use-persistent-state'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 
@@ -17,7 +18,7 @@ const isUnfiltered = filters => Object.keys(defaultFilters)
 
 export default function KrakenFees() {
 
-   const { configured, accountId, isLoading: isLoadingSettings } = useProvider('kraken')
+   const { configured, accountId, unreachable, isLoading: isLoadingSettings } = useProvider('kraken')
 
    const [filters, setFilters] = usePersistentState('kraken.fees.filters', defaultFilters)
    const [filtersKey, setFiltersKey] = useState(0)
@@ -31,14 +32,12 @@ export default function KrakenFees() {
    const { data: filterOptions } = useSWR(
       configured ? '/api/kraken/ledger/filters' : null)
 
-   if (!isLoadingSettings && !configured) {
+   if (!isLoadingSettings && (unreachable || !configured)) {
       return (
          <KrakenLayout name="Fees">
-            <Alert>
-               <AlertDescription>
-                  Generate an API key and secret on Kraken and add them in Settings to sync your ledger.
-               </AlertDescription>
-            </Alert>
+            <CredentialsAlert unreachable={unreachable}>
+               Generate an API key and secret on Kraken and add them in Settings to sync your ledger.
+            </CredentialsAlert>
          </KrakenLayout>
       )
    }

--- a/src/views/pages/kraken/ledger.jsx
+++ b/src/views/pages/kraken/ledger.jsx
@@ -11,6 +11,7 @@ import OrderFilters, { defaultFilters as defaultTradeFilters } from '../../compo
 import TradeTable from '../../components/kraken/trade-table'
 import { isJobRunning } from '../../components/kraken/sync-status'
 import { useProvider } from '../../lib/use-settings'
+import CredentialsAlert from '../../components/lib/credentials-alert'
 import usePersistentState from '../../lib/use-persistent-state'
 import { asCount } from '../../components/lib/filter-options'
 import { Card, CardHeader, CardAction, CardContent } from '@/components/ui/card'
@@ -25,7 +26,7 @@ const defaultSort = { column: 'time', direction: 'desc' }
 
 export default function KrakenLedger() {
 
-   const { configured, accountId, isLoading: isLoadingSettings } = useProvider('kraken')
+   const { configured, accountId, unreachable, isLoading: isLoadingSettings } = useProvider('kraken')
 
    // One tab per table the sync writes, so the page shows exactly what it stores.
    const [tab, setTab] = usePersistentState('kraken.ledger.tab', 'entries')
@@ -108,14 +109,12 @@ export default function KrakenLedger() {
    const job = status?.job
    const running = isJobRunning(job)
 
-   if (!isLoadingSettings && !configured) {
+   if (!isLoadingSettings && (unreachable || !configured)) {
       return (
          <KrakenLayout name="Ledger">
-            <Alert>
-               <AlertDescription>
-                  Generate an API key and secret on Kraken and add them in Settings to sync your ledger.
-               </AlertDescription>
-            </Alert>
+            <CredentialsAlert unreachable={unreachable}>
+               Generate an API key and secret on Kraken and add them in Settings to sync your ledger.
+            </CredentialsAlert>
          </KrakenLayout>
       )
    }

--- a/src/views/pages/kraken/ledger.jsx
+++ b/src/views/pages/kraken/ledger.jsx
@@ -10,6 +10,8 @@ import LedgerTable from '../../components/kraken/ledger-table'
 import OrderFilters, { defaultFilters as defaultTradeFilters } from '../../components/kraken/order-filters'
 import TradeTable from '../../components/kraken/trade-table'
 import { isJobRunning } from '../../components/kraken/sync-status'
+import { useProvider } from '../../lib/use-settings'
+import usePersistentState from '../../lib/use-persistent-state'
 import { asCount } from '../../components/lib/filter-options'
 import { Card, CardHeader, CardAction, CardContent } from '@/components/ui/card'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
@@ -17,28 +19,29 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 
 const PAGE_SIZE = 20
+const SYNC_STATUS_KEY = '/api/kraken/ledger/sync/status'
+const defaultSort = { column: 'time', direction: 'desc' }
 
 
 export default function KrakenLedger() {
 
-   const [credentials] = useState(() => ({
-      apiKey: (typeof window !== 'undefined' && localStorage.getItem('kraken.api.key')) || '',
-      apiSecret: (typeof window !== 'undefined' && localStorage.getItem('kraken.api.secret')) || ''
-   }))
+   const { configured, accountId, isLoading: isLoadingSettings } = useProvider('kraken')
 
    // One tab per table the sync writes, so the page shows exactly what it stores.
-   const [tab, setTab] = useState('entries')
+   const [tab, setTab] = usePersistentState('kraken.ledger.tab', 'entries')
 
-   const [filters, setFilters] = useState(defaultFilters)
+   // Filters, sorting and the open tab are remembered; the page number is not, because
+   // a stored page against a table that has since changed is a worse start than the top.
+   const [filters, setFilters] = usePersistentState('kraken.ledger.filters', defaultFilters)
    const [filtersKey, setFiltersKey] = useState(0)
-   const [sort, setSort] = useState({ column: 'time', direction: 'desc' })
+   const [sort, setSort] = usePersistentState('kraken.ledger.sort', defaultSort)
    const [page, setPage] = useState(0)
 
    // The trades tab filters on different columns and sorts on its own, so it keeps its
    // own state rather than sharing the ledger's and resetting it on every switch.
-   const [tradeFilters, setTradeFilters] = useState(defaultTradeFilters)
+   const [tradeFilters, setTradeFilters] = usePersistentState('kraken.ledger.tradeFilters', defaultTradeFilters)
    const [tradeFiltersKey, setTradeFiltersKey] = useState(0)
-   const [tradeSort, setTradeSort] = useState({ column: 'time', direction: 'desc' })
+   const [tradeSort, setTradeSort] = usePersistentState('kraken.ledger.tradeSort', defaultSort)
    const [tradePage, setTradePage] = useState(0)
 
    const [wasInterrupted, setWasInterrupted] = useState(false)
@@ -46,23 +49,19 @@ export default function KrakenLedger() {
    const startedRef = useRef(false)
    const { mutate } = useSWRConfig()
 
-   // Only the key is sent to the read endpoints: they never contact Kraken, and it
-   // keeps the secret out of the SWR cache keys.
-   const account = credentials.apiKey ? { apiKey: credentials.apiKey } : null
-
    // Everything the sync writes to, but not the sync endpoints themselves, which
    // would otherwise revalidate in a loop from the callback below.
-   const refreshStoredData = () => mutate(key =>
-      Array.isArray(key)
-      && String(key[0]).startsWith('/api/kraken/ledger/')
-      && !String(key[0]).startsWith('/api/kraken/ledger/sync'))
+   const refreshStoredData = () => mutate(key => {
+      const url = String(Array.isArray(key) ? key[0] : key)
+      return url.startsWith('/api/kraken/ledger/') && !url.startsWith('/api/kraken/ledger/sync')
+   })
 
    // The interval is a function of the latest response, so polling stops by itself
    // as soon as the job reaches a terminal phase. Reacting to the run finishing
    // belongs here rather than in an effect: it is a response to an external event,
    // not state being synchronised.
    const { data: status } = useSWR(
-      account ? ['/api/kraken/ledger/sync/status', { credentials: account }] : null,
+      configured ? SYNC_STATUS_KEY : null,
       {
          refreshInterval: latest => isJobRunning(latest?.job) ? 1500 : 0,
          onSuccess: (latest) => {
@@ -82,10 +81,10 @@ export default function KrakenLedger() {
       })
 
    const { data: filterOptions } = useSWR(
-      account ? ['/api/kraken/ledger/filters', { credentials: account }] : null)
+      configured ? '/api/kraken/ledger/filters' : null)
 
    const { data: entries, isLoading } = useSWR(
-      account ? ['/api/kraken/ledger/entries', { credentials: account, filters, sort, page, pageSize: PAGE_SIZE }] : null,
+      configured ? ['/api/kraken/ledger/entries', { accountId, filters, sort, page, pageSize: PAGE_SIZE }] : null,
       { keepPreviousData: true })
 
    // Fetched only once the tab is open — most visits here are to sync, not to read
@@ -93,12 +92,12 @@ export default function KrakenLedger() {
    const showTrades = tab === 'trades'
 
    const { data: tradeFilterOptions } = useSWR(
-      account && showTrades ? ['/api/kraken/ledger/trades/filters', { credentials: account }] : null)
+      configured && showTrades ? '/api/kraken/ledger/trades/filters' : null)
 
    const { data: trades, isLoading: isLoadingTrades } = useSWR(
-      account && showTrades
+      configured && showTrades
          ? ['/api/kraken/ledger/trades/fills',
-            { credentials: account, filters: tradeFilters, sort: tradeSort, page: tradePage, pageSize: PAGE_SIZE }]
+            { accountId, filters: tradeFilters, sort: tradeSort, page: tradePage, pageSize: PAGE_SIZE }]
          : null,
       { keepPreviousData: true })
 
@@ -109,7 +108,7 @@ export default function KrakenLedger() {
    const job = status?.job
    const running = isJobRunning(job)
 
-   if (!credentials.apiKey) {
+   if (!isLoadingSettings && !configured) {
       return (
          <KrakenLayout name="Ledger">
             <Alert>
@@ -124,18 +123,18 @@ export default function KrakenLedger() {
    const sync = (mode) => {
       startedRef.current = true
       setWasInterrupted(false)
-      startSync({ credentials, mode })
-         .then(() => mutate(['/api/kraken/ledger/sync/status', { credentials: account }]))
+      startSync({ mode })
+         .then(() => mutate(SYNC_STATUS_KEY))
          .catch(() => {})
    }
 
    // The status key is refreshed explicitly rather than through refreshStoredData,
    // which skips the sync endpoints to avoid revalidating in a loop from its own
    // callback. Without it the card keeps showing the counts of what was just deleted.
-   const clear = () => clearLedger({ credentials: account })
+   const clear = () => clearLedger()
       .then(() => Promise.all([
          refreshStoredData(),
-         mutate(['/api/kraken/ledger/sync/status', { credentials: account }])
+         mutate(SYNC_STATUS_KEY)
       ]))
       .catch(() => {})
 
@@ -197,7 +196,7 @@ export default function KrakenLedger() {
                isStarting={isMutating}
                onSync={() => sync('incremental')}
                onFullResync={() => sync('full')}
-               onCancel={() => cancelSync({ credentials: account }).catch(() => {})}
+               onCancel={() => cancelSync().catch(() => {})}
                onClear={clear} />
 
             <Tabs value={tab} onValueChange={setTab}>

--- a/src/views/pages/kraken/order-batch.jsx
+++ b/src/views/pages/kraken/order-batch.jsx
@@ -9,6 +9,7 @@ import ExternalLink from '../../components/lib/external-link'
 import OrderBatchForm from '../../components/kraken/order-batch-params'
 import OrderBatchTable from '../../components/kraken/order-batch-table'
 import { useProvider } from '../../lib/use-settings'
+import CredentialsAlert from '../../components/lib/credentials-alert'
 import usePersistentState from '../../lib/use-persistent-state'
 import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -82,7 +83,7 @@ export default function KrakenOrderBatch() {
    const { data: tradingPairs, isLoading } = useSWR('/api/kraken/trading-pairs')
    const { data: createdOrders, isMutating, error, trigger: createOrders, reset } = useSWRMutation('/api/kraken/order-batch')
 
-   const { configured, isLoading: isLoadingSettings } = useProvider('kraken')
+   const { configured, unreachable, isLoading: isLoadingSettings } = useProvider('kraken')
 
    const [ordersParams, setOrdersParams] = useState({})
    const [submittedMode, setSubmittedMode] = useState(null)
@@ -104,14 +105,12 @@ export default function KrakenOrderBatch() {
       createOrders({ ordersParams: params }).catch(() => {})
    }
 
-   if (!isLoadingSettings && !configured) {
+   if (!isLoadingSettings && (unreachable || !configured)) {
       return (
          <KrakenLayout name="Order Batch">
-            <Alert>
-               <AlertDescription>
-                  Generate an API key and secret on Kraken and add them in Settings to create orders.
-               </AlertDescription>
-            </Alert>
+            <CredentialsAlert unreachable={unreachable}>
+               Generate an API key and secret on Kraken and add them in Settings to create orders.
+            </CredentialsAlert>
          </KrakenLayout>
       )
    }

--- a/src/views/pages/kraken/order-batch.jsx
+++ b/src/views/pages/kraken/order-batch.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import useSWR from 'swr'
 import useSWRMutation from 'swr/mutation'
 import Big from 'big.js'
@@ -8,6 +8,8 @@ import InfoBanner from '../../components/lib/info-banner'
 import ExternalLink from '../../components/lib/external-link'
 import OrderBatchForm from '../../components/kraken/order-batch-params'
 import OrderBatchTable from '../../components/kraken/order-batch-table'
+import { useProvider } from '../../lib/use-settings'
+import usePersistentState from '../../lib/use-persistent-state'
 import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
@@ -66,17 +68,6 @@ const defaultFormValues = {
    volumeFn: 'linear-quote'
 }
 
-const loadFormValues = () => {
-   if (typeof window === 'undefined') return defaultFormValues
-   try {
-      const saved = localStorage.getItem(STORAGE_KEY)
-      return saved ? { ...defaultFormValues, ...JSON.parse(saved) } : defaultFormValues
-   }
-   catch {
-      return defaultFormValues
-   }
-}
-
 const postLimitOrders = <ExternalLink href="https://support.kraken.com/hc/en-us/articles/203053246-Other-order-options" className="underline">
    post limit orders
 </ExternalLink>
@@ -91,18 +82,12 @@ export default function KrakenOrderBatch() {
    const { data: tradingPairs, isLoading } = useSWR('/api/kraken/trading-pairs')
    const { data: createdOrders, isMutating, error, trigger: createOrders, reset } = useSWRMutation('/api/kraken/order-batch')
 
+   const { configured, isLoading: isLoadingSettings } = useProvider('kraken')
+
    const [ordersParams, setOrdersParams] = useState({})
    const [submittedMode, setSubmittedMode] = useState(null)
-   const [credentials] = useState(() => ({
-      apiKey: (typeof window !== 'undefined' && localStorage.getItem('kraken.api.key')) || '',
-      apiSecret: (typeof window !== 'undefined' && localStorage.getItem('kraken.api.secret')) || ''
-   }))
-   const [formValues, setFormValues] = useState(loadFormValues)
-
    // Remember the last entered parameters across navigations and app restarts.
-   useEffect(() => {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(formValues))
-   }, [formValues])
+   const [formValues, setFormValues] = usePersistentState(STORAGE_KEY, defaultFormValues)
 
    const showPreview = () => {
       setOrdersParams(buildOrdersParams(formValues))
@@ -116,10 +101,10 @@ export default function KrakenOrderBatch() {
       setSubmittedMode(mode)
       // Don't reset() here: useSWRMutation keeps the previous result while the new
       // request runs, so the table stays put instead of flashing back to "—".
-      createOrders({ credentials, ordersParams: params }).catch(() => {})
+      createOrders({ ordersParams: params }).catch(() => {})
    }
 
-   if (!credentials.apiKey) {
+   if (!isLoadingSettings && !configured) {
       return (
          <KrakenLayout name="Order Batch">
             <Alert>

--- a/src/views/pages/kraken/rewards.jsx
+++ b/src/views/pages/kraken/rewards.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useRef } from 'react'
 import { Link } from 'react-router'
 import useSWR, { useSWRConfig } from 'swr'
 import KrakenLayout from '../../components/kraken/kraken-layout'
@@ -9,40 +9,37 @@ import RewardChartCard from '../../components/kraken/reward-chart-card'
 import RewardHistoryCard from '../../components/kraken/reward-history-card'
 import RewardTable from '../../components/kraken/reward-table'
 import { isJobRunning } from '../../components/kraken/sync-status'
+import { useProvider } from '../../lib/use-settings'
 import { asCount } from '../../components/lib/filter-options'
 import { Alert, AlertDescription } from '@/components/ui/alert'
+
+const REWARDS_KEY = '/api/kraken/ledger/rewards'
 
 
 export default function KrakenRewards() {
 
-   const [credentials] = useState(() => ({
-      apiKey: (typeof window !== 'undefined' && localStorage.getItem('kraken.api.key')) || ''
-   }))
+   const { configured, isLoading: isLoadingSettings } = useProvider('kraken')
 
    const wasRunningRef = useRef(false)
    const { mutate } = useSWRConfig()
 
-   // This page reads the ledger the Ledger tab already downloaded, so the secret is
-   // neither needed nor sent. The rates it fetches on top are public data.
-   const account = credentials.apiKey ? { apiKey: credentials.apiKey } : null
-
    // A sync is started on the Ledger page but writes the rewards read here, so the run
    // is followed and the summary revalidated when it lands.
    const { data: status } = useSWR(
-      account ? ['/api/kraken/ledger/sync/status', { credentials: account }] : null,
+      configured ? '/api/kraken/ledger/sync/status' : null,
       {
          refreshInterval: latest => isJobRunning(latest?.job) ? 1500 : 0,
          onSuccess: (latest) => {
             const running = isJobRunning(latest?.job)
             if (!running && wasRunningRef.current) {
-               mutate(key => Array.isArray(key) && key[0] === '/api/kraken/ledger/rewards')
+               mutate(REWARDS_KEY)
             }
             wasRunningRef.current = running
          }
       })
 
    const { data: rewards, error, isLoading } = useSWR(
-      account ? ['/api/kraken/ledger/rewards', { credentials: account }] : null,
+      configured ? REWARDS_KEY : null,
       { keepPreviousData: true })
 
    // Asked for separately, and only once the assets are known, so the table renders
@@ -53,7 +50,7 @@ export default function KrakenRewards() {
       assets.length > 0 ? ['/api/kraken/asset-rates', { assets }] : null,
       { keepPreviousData: true })
 
-   if (!credentials.apiKey) {
+   if (!isLoadingSettings && !configured) {
       return (
          <KrakenLayout name="Rewards">
             <Alert>

--- a/src/views/pages/kraken/rewards.jsx
+++ b/src/views/pages/kraken/rewards.jsx
@@ -10,6 +10,7 @@ import RewardHistoryCard from '../../components/kraken/reward-history-card'
 import RewardTable from '../../components/kraken/reward-table'
 import { isJobRunning } from '../../components/kraken/sync-status'
 import { useProvider } from '../../lib/use-settings'
+import CredentialsAlert from '../../components/lib/credentials-alert'
 import { asCount } from '../../components/lib/filter-options'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 
@@ -18,7 +19,7 @@ const REWARDS_KEY = '/api/kraken/ledger/rewards'
 
 export default function KrakenRewards() {
 
-   const { configured, isLoading: isLoadingSettings } = useProvider('kraken')
+   const { configured, unreachable, isLoading: isLoadingSettings } = useProvider('kraken')
 
    const wasRunningRef = useRef(false)
    const { mutate } = useSWRConfig()
@@ -50,14 +51,12 @@ export default function KrakenRewards() {
       assets.length > 0 ? ['/api/kraken/asset-rates', { assets }] : null,
       { keepPreviousData: true })
 
-   if (!isLoadingSettings && !configured) {
+   if (!isLoadingSettings && (unreachable || !configured)) {
       return (
          <KrakenLayout name="Rewards">
-            <Alert>
-               <AlertDescription>
-                  Generate an API key and secret on Kraken and add them in Settings to sync your ledger.
-               </AlertDescription>
-            </Alert>
+            <CredentialsAlert unreachable={unreachable}>
+               Generate an API key and secret on Kraken and add them in Settings to sync your ledger.
+            </CredentialsAlert>
          </KrakenLayout>
       )
    }

--- a/src/views/pages/kraken/xstocks.jsx
+++ b/src/views/pages/kraken/xstocks.jsx
@@ -11,6 +11,8 @@ import Field from '../../components/lib/field'
 import NumericInput from '../../components/lib/numeric-input'
 import SelectField from '../../components/lib/select-field'
 import { asCount, ANY } from '../../components/lib/filter-options'
+import { useProvider } from '../../lib/use-settings'
+import usePersistentState from '../../lib/use-persistent-state'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -44,37 +46,35 @@ const numericColumns = new Set(['volumeUsd24h'])
 
 const collator = new Intl.Collator(undefined, { sensitivity: 'base' })
 
-const readSettings = () => {
-   if (typeof window === 'undefined') return {}
-   try { return JSON.parse(localStorage.getItem(SETTINGS_KEY)) ?? {} }
-   catch { return {} }
+const defaultSettings = {
+   wordCount: 60,
+   type: ANY,
+   scope: 'etf',
+   sort: { column: 'volumeUsd24h', direction: 'desc' }
 }
+
+const reviveSettings = (stored, defaults) => ({
+   ...stored,
+   scope: scopeValues.has(stored.scope) ? stored.scope : defaults.scope
+})
 
 export default function KrakenXStocks() {
 
-   const [credentials] = useState(() => ({
-      apiKey: (typeof window !== 'undefined' && localStorage.getItem('anthropic.api.key')) || ''
-   }))
+   const { configured: hasAnthropicKey } = useProvider('anthropic')
 
-   const [settings] = useState(readSettings)
+   const [settings, setSettings] = usePersistentState(SETTINGS_KEY, defaultSettings, reviveSettings)
+   const { wordCount, type, scope, sort } = settings
 
-   const [wordCountInput, setWordCountInput] = useState(() => String(settings.wordCount ?? 60))
-   const [wordCount, setWordCount] = useState(() => settings.wordCount ?? 60)
+   const updateSettings = patch => setSettings(previous => ({ ...previous, ...patch }))
+
+   const [wordCountInput, setWordCountInput] = useState(() => String(wordCount))
    const [searchInput, setSearchInput] = useState('')
    const [search, setSearch] = useState('')
-   const [type, setType] = useState(() => settings.type ?? ANY)
-   const [scope, setScope] = useState(() => scopeValues.has(settings.scope) ? settings.scope : 'etf')
-   const [sort, setSort] = useState(() => settings.sort ?? { column: 'volumeUsd24h', direction: 'desc' })
    const [page, setPage] = useState(0)
    const [describing, setDescribing] = useState(() => new Set())
    const [progress, setProgress] = useState(null)
 
    const stopRequested = useRef(false)
-
-   useEffect(() => {
-      if (typeof window === 'undefined') return
-      localStorage.setItem(SETTINGS_KEY, JSON.stringify({ wordCount, type, scope, sort }))
-   }, [wordCount, type, scope, sort])
 
    useEffect(() => {
       const timer = setTimeout(() => {
@@ -86,18 +86,18 @@ export default function KrakenXStocks() {
 
    useEffect(() => {
       const timer = setTimeout(() => {
-         setWordCount(Math.min(300, Math.max(10, parseInt(wordCountInput) || 60)))
+         updateSettings({ wordCount: Math.min(300, Math.max(10, parseInt(wordCountInput) || 60)) })
       }, 500)
       return () => clearTimeout(timer)
    }, [wordCountInput])
 
    const changeType = (value) => {
-      setType(value)
+      updateSettings({ type: value })
       setPage(0)
    }
 
    const changeSort = (value) => {
-      setSort(value)
+      updateSettings({ sort: value })
       setPage(0)
    }
 
@@ -187,13 +187,13 @@ export default function KrakenXStocks() {
    }
 
    const generateDescriptions = (tickers) =>
-      runInBatches(tickers, 'describe', batch => describe({ credentials, tickers: batch, wordCount }))
+      runInBatches(tickers, 'describe', batch => describe({ tickers: batch, wordCount }))
 
    const classifyUnknown = () =>
       runInBatches(
          listings.filter(listing => listing.type === 'unclassified').map(listing => listing.ticker),
          'classify',
-         batch => classify({ credentials, tickers: batch }))
+         batch => classify({ tickers: batch }))
 
    const describeScope = () =>
       generateDescriptions(listings
@@ -201,7 +201,7 @@ export default function KrakenXStocks() {
          .map(listing => listing.ticker))
 
    const isBusy = progress !== null
-   const canDescribe = Boolean(credentials.apiKey) && !isBusy
+   const canDescribe = hasAnthropicKey && !isBusy
 
    const pendingInScope = useMemo(
       () => listings.filter(listing => inScope(listing, scope) && !listing.description).length,
@@ -254,7 +254,7 @@ export default function KrakenXStocks() {
                         {asCount(counts.unclassified, 'listing')} not in the reference list — Kraken has
                         added them since it was last refreshed.
                      </span>
-                     {credentials.apiKey
+                     {hasAnthropicKey
                         ? <Button variant="outline" size="sm" type="button" disabled={isBusy} onClick={classifyUnknown}>
                            <SparklesIcon className="size-3.5" />
                            Classify with Claude
@@ -285,7 +285,7 @@ export default function KrakenXStocks() {
                            label="Generate for"
                            className="min-w-44 flex-1"
                            value={scope}
-                           onValueChange={setScope}
+                           onValueChange={value => updateSettings({ scope: value })}
                            options={scopeOptions} />
                         <NumericInput
                            name="wordCount"
@@ -308,7 +308,7 @@ export default function KrakenXStocks() {
                            </Button>}
                      </div>
 
-                     {!credentials.apiKey &&
+                     {!hasAnthropicKey &&
                         <Alert>
                            <AlertDescription>
                               Add an Anthropic API key in{' '}

--- a/src/views/pages/settings.jsx
+++ b/src/views/pages/settings.jsx
@@ -1,9 +1,10 @@
+import { useSWRConfig } from 'swr'
 import useSWRMutation from 'swr/mutation'
 import { toast } from 'sonner'
 import Input from '../components/lib/input'
 import InfoBanner from '../components/lib/info-banner'
 import Layout from '../components/layout'
-import useSettings, { SETTINGS_KEY } from '../lib/use-settings'
+import useSettings, { SETTINGS_KEY, SETTINGS_REVEAL_KEY } from '../lib/use-settings'
 import { Button } from '@/components/ui/button'
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
 
@@ -31,8 +32,10 @@ const providers = [
 
 export default function Settings() {
 
-   const { settings, isLoading, mutate } = useSettings()
+   // The only place that asks for the keys themselves, to prefill the form.
+   const { settings, isLoading, mutate } = useSettings(SETTINGS_REVEAL_KEY)
    const { trigger: saveSettings, isMutating } = useSWRMutation(SETTINGS_KEY)
+   const { mutate: globalMutate } = useSWRConfig()
 
    const save = async (event, provider) => {
       event.preventDefault()
@@ -46,7 +49,8 @@ export default function Settings() {
 
       try {
          await saveSettings({ [provider.id]: update })
-         await mutate()
+         // Both keys: this page's revealed copy, and the booleans every other page reads.
+         await Promise.all([mutate(), globalMutate(SETTINGS_KEY)])
          toast.success(`${provider.name} API key saved`)
       }
       catch (error) {

--- a/src/views/pages/settings.jsx
+++ b/src/views/pages/settings.jsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import useSWRMutation from 'swr/mutation'
 import { toast } from 'sonner'
 import Input from '../components/lib/input'
 import InfoBanner from '../components/lib/info-banner'
 import Layout from '../components/layout'
+import useSettings, { SETTINGS_KEY } from '../lib/use-settings'
 import { Button } from '@/components/ui/button'
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
 
@@ -11,93 +12,96 @@ const providers = [
       id: 'binance',
       name: 'Binance',
       description: 'Reads your staking positions and balances. Read-only permissions are enough.',
-      hasSecret: true,
-      envKey: import.meta.env.VITE_BINANCE_API_KEY,
-      envSecret: import.meta.env.VITE_BINANCE_API_SECRET
+      hasSecret: true
    },
    {
       id: 'kraken',
       name: 'Kraken',
       description: 'Syncs your ledger and trade history, and creates orders. The secret is only sent for private calls.',
-      hasSecret: true,
-      envKey: import.meta.env.VITE_KRAKEN_API_KEY,
-      envSecret: import.meta.env.VITE_KRAKEN_API_SECRET
+      hasSecret: true
    },
    {
       id: 'anthropic',
       name: 'Anthropic',
       description: 'Writes the xStocks summaries. Usage is billed to your own Anthropic account.',
-      hasSecret: false,
-      envKey: import.meta.env.VITE_ANTHROPIC_API_KEY
+      hasSecret: false
    }
 ]
-
-const storedCredentials = provider => ({
-   apiKey: (typeof window !== 'undefined' && localStorage.getItem(`${provider.id}.api.key`))
-      || provider.envKey
-      || '',
-   apiSecret: provider.hasSecret
-      ? (typeof window !== 'undefined' && localStorage.getItem(`${provider.id}.api.secret`))
-         || provider.envSecret
-         || ''
-      : ''
-})
-
-const saveApiKeys = (event, provider) => {
-   event.preventDefault()
-
-   const formData = new FormData(event.target)
-   localStorage.setItem(`${provider.id}.api.key`, formData.get(`${provider.id}-api-key`))
-
-   if (provider.hasSecret) {
-      localStorage.setItem(`${provider.id}.api.secret`, formData.get(`${provider.id}-api-secret`))
-   }
-
-   toast.success(`${provider.name} API key saved`)
-}
 
 
 export default function Settings() {
 
-   const [credentials] = useState(() =>
-      Object.fromEntries(providers.map(provider => [provider.id, storedCredentials(provider)])))
+   const { settings, isLoading, mutate } = useSettings()
+   const { trigger: saveSettings, isMutating } = useSWRMutation(SETTINGS_KEY)
+
+   const save = async (event, provider) => {
+      event.preventDefault()
+
+      const formData = new FormData(event.target)
+      const update = { apiKey: formData.get(`${provider.id}-api-key`) }
+
+      if (provider.hasSecret) {
+         update.apiSecret = formData.get(`${provider.id}-api-secret`)
+      }
+
+      try {
+         await saveSettings({ [provider.id]: update })
+         await mutate()
+         toast.success(`${provider.name} API key saved`)
+      }
+      catch (error) {
+         toast.error(String(error))
+      }
+   }
 
    return (
       <Layout name="Settings">
          <div className="space-y-6">
 
             <InfoBanner>
-               The keys the other pages use to reach each exchange. They are kept in this
-               browser&apos;s local storage on this machine, never uploaded anywhere, and sent to
-               the local server only to sign the calls a page makes on your behalf. Removing a key
+               The keys the other pages use to reach each exchange. They are stored on this machine
+               in the app&apos;s own data folder, beside the ledger database, never uploaded
+               anywhere, and used only to sign the calls a page makes on your behalf. Removing a key
                here is enough to cut a page off from its exchange.
             </InfoBanner>
 
-            {providers.map(provider =>
-               <Card key={provider.id} size="sm">
-                  <CardHeader>
-                     <CardTitle>{provider.name}</CardTitle>
-                     <CardDescription>{provider.description}</CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                     <form method="post" onSubmit={event => saveApiKeys(event, provider)} className="space-y-4">
-                        <div className="grid gap-x-4 gap-y-3 sm:grid-cols-2">
-                           <Input
-                              name={`${provider.id}-api-key`}
-                              label="API Key"
-                              defaultValue={credentials[provider.id].apiKey} />
-                           {provider.hasSecret &&
+            {providers.map(provider => {
+               const stored = settings?.[provider.id]
+               const fromEnvironment = stored?.source === 'env'
+
+               return (
+                  <Card key={provider.id} size="sm">
+                     <CardHeader>
+                        <CardTitle>{provider.name}</CardTitle>
+                        <CardDescription>
+                           {provider.description}
+                           {fromEnvironment && ' Currently provided by an environment variable, which takes precedence over anything saved here.'}
+                        </CardDescription>
+                     </CardHeader>
+                     <CardContent>
+                        <form method="post" onSubmit={event => save(event, provider)} className="space-y-4">
+                           <div className="grid gap-x-4 gap-y-3 sm:grid-cols-2">
                               <Input
-                                 name={`${provider.id}-api-secret`}
-                                 label="API Secret"
-                                 type="password"
-                                 defaultValue={credentials[provider.id].apiSecret} />}
-                        </div>
-                        <Button type="submit" size="sm">Save</Button>
-                     </form>
-                  </CardContent>
-               </Card>
-            )}
+                                 key={`${provider.id}-key-${stored?.apiKey ?? ''}`}
+                                 name={`${provider.id}-api-key`}
+                                 label="API Key"
+                                 disabled={isLoading}
+                                 defaultValue={stored?.apiKey ?? ''} />
+                              {provider.hasSecret &&
+                                 <Input
+                                    key={`${provider.id}-secret-${stored?.apiSecret ?? ''}`}
+                                    name={`${provider.id}-api-secret`}
+                                    label="API Secret"
+                                    type="password"
+                                    disabled={isLoading}
+                                    defaultValue={stored?.apiSecret ?? ''} />}
+                           </div>
+                           <Button type="submit" size="sm" disabled={isLoading || isMutating}>Save</Button>
+                        </form>
+                     </CardContent>
+                  </Card>
+               )
+            })}
 
          </div>
       </Layout>


### PR DESCRIPTION
## Context

The API keys lived in the renderer's `localStorage` while everything they unlock lived in a SQLite database in the app's data directory. That split was not principled, and three defects followed from it.

## What was wrong

**A Kraken key change lost the ledger.** `account_id` — the column every stored row is partitioned by — was `sha256(apiKey)` (`src/server/db/entry-key.js`). Rotating the key made the whole synced database unreachable *and* un-deletable, while `dbSizeBytes()` kept counting the orphaned rows. `sync_state.api_key_prefix` was written on every sync and read nowhere: the problem had been anticipated and then dropped.

**The environment fallback only worked on one page.** The `VITE_*` fallback existed solely in `src/views/pages/settings.jsx`. The other eight pages read `localStorage` directly, so a developer with `KRAKEN_API_KEY` set saw the key on Settings and "add them in Settings" everywhere else.

**Saving a key did not reach a mounted page**, because each page snapshotted `localStorage` into `useState` at mount.

Underneath all three: under `views://` the page origin is opaque, so `localStorage` was the one store that did not live in `~/Library/Application Support/Crypto Tools`, was not backed up with the database, and had no migration path — yet it held the only copy of the credentials.

## What changed

The keys move to a `settings.json` beside `ledger.db`, written `0600`, carried by the existing legacy-directory migration. `bun run dev` writes `settings-dev.json` so it never touches the installed app's keys.

- **Stable account id.** Derived once from the first key saved, then kept. Still derived with `accountIdFor`, so an existing installation resolves to the id its rows already use and needs **no data migration**. `startSync` also had to stop deriving the id from the key, or a rotated key would have synced into a fresh partition while reads used the stable one.
- **Routes resolve their own credentials.** `withCredentials` reads them from the settings file and `withAccount` reads the account id, so a caller says which call to make rather than who to make it as. Reads that no longer carry a body became GETs, and the fetcher treats a mutation as a POST even when its argument is empty.
- **One-time migration.** Keys left behind by an earlier version are handed to the server once and then removed, so upgrading neither costs the user their configuration nor strands their secrets in the WebView's store.
- **View state gets one hook.** `usePersistentState` replaces two hand-rolled implementations, and filters, sorting and the open tab now survive navigation on Ledger, Balances, Fees and Closed Orders, which discarded them before. Page number and in-flight state are deliberately excluded, and nothing is written on mount.
- **Incidental:** `index.js` declared its own route table in parallel with `createApp()` — the drift the comment in `kraken.js` warned about — and would otherwise have needed the settings route mounted twice.

## Second commit: review follow-ups

Review found a security regression in the first commit, and it is the reason for `b6d0135`.

**Cross-origin writes.** Moving the credentials server-side removed the only thing keeping the mutating endpoints unreachable from outside the app: the body used to have to carry a valid key. CORS does not close that gap — a cross-origin POST with a simple content type is sent without a preflight, and the attacker never needs to read the response. Reproduced against the first commit: `Origin: https://evil.example` with `Content-Type: text/plain` to `/ledger/sync` answered 200 and the server then made signed private calls to Kraken with the stored key. The allowlist is now enforced server-side rather than left to the browser, and writes must be `application/json`. Since the browser sends `Origin` on same-origin writes too, any localhost origin is accepted outside production so a non-default Vite port does not 403 every write; the packaged app only loads from `views://`.

Also in that commit: environment credentials are all-or-nothing (exporting only the key used to blank a secret sitting in the file); an environment key gets the partition its own key names rather than inheriting the stored id; `settings.json` is written via temp-and-rename, making the save atomic and the `0600` unconditional rather than first-write-only; `/api/settings` masks the key except for the Settings form, so the plaintext no longer sits in nine SWR caches; a failed settings request says the server is unreachable instead of claiming there are no keys; and an `?order=` deep link no longer inherits or becomes sticky filter state.

## Verification

- Upgrade path: `sha256("KRAKENKEY123456")[:16]` matches the stored `4c42fc22ea499e08`, confirming existing rows are found.
- Key rotation: synced, changed the key, reloaded — entries still listed, account id unchanged.
- The env-var regression: with only `KRAKEN_API_KEY`/`KRAKEN_API_SECRET` set and no settings file, a Kraken read endpoint returns 200. On `master` today every page but Settings shows the alert.
- Cross-origin attack: 403 on `/ledger/clear`, `/ledger/sync` and `/order-batch`, and no private Kraken call in the log. `views://main` and `localhost:3000` still pass in production; `localhost:3010` and `evil.example` do not.
- Environment resolution: key-only leaves the file's pair intact; key+secret get their own account id; no environment leaves the stored id untouched.
- Permissions: `chmod 644` then save returns the file to `-rw-------`, no `.tmp` left behind.
- Masking: `apiKey` is `*****` by default and real under `?reveal=true`; saving a masked field does not overwrite the stored value.
- Migration: legacy keys moved to `settings-dev.json`; `localStorage` left holding only view state.
- Stopped the server: pages report it as unreachable rather than as missing keys.
- Saved a key through the real Settings form; all nine pages render, in both live and mock mode. Ledger filter set, navigated away and back, still there.
- `bun run lint` clean, `bun run build` clean.

**Not covered:** `bunx electrobun dev` under the real `views://` origin, where storage behaviour differs from the Vite dev server.

## Note

Secrets are still plaintext, now in a `0600` file in the user's own data directory rather than in WebView storage. That is a strict improvement but not Keychain; worth a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)