### PR TITLE
feat(rewards): show what the last complete week or month paid

### DIFF
--- a/src/server/db/ledger-repository.js
+++ b/src/server/db/ledger-repository.js
@@ -23,6 +23,22 @@ const nonZeroFee = 'CAST(fee AS REAL) <> 0'
 const isReward = `type IN ('staking', 'earn')
    AND subtype NOT IN ('allocation', 'deallocation', 'autoallocation', 'migration')`
 
+const DAY = 86400000
+
+function lastCompletePeriods(now = Date.now()) {
+
+   const today = new Date(now)
+   const [year, month, day] = [today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()]
+
+   const thisWeek = Date.UTC(year, month, day) - ((today.getUTCDay() + 6) % 7) * DAY
+   const thisMonth = Date.UTC(year, month, 1)
+
+   return {
+      week: { from: thisWeek - 7 * DAY, to: thisWeek - 1 },
+      month: { from: Date.UTC(year, month - 1, 1), to: thisMonth - 1 }
+   }
+}
+
 const upsertStatement = `
    INSERT INTO ledger_entry (
       account_id, entry_key, txid, refid, time, type, subtype, aclass,
@@ -202,8 +218,22 @@ export default function LedgerRepository(accountId) {
 
       const years = [...new Set(rows.map(row => row.year))].toSorted((a, b) => a - b)
 
+      const periodQuery = db.query(`
+         SELECT base_asset AS asset,
+                SUM(CAST(amount AS REAL) - CAST(fee AS REAL)) AS total,
+                COUNT(*) AS entries
+         FROM ledger_entry
+         WHERE account_id = ? AND ${isReward} AND time >= ? AND time <= ?
+         GROUP BY asset
+         ORDER BY asset`)
+
+      const periods = Object.fromEntries(Object.entries(lastCompletePeriods())
+         .map(([name, { from, to }]) =>
+            [name, { from, to, assets: periodQuery.all(accountId, from, to) }]))
+
       return {
          years,
+         periods,
          assets: [...assets.values()],
          entries: rows.reduce((count, row) => count + row.entries, 0),
          first: rows.length > 0 ? Math.min(...rows.map(row => row.first)) : null,

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -2,6 +2,7 @@ import { locales } from './locale'
 
 const shortDateFormatter = new Intl.DateTimeFormat(locales, { month: 'short', day: 'numeric' })
 const longDateFormatter = new Intl.DateTimeFormat(locales, { year: 'numeric', month: 'short', day: 'numeric' })
+const utcLongDateFormatter = new Intl.DateTimeFormat(locales, { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'UTC' })
 const monthDateFormatter = new Intl.DateTimeFormat(locales, { year: 'numeric', month: 'long' })
 const shortMonthDateFormatter = new Intl.DateTimeFormat(locales, { year: '2-digit', month: 'short' })
 const percentageFormatter = new Intl.NumberFormat(locales, { style: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 })
@@ -50,6 +51,10 @@ export function asShortDate(timestamp) {
 
 export function asLongDate(timestamp) {
    return dateFormat(longDateFormatter, timestamp)
+}
+
+export function asUtcLongDate(timestamp) {
+   return dateFormat(utcLongDateFormatter, timestamp)
 }
 
 export function asMonthYearDate(timestamp) {

--- a/src/views/components/kraken/reward-period-card.jsx
+++ b/src/views/components/kraken/reward-period-card.jsx
@@ -1,0 +1,92 @@
+import { Card, CardHeader, CardTitle, CardDescription, CardAction, CardContent } from '@/components/ui/card'
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
+import SelectField from '../lib/select-field'
+import usePersistentState from '../../lib/use-persistent-state'
+import { RewardCell, valueOf } from './reward-table'
+import { asDollarAmount, asUtcLongDate } from '../../../utils/format'
+
+const periods = [
+   { value: 'week', label: 'Weekly' },
+   { value: 'month', label: 'Monthly' }
+]
+
+const titles = { week: 'Last week', month: 'Last month' }
+
+
+export default function RewardPeriodCard({ rewards, rates }) {
+
+   const [period, setPeriod] = usePersistentState('kraken.rewards.period', 'month')
+
+   const selected = rewards?.periods?.[period] ?? null
+   const rateFor = asset => rates?.[asset] ?? null
+
+   const rows = (selected?.assets ?? []).toSorted((a, b) => {
+      const [left, right] = [valueOf(a.total, rateFor(a.asset)), valueOf(b.total, rateFor(b.asset))]
+      if (left == null && right == null) return a.asset.localeCompare(b.asset)
+      if (left == null) return 1
+      if (right == null) return -1
+      if (left === right) return a.asset.localeCompare(b.asset)
+      return right - left
+   })
+
+   const valued = rows.filter(row => rateFor(row.asset) != null)
+   const total = valued.reduce((sum, row) => sum + valueOf(row.total, rateFor(row.asset)), 0)
+
+   const range = selected
+      ? `${asUtcLongDate(selected.from)} – ${asUtcLongDate(selected.to)}`
+      : 'No period yet'
+
+   return (
+      <Card>
+         <CardHeader>
+            <CardTitle>{titles[period]}</CardTitle>
+            <CardDescription className="text-xs">{range}</CardDescription>
+            <CardAction>
+               <SelectField
+                  name="reward-period"
+                  className="w-28"
+                  value={period}
+                  onValueChange={setPeriod}
+                  options={periods} />
+            </CardAction>
+         </CardHeader>
+         <CardContent>
+
+            {rows.length === 0
+               ? <p className="text-sm text-muted-foreground">
+                  {selected
+                     ? `No rewards paid between ${asUtcLongDate(selected.from)} and ${asUtcLongDate(selected.to)}.`
+                     : 'No rewards to show. Sync your ledger on the Ledger tab first.'}
+               </p>
+               : <div className="space-y-3">
+                  <div className="max-h-[232px] overflow-y-auto">
+                     <Table className="tabular-nums">
+                        <TableHeader>
+                           <TableRow>
+                              <TableHead>Asset</TableHead>
+                              <TableHead className="text-right">Earned</TableHead>
+                           </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                           {rows.map(row =>
+                              <TableRow key={row.asset}>
+                                 <TableCell className="font-medium">{row.asset}</TableCell>
+                                 <RewardCell amount={row.total} rate={rateFor(row.asset)} />
+                              </TableRow>)}
+                        </TableBody>
+                     </Table>
+                  </div>
+                  <div
+                     className="flex items-center justify-between border-t border-border pt-3 text-sm tabular-nums"
+                     title={valued.length < rows.length
+                        ? `${rows.length - valued.length} asset(s) have no USD pair and are not counted`
+                        : undefined}>
+                     <span>Total</span>
+                     <span className="font-medium">{asDollarAmount(total)}</span>
+                  </div>
+               </div>}
+
+         </CardContent>
+      </Card>
+   )
+}

--- a/src/views/components/kraken/reward-period-card.jsx
+++ b/src/views/components/kraken/reward-period-card.jsx
@@ -1,5 +1,5 @@
 import { Card, CardHeader, CardTitle, CardDescription, CardAction, CardContent } from '@/components/ui/card'
-import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
+import { Table, TableBody, TableRow, TableCell } from '@/components/ui/table'
 import SelectField from '../lib/select-field'
 import usePersistentState from '../../lib/use-persistent-state'
 import { RewardCell, valueOf } from './reward-table'
@@ -61,12 +61,6 @@ export default function RewardPeriodCard({ rewards, rates }) {
                : <div className="space-y-3">
                   <div className="max-h-[232px] overflow-y-auto">
                      <Table className="tabular-nums">
-                        <TableHeader>
-                           <TableRow>
-                              <TableHead>Asset</TableHead>
-                              <TableHead className="text-right">Earned</TableHead>
-                           </TableRow>
-                        </TableHeader>
                         <TableBody>
                            {rows.map(row =>
                               <TableRow key={row.asset}>
@@ -77,7 +71,7 @@ export default function RewardPeriodCard({ rewards, rates }) {
                      </Table>
                   </div>
                   <div
-                     className="flex items-center justify-between border-t border-border pt-3 text-sm tabular-nums"
+                     className="flex items-center justify-between border-t border-border px-2 pt-3 text-sm tabular-nums"
                      title={valued.length < rows.length
                         ? `${rows.length - valued.length} asset(s) have no USD pair and are not counted`
                         : undefined}>

--- a/src/views/components/kraken/reward-period-card.jsx
+++ b/src/views/components/kraken/reward-period-card.jsx
@@ -59,7 +59,7 @@ export default function RewardPeriodCard({ rewards, rates }) {
                      : 'No rewards to show. Sync your ledger on the Ledger tab first.'}
                </p>
                : <div className="space-y-3">
-                  <div className="max-h-[232px] overflow-y-auto">
+                  <div className="scroll-shadows max-h-[232px] overflow-y-auto pr-3">
                      <Table className="tabular-nums">
                         <TableBody>
                            {rows.map(row =>
@@ -71,7 +71,7 @@ export default function RewardPeriodCard({ rewards, rates }) {
                      </Table>
                   </div>
                   <div
-                     className="flex items-center justify-between border-t border-border px-2 pt-3 text-sm tabular-nums"
+                     className="flex items-center justify-between border-t border-border pt-3 pl-2 pr-5 text-sm tabular-nums"
                      title={valued.length < rows.length
                         ? `${rows.length - valued.length} asset(s) have no USD pair and are not counted`
                         : undefined}>

--- a/src/views/components/kraken/reward-summary-card.jsx
+++ b/src/views/components/kraken/reward-summary-card.jsx
@@ -1,33 +1,27 @@
 import { Loader2Icon } from 'lucide-react'
 import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
 import Field from '../lib/field'
-import { asCount } from '../lib/filter-options'
 import { asDollarAmount, asNumber, asLongDate } from '../../../utils/format'
 
 
 export default function RewardSummaryCard({ rewards, rates, isLoading, isLoadingRates }) {
 
    const assets = rewards?.assets ?? []
-   const entries = rewards?.entries ?? 0
 
    const valued = assets.filter(asset => rates?.[asset.asset] != null)
    const totalValue = valued.reduce((sum, asset) => sum + asset.total * rates[asset.asset], 0)
 
    return (
-      <Card>
+      <Card className="xl:self-start">
          <CardHeader>
             <CardTitle>Rewards earned</CardTitle>
-            <CardAction>
-               {isLoading
-                  ? <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
-                  : <Badge variant="outline">{asCount(entries, 'reward')}</Badge>}
-            </CardAction>
+            {isLoading &&
+               <CardAction>
+                  <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
+               </CardAction>}
          </CardHeader>
          <CardContent>
-            {/* Two columns rather than four: the card sits beside the charts, and the
-                stats read better stacked in a narrow column than squeezed into one row. */}
-            <div className="grid grid-cols-2 gap-x-6 gap-y-6">
+            <div className="grid grid-cols-1 gap-y-4">
                <Field label="Assets rewarded">{asNumber(assets.length)}</Field>
                <Field
                   label="Worth today"

--- a/src/views/components/kraken/reward-summary-card.jsx
+++ b/src/views/components/kraken/reward-summary-card.jsx
@@ -12,7 +12,7 @@ export default function RewardSummaryCard({ rewards, rates, isLoading, isLoading
    const totalValue = valued.reduce((sum, asset) => sum + asset.total * rates[asset.asset], 0)
 
    return (
-      <Card className="xl:self-start">
+      <Card>
          <CardHeader>
             <CardTitle>Rewards earned</CardTitle>
             {isLoading &&

--- a/src/views/components/kraken/reward-table.jsx
+++ b/src/views/components/kraken/reward-table.jsx
@@ -8,7 +8,7 @@ import { asAssetAmount, asDollarAmount } from '../../../utils/format'
 // An asset Kraken has no USD pair for has no rate at all, which is not the same as
 // being worth nothing: it is left out of the totals, shown as a dash, and sorted last
 // whichever column is sorted on.
-const valueOf = (amount, rate) => rate == null ? null : (amount ?? 0) * rate
+export const valueOf = (amount, rate) => rate == null ? null : (amount ?? 0) * rate
 
 // The sorted column shows the single arrow it is sorted by, drawn heavier; the rest
 // keep the two-headed arrow that says they can be sorted at all.
@@ -42,7 +42,7 @@ function SortableHead({ column, sort, onSortChange, children }) {
 
 // The value is what the column is read for, so it leads; the amount actually paid out
 // sits underneath it.
-const RewardCell = ({ amount, rate }) => {
+export const RewardCell = ({ amount, rate }) => {
 
    if (amount === undefined) {
       return <TableCell className="text-right text-muted-foreground">—</TableCell>

--- a/src/views/mocks/kraken-ledger.js
+++ b/src/views/mocks/kraken-ledger.js
@@ -13,6 +13,22 @@ function randomizer(seed) {
    }
 }
 
+const DAY = 86400000
+
+function lastCompletePeriods(now = Date.now()) {
+
+   const today = new Date(now)
+   const [year, month, day] = [today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()]
+
+   const thisWeek = Date.UTC(year, month, day) - ((today.getUTCDay() + 6) % 7) * DAY
+   const thisMonth = Date.UTC(year, month, 1)
+
+   return {
+      week: { from: thisWeek - 7 * DAY, to: thisWeek - 1 },
+      month: { from: Date.UTC(year, month - 1, 1), to: thisMonth - 1 }
+   }
+}
+
 const assets = [
    { asset: 'XXBT', baseAsset: 'BTC' },
    { asset: 'XETH', baseAsset: 'ETH' },
@@ -109,6 +125,20 @@ function buildEntries() {
       asset: 'ADA', baseAsset: 'ADA', wallet: 'earn / locked', amount: '9000.00000000', balance: '9000.00000000' })
    push({ txid: 'LADA2', refid: 'RWADA', time: recently(6), type: 'earn', subtype: 'reward',
       asset: 'ADA', baseAsset: 'ADA', wallet: 'earn / locked', amount: '12.40000000', balance: '9012.40000000' })
+
+   const { week, month } = lastCompletePeriods()
+   const midWeek = week.from + 3 * DAY
+   const midMonth = month.from + Math.floor((month.to - month.from) / 2)
+
+   push({ txid: 'LBTC3', refid: 'RWBTCW', time: midWeek, type: 'earn', subtype: 'reward',
+      asset: 'XXBT', baseAsset: 'BTC', wallet: 'earn / flexible', amount: '0.00038000', balance: '0.35080000' })
+   push({ txid: 'LSOL3', refid: 'RWSOLW', time: midWeek + DAY, type: 'earn', subtype: 'reward',
+      asset: 'SOL', baseAsset: 'SOL', wallet: 'earn / bonded', amount: '0.16500000', balance: '38.35500000' })
+
+   push({ txid: 'LADA4', refid: 'RWADAM', time: midMonth, type: 'earn', subtype: 'reward',
+      asset: 'ADA', baseAsset: 'ADA', wallet: 'earn / locked', amount: '11.80000000', balance: '9024.20000000' })
+   push({ txid: 'LETH3', refid: 'RWETHM', time: midMonth + DAY, type: 'earn', subtype: 'reward',
+      asset: 'ETH2.S', baseAsset: 'ETH', wallet: 'earn / liquid', amount: '0.00980000', balance: '4.52100000' })
 
    // Staked under the name Kraken has since retired, and never opted back in, so it
    // reads as an idle spot holding with two raw names behind it.
@@ -412,8 +442,26 @@ export function ledgerRewards() {
    const years = [...new Set([...assets.values()].flatMap(asset => Object.keys(asset.byYear).map(Number)))]
       .toSorted((a, b) => a - b)
 
+   const periodAssets = (from, to) => {
+
+      const totals = new Map()
+
+      for (const entry of rewards.filter(entry => entry.time >= from && entry.time <= to)) {
+         const total = totals.get(entry.baseAsset) ?? { asset: entry.baseAsset, total: 0, entries: 0 }
+         total.total += Number(entry.amount) - Number(entry.fee)
+         total.entries += 1
+         totals.set(entry.baseAsset, total)
+      }
+
+      return [...totals.values()].toSorted((a, b) => a.asset.localeCompare(b.asset))
+   }
+
+   const periods = Object.fromEntries(Object.entries(lastCompletePeriods())
+      .map(([name, { from, to }]) => [name, { from, to, assets: periodAssets(from, to) }]))
+
    return {
       years,
+      periods,
       assets: [...assets.values()].toSorted((a, b) => a.asset.localeCompare(b.asset)),
       entries: rewards.length,
       first: rewards.length > 0 ? Math.min(...rewards.map(entry => entry.time)) : null,

--- a/src/views/pages/kraken/rewards.jsx
+++ b/src/views/pages/kraken/rewards.jsx
@@ -7,6 +7,7 @@ import SyncStatusStrip from '../../components/kraken/sync-status-strip'
 import RewardSummaryCard from '../../components/kraken/reward-summary-card'
 import RewardChartCard from '../../components/kraken/reward-chart-card'
 import RewardHistoryCard from '../../components/kraken/reward-history-card'
+import RewardPeriodCard from '../../components/kraken/reward-period-card'
 import RewardTable from '../../components/kraken/reward-table'
 import { isJobRunning } from '../../components/kraken/sync-status'
 import { useProvider } from '../../lib/use-settings'
@@ -95,7 +96,7 @@ export default function KrakenRewards() {
                counts={asCount(status?.state?.entryCount, 'ledger entry', 'ledger entries')}
                emptyLabel="No ledger stored yet" />
 
-            <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-[minmax(14rem,max-content)_repeat(3,minmax(0,1fr))]">
                <RewardSummaryCard
                   rewards={rewards}
                   rates={rateData?.rates}
@@ -103,6 +104,7 @@ export default function KrakenRewards() {
                   isLoadingRates={isLoadingRates} />
                <RewardChartCard rewards={rewards} rates={rateData?.rates} />
                <RewardHistoryCard rewards={rewards} rates={rateData?.rates} />
+               <RewardPeriodCard rewards={rewards} rates={rateData?.rates} />
             </div>
 
             <RewardTable rewards={rewards} rates={rateData?.rates} />

--- a/src/views/styles/global.css
+++ b/src/views/styles/global.css
@@ -160,3 +160,20 @@
 [data-slot='chart'] .recharts-sector[stroke='#fff'] {
     stroke: transparent;
 }
+
+.scroll-shadows {
+    --scroll-shadow: oklch(0 0 0 / 0.14);
+
+    background:
+        linear-gradient(var(--card) 30%, transparent) center top,
+        linear-gradient(transparent, var(--card) 70%) center bottom,
+        radial-gradient(farthest-side at 50% 0, var(--scroll-shadow), transparent) center top,
+        radial-gradient(farthest-side at 50% 100%, var(--scroll-shadow), transparent) center bottom;
+    background-repeat: no-repeat;
+    background-size: 100% 28px, 100% 28px, 100% 9px, 100% 9px;
+    background-attachment: local, local, scroll, scroll;
+}
+
+.dark .scroll-shadows {
+    --scroll-shadow: oklch(0 0 0 / 0.55);
+}


### PR DESCRIPTION
Closes #241.

## What

A fourth card in the top row of the Kraken Rewards page, to the right of *Over time*, showing what the **last complete week or month** paid — per asset, in USD over the amount actually paid, with the period total under the list and a dropdown to switch between weekly and monthly. The choice is remembered across reloads.

The window is always the *previous* complete period, never the running one, which would understate every figure until the period closed. The exact range is printed under the card title so there is no guessing about which days are counted.

## How

`LedgerRepository.rewardSummary()` gains a `periods` block holding both windows with their per-asset totals. Computing them server-side is deliberate: weeks cannot be folded out of the existing year pivot the way the fee page folds quarters out of months, and shipping a full weekly history to bucket in the browser would cost far more than the handful of rows the card draws. Both windows travel in the one payload the page already fetches, so the dropdown switches without a request and no new route was needed.

Weeks are Monday-to-Sunday and both windows are taken in UTC, matching the timestamps Kraken writes and the rest of the page's bucketing. Totals reuse the existing `isReward` predicate and the same net-of-fee sum as the year pivot, so allocations and deallocations stay out — they are transfers, not income.

`RewardCell` and `valueOf` are now exported from `reward-table.jsx` and reused, so the "an asset with no USD pair has no value, which is not the same as being worth nothing" rule is stated once.

## Drive-by fix

Period boundaries are formatted with a new `asUtcLongDate` rather than `asLongDate`. The last millisecond of a UTC month falls into the next one anywhere east of Greenwich, so the local formatter labelled the July window `Jul 1 – Aug 1` — a date outside the window it described. Existing `asLongDate` callers are untouched.

## Also

The *Rewards earned* card loses its reward count and its two-column layout. Beside three content cards it was mostly empty space, so the stats stack in a column and the card sizes to that column instead of taking an equal quarter of the row.

## Verification

- Period maths checked across edge cases: weeks always land Mon 00:00:00.000 → Sun 23:59:59.999, January rolls back to the previous December, February respects 28 and 29 days.
- `rewardSummary()` exercised against a scratch SQLite database: boundaries inclusive on both ends, entries one millisecond either side excluded, `allocation`/`deallocation` and non-earn types excluded, fees netted out, assets kept separate.
- Mocked app at 1440/900/375 wide: dropdown switches between the two windows, total matches the valued rows with an unpriced asset correctly dashed and excluded, choice persists across reload, empty-period branch renders, no console errors, no horizontal overflow.
- `bun run lint` and `bun run build` clean.

The mock fixture mirrors the new payload and gained four rewards that track the two windows, so mocked mode is never empty whichever day it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)