### PR TITLE
fix(server): 404 unresolvable asset requests instead of index.html

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -23,9 +23,16 @@ if (IS_PROD) {
       return null
    }
 
+   const isAssetRequest = (pathname) => pathname.split('/').includes('assets')
+
    app.get('*', (c) => {
-      const file = distFile(new URL(c.req.url).pathname)
-      return new Response(Bun.file(file ?? path.join(DIST, 'index.html')))
+      const pathname = new URL(c.req.url).pathname
+      const file = distFile(pathname)
+
+      if (file) return new Response(Bun.file(file))
+      if (isAssetRequest(pathname)) return c.notFound()
+
+      return new Response(Bun.file(path.join(DIST, 'index.html')))
    })
 }
 


### PR DESCRIPTION
Follow-up to #237, which fixed asset resolution on deep links but left one case behind.

## The gap

The SPA fallback answers *anything* it cannot resolve with `index.html`. That is exactly right for routes — it is what makes refreshing `/kraken/xstocks` work — but wrong for subresources. A request for an asset that genuinely does not exist got a `200` HTML document:

```
/assets/does-not-exist.js  →  200 text/html
```

Which is the same failure shape #237 fixed, just narrowed to files that really are absent: the browser asks for a module, gets a document, refuses to execute it, and the page goes blank. Nothing in the network log is red, so there is nothing to point at.

This is not hypothetical for a self-hosted deploy — a partial upload, a stale `index.html` served next to a newer `assets/`, or a cache holding the previous build's hashed filename all land here.

## The fix

A path carrying an `assets` segment is only ever emitted by the built `index.html`; no route in the app contains one, and nobody types it. So when such a path does not resolve to a real file, it is a genuine 404 and now says so. Everything else still falls through to `index.html`.

## Verified

Against a real production build (`NODE_ENV=production bun src/server/index.js`):

| Request | Before | After |
|---|---|---|
| `/assets/index-BHyw8fYl.js` | `200 text/javascript` | `200 text/javascript` |
| `/kraken/assets/index-BHyw8fYl.js` | `200 text/javascript` | `200 text/javascript` |
| `/kraken/xstocks/assets/index-ep2U2LHe.css` | `200 text/css` | `200 text/css` |
| `/assets/does-not-exist.js` | **`200 text/html`** | `404` |
| `/kraken/assets/does-not-exist.js` | **`200 text/html`** | `404` |
| `/assets` | **`200 text/html`** | `404` |
| `/kraken/favicon.svg` | `200 image/svg+xml` | `200 image/svg+xml` |
| `/`, `/settings`, `/kraken/xstocks`, `/does/not/exist` | `200 text/html` | `200 text/html` |
| `/kraken/../../package.json` | `200 text/html` | `200 text/html` |

## Scope

Only `src/server/index.js`, the standalone web server. `src/server/app.js` — the entry the desktop app uses — serves no static files, so Electrobun behaviour is untouched and no rebuild of the desktop bundle is implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)