### PR TITLE
feat(xstocks): follow generation as a job with live AI steps

### DIFF
--- a/src/server/adapters/anthropic/adapter.js
+++ b/src/server/adapters/anthropic/adapter.js
@@ -1,4 +1,4 @@
-import { generateText, Output } from 'ai'
+import { streamText, Output } from 'ai'
 import { createAnthropic } from '@ai-sdk/anthropic'
 import { z } from 'zod'
 
@@ -9,9 +9,9 @@ export const SUBTYPES = [
    'money-market', 'preferred', 'adr', 'closed-end-fund'
 ]
 
-const CLASSIFY_CHUNK_SIZE = 10
-const CLASSIFY_CONCURRENCY = 3
-const DESCRIBE_CONCURRENCY = 4
+export const CLASSIFY_CHUNK_SIZE = 10
+export const CLASSIFY_CONCURRENCY = 3
+export const DESCRIBE_CONCURRENCY = 4
 
 const listingSchema = z.object({
    ticker: z.string().describe('The requested ticker, echoed back exactly'),
@@ -52,9 +52,9 @@ Rules:
 * Return exactly one entry per requested ticker, echoing the ticker string verbatim. No additions,
   no omissions.`
 
-const asSources = (result) => {
+const asSources = (content) => {
    const urls = new Set()
-   for (const part of result.content ?? []) {
+   for (const part of content ?? []) {
       if (part.type !== 'tool-result') continue
       for (const item of Array.isArray(part.output) ? part.output : []) {
          if (item?.url) urls.add(item.url)
@@ -63,12 +63,12 @@ const asSources = (result) => {
    return [...urls]
 }
 
-const inBatches = async (items, size, worker) => {
-   const results = []
+export const chunked = (items, size) => {
+   const chunks = []
    for (let index = 0; index < items.length; index += size) {
-      results.push(...await Promise.all(items.slice(index, index + size).map(worker)))
+      chunks.push(items.slice(index, index + size))
    }
-   return results
+   return chunks
 }
 
 export default function AnthropicAPI(apiKey) {
@@ -79,46 +79,53 @@ export default function AnthropicAPI(apiKey) {
       web_search: anthropic.tools.webSearch_20260209({ maxUses })
    })
 
-   this.classifyListings = async function (tickers) {
+   const run = async function ({ prompt, schema, maxSearches, onActivity, abortSignal }) {
 
-      const chunks = []
-      for (let index = 0; index < tickers.length; index += CLASSIFY_CHUNK_SIZE) {
-         chunks.push(tickers.slice(index, index + CLASSIFY_CHUNK_SIZE))
+      const result = streamText({
+         model: anthropic(MODEL),
+         tools: webSearch(maxSearches),
+         output: Output.object({ schema }),
+         prompt,
+         abortSignal
+      })
+
+      const report = onActivity ?? (() => {})
+
+      for await (const part of result.stream) {
+         if (part.toolName === 'web_search') {
+            if (part.type === 'tool-call') report({ type: 'searching', query: part.input?.query ?? '' })
+            else if (part.type === 'tool-result') report({ type: 'reading' })
+         }
+         else if (part.type === 'text-delta') report({ type: 'writing' })
       }
 
-      const chunkResults = await inBatches(chunks, CLASSIFY_CONCURRENCY, async (chunk) => {
-
-         const result = await generateText({
-            model: anthropic(MODEL),
-            tools: webSearch(chunk.length + 4),
-            output: Output.object({ schema: z.object({ listings: z.array(listingSchema) }) }),
-            prompt: `Classify these ${chunk.length} tickers: ${chunk.join(', ')}.\n${classificationRules}`
-         })
-
-         const sources = asSources(result)
-         return (result.output?.listings ?? []).map(listing => ({ ...listing, sources }))
-      })
-
-      return chunkResults.flat()
+      return { output: await result.output, sources: asSources(await result.content) }
    }
 
-   this.describeListings = async function (listings, wordCount) {
+   this.classifyTickers = async function (tickers, { onActivity, abortSignal } = {}) {
 
-      return await inBatches(listings, DESCRIBE_CONCURRENCY, async (listing) => {
-
-         const result = await generateText({
-            model: anthropic(MODEL),
-            tools: webSearch(4),
-            output: Output.object({ schema: z.object({ description: z.string() }) }),
-            prompt: describePrompt(listing, wordCount)
-         })
-
-         return {
-            ticker: listing.ticker,
-            description: result.output?.description ?? '',
-            sources: asSources(result)
-         }
+      const { output, sources } = await run({
+         prompt: `Classify these ${tickers.length} tickers: ${tickers.join(', ')}.\n${classificationRules}`,
+         schema: z.object({ listings: z.array(listingSchema) }),
+         maxSearches: tickers.length + 4,
+         onActivity,
+         abortSignal
       })
+
+      return (output?.listings ?? []).map(listing => ({ ...listing, sources }))
+   }
+
+   this.describeListing = async function (listing, wordCount, { onActivity, abortSignal } = {}) {
+
+      const { output, sources } = await run({
+         prompt: describePrompt(listing, wordCount),
+         schema: z.object({ description: z.string() }),
+         maxSearches: 4,
+         onActivity,
+         abortSignal
+      })
+
+      return { ticker: listing.ticker, description: output?.description ?? '', sources }
    }
 
    const describePrompt = (listing, wordCount) => {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -39,6 +39,7 @@ if (IS_PROD) {
 Bun.serve({
    port: PORT,
    fetch: app.fetch,
+   idleTimeout: 0,
 })
 
 console.log(`✓ Server listening on http://localhost:${PORT}`)

--- a/src/server/routes/kraken-xstocks.js
+++ b/src/server/routes/kraken-xstocks.js
@@ -1,13 +1,12 @@
 import { Hono } from 'hono'
 import KrakenAPI from '../adapters/kraken-api/adapter.js'
-import AnthropicAPI, { MODEL } from '../adapters/anthropic/adapter.js'
 import XStockRepository from '../db/xstock-repository.js'
 import { handleError, withCredentials } from './with-account.js'
-import seed from '../data/xstocks.json'
+import { isSeeded, seededListing } from '../services/xstock-reference.js'
+import { currentJob, requestCancel, startClassify, startDescribe } from '../services/xstock-ai-job.js'
 
 const app = new Hono()
 
-const MAX_BATCH = 20
 const MIN_WORD_COUNT = 10
 const MAX_WORD_COUNT = 300
 const VOLUME_TTL_MS = 60 * 1000
@@ -31,46 +30,14 @@ async function tokenizedVolumes(krakenAPI) {
 const asWordCount = (value) =>
    Math.min(MAX_WORD_COUNT, Math.max(MIN_WORD_COUNT, Math.round(Number(value)) || 60))
 
-const seededListing = (ticker) => {
-   const entry = seed.listings[ticker]
-   return entry ? { ...entry, origin: 'seed', confidence: 'high', sources: [] } : null
-}
+async function requestedListings(tickers) {
 
-const resolveTickers = (requested, byTicker) =>
-   [...new Set(requested)].filter(ticker => byTicker.has(ticker)).slice(0, MAX_BATCH)
+   const listings = await new KrakenAPI().fetchTokenizedListings()
+   const byTicker = new Map(listings.map(listing => [listing.ticker, listing]))
 
-function reconcile(requested, returned, byTicker) {
-
-   const wanted = new Set(requested)
-   const seen = new Map()
-
-   for (const item of returned) {
-      if (!wanted.has(item.ticker)) {
-         console.warn(`xStocks classification returned an unrequested ticker, dropping: ${item.ticker}`)
-         continue
-      }
-      seen.set(item.ticker, item)
-   }
-
-   return requested.map(ticker => {
-      const item = seen.get(ticker)
-      if (!item) console.warn(`xStocks classification omitted a requested ticker: ${ticker}`)
-
-      const named = Boolean(item?.officialName?.trim())
-      const type = !item || !named ? 'unknown' : item.type
-
-      return {
-         ticker,
-         altname: byTicker.get(ticker).altname,
-         name: named ? item.officialName.trim() : '',
-         exchange: item?.listingExchange ?? '',
-         type,
-         subtype: type === 'unknown' ? '' : item.subtype ?? '',
-         confidence: type === 'unknown' ? 'low' : item.confidence ?? 'low',
-         sources: item?.sources ?? [],
-         origin: 'ai'
-      }
-   })
+   return [...new Set(tickers)]
+      .filter(ticker => byTicker.has(ticker))
+      .map(ticker => byTicker.get(ticker))
 }
 
 app.post('/listings', async (c) => {
@@ -115,57 +82,32 @@ app.post('/listings', async (c) => {
    }
 })
 
+app.get('/job', async (c) => c.json({ job: currentJob() }))
+
+app.post('/job/cancel', async (c) => c.json({ job: requestCancel() }))
+
 app.post('/classify', async (c) => withCredentials(c, 'anthropic', async ({ body, credentials }) => {
 
-   const { tickers = [] } = body
+   const listings = (await requestedListings(body.tickers ?? []))
+      .filter(listing => !isSeeded(listing.ticker))
 
-   const krakenAPI = new KrakenAPI()
-   const listings = await krakenAPI.fetchTokenizedListings()
-   const byTicker = new Map(listings.map(listing => [listing.ticker, listing]))
+   if (listings.length === 0) return c.json({ job: currentJob(), alreadyRunning: false })
 
-   const requested = resolveTickers(tickers, byTicker).filter(ticker => !seed.listings[ticker])
-   if (requested.length === 0) return c.json({ classified: [] })
-
-   const anthropicAPI = new AnthropicAPI(credentials.apiKey)
-   const returned = await anthropicAPI.classifyListings(requested)
-   const classified = reconcile(requested, returned, byTicker)
-
-   new XStockRepository().upsertListings(classified, Date.now())
-   return c.json({ classified })
+   return c.json(startClassify({ credentials, listings }))
 }, { secret: false }))
 
 app.post('/describe', async (c) => withCredentials(c, 'anthropic', async ({ body, credentials }) => {
 
-   const { tickers = [] } = body
    const wordCount = asWordCount(body.wordCount)
+   const listings = await requestedListings(body.tickers ?? [])
 
-   const krakenAPI = new KrakenAPI()
-   const listings = await krakenAPI.fetchTokenizedListings()
-   const byTicker = new Map(listings.map(listing => [listing.ticker, listing]))
+   if (listings.length === 0) return c.json({ job: currentJob(), alreadyRunning: false })
 
-   const requested = resolveTickers(tickers, byTicker)
-   if (requested.length === 0) return c.json({ described: [], wordCount })
-
-   const repository = new XStockRepository()
-   const stored = repository.findListings(requested)
-
-   const targets = requested.map(ticker => {
-      const base = seededListing(ticker) ?? stored.get(ticker)
-      return {
-         ticker,
-         name: base?.name ?? '',
-         exchange: base?.exchange ?? '',
-         type: base?.type ?? 'unknown',
-         subtype: base?.subtype ?? ''
-      }
-   })
-
-   const anthropicAPI = new AnthropicAPI(credentials.apiKey)
-   const described = (await anthropicAPI.describeListings(targets, wordCount))
-      .filter(item => item.description.trim())
-
-   repository.upsertDescriptions(described, wordCount, MODEL, Date.now())
-   return c.json({ described, wordCount })
+   return c.json(startDescribe({
+      credentials,
+      wordCount,
+      tickers: listings.map(listing => listing.ticker)
+   }))
 }, { secret: false }))
 
 export default app

--- a/src/server/services/xstock-ai-job.js
+++ b/src/server/services/xstock-ai-job.js
@@ -1,0 +1,265 @@
+import AnthropicAPI, {
+   MODEL, CLASSIFY_CHUNK_SIZE, CLASSIFY_CONCURRENCY, DESCRIBE_CONCURRENCY, chunked
+} from '../adapters/anthropic/adapter.js'
+import XStockRepository from '../db/xstock-repository.js'
+import { seededListing } from './xstock-reference.js'
+
+const terminalPhases = ['done', 'error', 'cancelled']
+
+let job = null
+let controller = null
+
+export function isRunning(candidate) {
+   return Boolean(candidate) && !terminalPhases.includes(candidate.phase)
+}
+
+export function currentJob() {
+   return job
+}
+
+export function requestCancel() {
+   if (isRunning(job)) {
+      job.cancelRequested = true
+      job.updatedAt = Date.now()
+      controller?.abort()
+   }
+   return job
+}
+
+export function startDescribe({ credentials, tickers, wordCount }) {
+   return start({
+      kind: 'describe',
+      wordCount,
+      groups: chunked(tickers, 1),
+      concurrency: DESCRIBE_CONCURRENCY,
+      run: (context) => describeWorker(context)
+   }, credentials)
+}
+
+export function startClassify({ credentials, listings }) {
+   const altnames = new Map(listings.map(listing => [listing.ticker, listing.altname]))
+   return start({
+      kind: 'classify',
+      wordCount: null,
+      groups: chunked(listings.map(listing => listing.ticker), CLASSIFY_CHUNK_SIZE),
+      concurrency: CLASSIFY_CONCURRENCY,
+      run: (context) => classifyWorker(context, altnames)
+   }, credentials)
+}
+
+function start({ kind, wordCount, groups, concurrency, run }, credentials) {
+
+   if (isRunning(job)) return { job, alreadyRunning: true }
+
+   job = {
+      kind,
+      wordCount,
+      phase: 'running',
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+      finishedAt: null,
+      steps: groups.flatMap((group, index) => group.map(ticker => newStep(ticker, index))),
+      error: null,
+      cancelRequested: false
+   }
+
+   controller = new AbortController()
+
+   const started = job
+   const signal = controller.signal
+
+   runJob(started, groups, concurrency, run, credentials, signal)
+      .catch(error => console.error(`Unexpected xStocks ${kind} failure:`, error))
+
+   return { job: started, alreadyRunning: false }
+}
+
+function newStep(ticker, group) {
+   return {
+      ticker,
+      group,
+      phase: 'pending',
+      activity: '',
+      searches: [],
+      startedAt: null,
+      finishedAt: null,
+      error: null
+   }
+}
+
+async function runJob(job, groups, concurrency, run, credentials, signal) {
+
+   try {
+      const anthropicAPI = new AnthropicAPI(credentials.apiKey)
+      const repository = new XStockRepository()
+      const worker = await run({ job, anthropicAPI, repository, signal })
+
+      await inParallel(groups.map((_, index) => index), concurrency,
+         index => runGroup(job, index, worker))
+
+      finish(job)
+   }
+   catch (error) {
+      finishSteps(job, job.steps.filter(step => step.phase === 'pending'), 'skipped')
+      job.phase = 'error'
+      job.error = String(error?.message ?? error)
+      job.finishedAt = Date.now()
+      job.updatedAt = job.finishedAt
+      console.error(`xStocks ${job.kind} failed before it could run:`, job.error)
+   }
+}
+
+async function describeWorker({ job, anthropicAPI, repository, signal }) {
+
+   const tickers = job.steps.map(step => step.ticker)
+   const stored = repository.findListings(tickers)
+
+   const targets = new Map(tickers.map(ticker => {
+      const base = seededListing(ticker) ?? stored.get(ticker)
+      return [ticker, {
+         ticker,
+         name: base?.name ?? '',
+         exchange: base?.exchange ?? '',
+         type: base?.type ?? 'unknown',
+         subtype: base?.subtype ?? ''
+      }]
+   }))
+
+   return async ([ticker], onActivity) => {
+
+      const described = await anthropicAPI.describeListing(
+         targets.get(ticker), job.wordCount, { onActivity, abortSignal: signal })
+
+      if (!described.description.trim()) throw new Error('Claude returned an empty description.')
+
+      repository.upsertDescriptions([described], job.wordCount, MODEL, Date.now())
+   }
+}
+
+async function classifyWorker({ anthropicAPI, repository, signal }, altnames) {
+
+   return async (tickers, onActivity) => {
+
+      const returned = await anthropicAPI.classifyTickers(tickers, { onActivity, abortSignal: signal })
+      repository.upsertListings(reconcile(tickers, returned, altnames), Date.now())
+   }
+}
+
+async function runGroup(job, group, worker) {
+
+   const steps = job.steps.filter(step => step.group === group)
+
+   if (job.cancelRequested) return finishSteps(job, steps, 'cancelled')
+
+   const startedAt = Date.now()
+   for (const step of steps) {
+      step.phase = 'running'
+      step.startedAt = startedAt
+   }
+
+   setActivity(job, steps, 'Asking Claude…')
+
+   try {
+      await worker(steps.map(step => step.ticker), (event) => report(job, steps, event))
+      finishSteps(job, steps, 'done')
+   }
+   catch (error) {
+      const message = String(error?.message ?? error)
+      if (job.cancelRequested) finishSteps(job, steps, 'cancelled')
+      else finishSteps(job, steps, 'error', message)
+   }
+}
+
+function report(job, steps, event) {
+
+   if (event.type === 'searching') {
+      for (const step of steps) step.searches.push(event.query)
+      return setActivity(job, steps,
+         event.query ? `Searching the web for “${event.query}”` : 'Searching the web…')
+   }
+
+   if (event.type === 'reading') {
+      const query = steps[0]?.searches.at(-1)
+      return setActivity(job, steps,
+         query ? `Reading the results for “${query}”` : 'Reading what the search found…')
+   }
+
+   setActivity(job, steps, 'Writing the answer…')
+}
+
+function setActivity(job, steps, activity) {
+   if (steps.every(step => step.activity === activity)) return
+   for (const step of steps) step.activity = activity
+   job.updatedAt = Date.now()
+}
+
+function finishSteps(job, steps, phase, error = null) {
+   const finishedAt = Date.now()
+   for (const step of steps) {
+      step.phase = phase
+      step.activity = ''
+      step.error = error
+      step.finishedAt = finishedAt
+   }
+   job.updatedAt = finishedAt
+}
+
+function finish(job) {
+
+   const done = job.steps.filter(step => step.phase === 'done').length
+   const failed = job.steps.filter(step => step.phase === 'error')
+
+   if (job.cancelRequested) job.phase = 'cancelled'
+   else if (done === 0 && failed.length > 0) {
+      job.phase = 'error'
+      job.error = failed[0].error
+   }
+   else job.phase = 'done'
+
+   job.finishedAt = Date.now()
+   job.updatedAt = job.finishedAt
+
+   console.log(`xStocks ${job.kind} finished ${job.phase}: ${done} done, ${failed.length} failed`)
+}
+
+const inParallel = async (items, size, worker) => {
+   let cursor = 0
+   const runners = Array.from({ length: Math.min(size, items.length) }, async () => {
+      while (cursor < items.length) await worker(items[cursor++])
+   })
+   await Promise.all(runners)
+}
+
+function reconcile(requested, returned, altnames) {
+
+   const wanted = new Set(requested)
+   const seen = new Map()
+
+   for (const item of returned) {
+      if (!wanted.has(item.ticker)) {
+         console.warn(`xStocks classification returned an unrequested ticker, dropping: ${item.ticker}`)
+         continue
+      }
+      seen.set(item.ticker, item)
+   }
+
+   return requested.map(ticker => {
+      const item = seen.get(ticker)
+      if (!item) console.warn(`xStocks classification omitted a requested ticker: ${ticker}`)
+
+      const named = Boolean(item?.officialName?.trim())
+      const type = !item || !named ? 'unknown' : item.type
+
+      return {
+         ticker,
+         altname: altnames.get(ticker),
+         name: named ? item.officialName.trim() : '',
+         exchange: item?.listingExchange ?? '',
+         type,
+         subtype: type === 'unknown' ? '' : item.subtype ?? '',
+         confidence: type === 'unknown' ? 'low' : item.confidence ?? 'low',
+         sources: item?.sources ?? [],
+         origin: 'ai'
+      }
+   })
+}

--- a/src/server/services/xstock-reference.js
+++ b/src/server/services/xstock-reference.js
@@ -1,0 +1,8 @@
+import seed from '../data/xstocks.json'
+
+export const isSeeded = (ticker) => Boolean(seed.listings[ticker])
+
+export const seededListing = (ticker) => {
+   const entry = seed.listings[ticker]
+   return entry ? { ...entry, origin: 'seed', confidence: 'high', sources: [] } : null
+}

--- a/src/views/components/kraken/xstock-job.jsx
+++ b/src/views/components/kraken/xstock-job.jsx
@@ -1,0 +1,93 @@
+import { Loader2Icon, XIcon } from 'lucide-react'
+import { asCount } from '../lib/filter-options'
+
+const terminalPhases = ['done', 'error', 'cancelled']
+const settledPhases = ['done', 'error', 'cancelled', 'skipped']
+
+export const isJobRunning = job => Boolean(job) && !terminalPhases.includes(job.phase)
+
+export const jobVerbs = {
+   describe: { action: 'describe', gerund: 'describing', present: 'Describing', past: 'Described' },
+   classify: { action: 'classify', gerund: 'classifying', present: 'Classifying', past: 'Classified' }
+}
+
+export function jobCounts(job) {
+   const steps = job?.steps ?? []
+   return {
+      total: steps.length,
+      done: steps.filter(step => step.phase === 'done').length,
+      failed: steps.filter(step => step.phase === 'error').length,
+      settled: steps.filter(step => settledPhases.includes(step.phase)).length,
+      running: steps.filter(step => step.phase === 'running')
+   }
+}
+
+export const describingTickers = job =>
+   new Set(jobCounts(job).running.map(step => step.ticker))
+
+const elapsedSeconds = (job) => {
+   const end = isJobRunning(job) ? Date.now() : (job.finishedAt ?? job.startedAt)
+   return Math.max(0, Math.round((end - job.startedAt) / 1000))
+}
+
+export default function XStockJobProgress({ job }) {
+
+   if (!job) return null
+
+   const running = isJobRunning(job)
+   const counts = jobCounts(job)
+   const failures = (job.steps ?? []).filter(step => step.phase === 'error')
+
+   if (!running && failures.length === 0) return null
+
+   const verbs = jobVerbs[job.kind] ?? jobVerbs.describe
+   const percent = counts.total === 0 ? 0 : Math.round((counts.settled / counts.total) * 100)
+
+   return (
+      <div className="space-y-3 rounded-md border border-border bg-muted/40 p-3">
+
+         <div className="flex items-baseline justify-between gap-4 text-sm">
+            <span className="font-medium">
+               {running
+                  ? `${verbs.present} ${counts.settled} of ${counts.total}`
+                  : `${verbs.past} ${counts.done} of ${counts.total}`}
+            </span>
+            <span className="shrink-0 tabular-nums text-muted-foreground">{elapsedSeconds(job)}s</span>
+         </div>
+
+         <div className="h-1.5 overflow-hidden rounded-full bg-border">
+            <div
+               className="h-full rounded-full bg-primary transition-[width] duration-500"
+               style={{ width: `${percent}%` }} />
+         </div>
+
+         {counts.running.length > 0 &&
+            <ul className="space-y-1.5">
+               {counts.running.map(step =>
+                  <li key={step.ticker} className="flex items-baseline gap-2 text-sm">
+                     <Loader2Icon className="size-3.5 shrink-0 translate-y-0.5 animate-spin text-muted-foreground" />
+                     <span className="w-16 shrink-0 truncate font-medium" title={step.ticker}>{step.ticker}</span>
+                     <span className="min-w-0 flex-1 truncate text-muted-foreground" title={step.activity}>
+                        {step.activity || 'Waiting for Claude…'}
+                     </span>
+                  </li>)}
+            </ul>}
+
+         {failures.length > 0 &&
+            <div className="space-y-1.5 border-t border-border pt-3">
+               <p className="text-sm text-destructive">
+                  {asCount(failures.length, 'listing')} Claude could not {verbs.action}.
+               </p>
+               <ul className="space-y-1">
+                  {failures.map(step =>
+                     <li key={step.ticker} className="flex items-baseline gap-2 text-xs">
+                        <XIcon className="size-3 shrink-0 translate-y-0.5 text-destructive" />
+                        <span className="w-16 shrink-0 truncate font-medium" title={step.ticker}>{step.ticker}</span>
+                        <span className="min-w-0 flex-1 text-muted-foreground">{step.error}</span>
+                     </li>)}
+               </ul>
+            </div>}
+
+      </div>
+   )
+}

--- a/src/views/mocks/index.js
+++ b/src/views/mocks/index.js
@@ -1,6 +1,6 @@
 import {
    tradingPairs, orderBatch, balances, assetRates,
-   xstockListings, xstockClassify, xstockDescribe
+   xstockListings, xstockClassify, xstockDescribe, xstockJob, xstockJobCancel
 } from './kraken'
 import {
    ledgerSync, ledgerSyncStatus, ledgerSyncCancel, ledgerClear,
@@ -18,6 +18,8 @@ const mockRoutes = {
    '/api/kraken/xstocks/listings': (params) => xstockListings(params?.arg),
    '/api/kraken/xstocks/classify': (params) => xstockClassify(params?.arg),
    '/api/kraken/xstocks/describe': (params) => xstockDescribe(params?.arg),
+   '/api/kraken/xstocks/job': () => xstockJob(),
+   '/api/kraken/xstocks/job/cancel': () => xstockJobCancel(),
    '/api/kraken/ledger/sync': (params) => ledgerSync(params?.arg),
    '/api/kraken/ledger/sync/status': () => ledgerSyncStatus(),
    '/api/kraken/ledger/sync/cancel': () => ledgerSyncCancel(),

--- a/src/views/mocks/kraken.js
+++ b/src/views/mocks/kraken.js
@@ -129,8 +129,88 @@ const xstockListings = (params) => {
    }
 }
 
-const xstockClassify = (params) => {
-   const classified = (params?.tickers ?? []).map(ticker => ({
+const mockActivities = [
+   'Asking Claude…',
+   'Searching the web for “latest holdings and expense ratio”',
+   'Reading what the search found…',
+   'Writing the answer…'
+]
+
+let mockJob = null
+
+const mockStep = (ticker, group) => ({
+   ticker, group, phase: 'pending', activity: '', searches: [],
+   startedAt: null, finishedAt: null, error: null
+})
+
+const startMockJob = (kind, tickers, wordCount, groupSize) => {
+
+   const groups = []
+   for (let index = 0; index < tickers.length; index += groupSize) {
+      groups.push(tickers.slice(index, index + groupSize))
+   }
+
+   mockJob = {
+      kind,
+      wordCount,
+      phase: 'running',
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+      finishedAt: null,
+      steps: groups.flatMap((group, index) => group.map(ticker => mockStep(ticker, index))),
+      error: null,
+      cancelRequested: false,
+      ticks: 0
+   }
+
+   return { job: structuredClone(mockJob), alreadyRunning: false }
+}
+
+const snapshot = () => ({ job: mockJob ? structuredClone(mockJob) : null })
+
+const advanceMockJob = () => {
+
+   if (!mockJob || mockJob.phase !== 'running') return snapshot()
+
+   mockJob.ticks++
+   mockJob.updatedAt = Date.now()
+
+   const running = mockJob.steps.filter(step => step.phase === 'running')
+
+   for (const step of running) {
+      step.activity = mockActivities[Math.min(mockJob.ticks % 5, mockActivities.length - 1)]
+   }
+
+   if (mockJob.ticks % 4 === 0) {
+      for (const step of running) {
+         step.phase = 'done'
+         step.activity = ''
+         step.finishedAt = Date.now()
+         if (mockJob.kind === 'describe') storeMockDescription(step.ticker, mockJob.wordCount)
+         else storeMockClassification(step.ticker)
+      }
+   }
+
+   if (!mockJob.steps.some(step => step.phase === 'running')) {
+      const next = mockJob.steps.find(step => step.phase === 'pending')
+      if (next) {
+         for (const step of mockJob.steps.filter(s => s.group === next.group)) {
+            step.phase = 'running'
+            step.startedAt = Date.now()
+            step.activity = mockActivities[0]
+         }
+      }
+      else {
+         mockJob.phase = 'done'
+         mockJob.finishedAt = Date.now()
+      }
+   }
+
+   return snapshot()
+}
+
+const storeMockClassification = (ticker) => {
+   mockClassifications.set(ticker, {
       ticker,
       altname: `${ticker}x`,
       name: ticker === 'KRAQ' ? 'KRAKacquisition Corp.' : 'Jersey Mike\'s Subs Inc.',
@@ -140,33 +220,37 @@ const xstockClassify = (params) => {
       confidence: 'high',
       sources: ['https://example.com/mock-source'],
       origin: 'ai'
-   }))
-
-   for (const listing of classified) {
-      mockClassifications.set(listing.ticker, listing)
-   }
-
-   return { classified }
+   })
 }
 
-const xstockDescribe = (params) => {
-   const wordCount = params?.wordCount ?? 60
-   const described = (params?.tickers ?? []).map(ticker => ({
-      ticker,
-      description: `Mocked ${wordCount}-word description for ${ticker}. Generated without contacting `
-         + 'Anthropic, so it is filler rather than anything you should read as fact. Click to expand '
-         + 'and collapse this text the way a real description behaves.',
-      sources: ['https://example.com/mock-source']
-   }))
+const storeMockDescription = (ticker, wordCount) => {
+   mockDescriptions.set(describedKey(ticker, wordCount),
+      `Mocked ${wordCount}-word description for ${ticker}. Generated without contacting `
+      + 'Anthropic, so it is filler rather than anything you should read as fact. Click to expand '
+      + 'and collapse this text the way a real description behaves.')
+}
 
-   for (const item of described) {
-      mockDescriptions.set(describedKey(item.ticker, wordCount), item.description)
+const xstockClassify = (params) =>
+   startMockJob('classify', params?.tickers ?? [], null, 10)
+
+const xstockDescribe = (params) =>
+   startMockJob('describe', params?.tickers ?? [], params?.wordCount ?? 60, 1)
+
+const xstockJob = () => advanceMockJob()
+
+const xstockJobCancel = () => {
+   if (mockJob?.phase === 'running') {
+      mockJob.cancelRequested = true
+      mockJob.phase = 'cancelled'
+      mockJob.finishedAt = Date.now()
+      for (const step of mockJob.steps) {
+         if (step.phase === 'running' || step.phase === 'pending') step.phase = 'cancelled'
+      }
    }
-
-   return { described, wordCount }
+   return snapshot()
 }
 
 export {
    tradingPairs, orderBatch, balances, assetRates,
-   xstockListings, xstockClassify, xstockDescribe
+   xstockListings, xstockClassify, xstockDescribe, xstockJob, xstockJobCancel
 }

--- a/src/views/pages/kraken/xstocks.jsx
+++ b/src/views/pages/kraken/xstocks.jsx
@@ -7,6 +7,7 @@ import { Loader2Icon, SparklesIcon, SearchIcon } from 'lucide-react'
 import KrakenLayout from '../../components/kraken/kraken-layout'
 import InfoBanner from '../../components/lib/info-banner'
 import XStockTable from '../../components/kraken/xstock-table'
+import XStockJobProgress, { describingTickers, isJobRunning, jobCounts, jobVerbs } from '../../components/kraken/xstock-job'
 import Field from '../../components/lib/field'
 import NumericInput from '../../components/lib/numeric-input'
 import SelectField from '../../components/lib/select-field'
@@ -21,8 +22,8 @@ import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 
 const PAGE_SIZE = 50
-const BATCH_SIZE = 20
 const SETTINGS_KEY = 'kraken.xstocks.settings'
+const JOB_KEY = '/api/kraken/xstocks/job'
 
 const typeOptions = [
    { value: ANY, label: 'All types' },
@@ -58,6 +59,29 @@ const reviveSettings = (stored, defaults) => ({
    scope: scopeValues.has(stored.scope) ? stored.scope : defaults.scope
 })
 
+function announce(job) {
+
+   const verbs = jobVerbs[job.kind] ?? jobVerbs.describe
+   const { done, failed } = jobCounts(job)
+
+   if (job.phase === 'error') {
+      return toast.error(job.error ?? `Could not ${verbs.action} those listings.`)
+   }
+
+   if (done === 0) {
+      return toast.info(job.phase === 'cancelled'
+         ? 'Stopped before anything was generated.'
+         : `Nothing was ${verbs.past.toLowerCase()}.`)
+   }
+
+   const summary = `${verbs.past} ${asCount(done, 'listing')}`
+
+   if (job.phase === 'cancelled') return toast.info(`${summary} before stopping.`)
+   if (failed > 0) return toast.warning(`${summary}, ${failed} failed.`)
+
+   toast.success(`${summary}.`)
+}
+
 export default function KrakenXStocks() {
 
    const { configured: hasAnthropicKey } = useProvider('anthropic')
@@ -71,10 +95,9 @@ export default function KrakenXStocks() {
    const [searchInput, setSearchInput] = useState('')
    const [search, setSearch] = useState('')
    const [page, setPage] = useState(0)
-   const [describing, setDescribing] = useState(() => new Set())
-   const [progress, setProgress] = useState(null)
 
-   const stopRequested = useRef(false)
+   const startedRef = useRef(false)
+   const settledRef = useRef(0)
 
    useEffect(() => {
       const timer = setTimeout(() => {
@@ -105,6 +128,34 @@ export default function KrakenXStocks() {
 
    const { trigger: describe } = useSWRMutation('/api/kraken/xstocks/describe')
    const { trigger: classify } = useSWRMutation('/api/kraken/xstocks/classify')
+   const { trigger: cancel } = useSWRMutation('/api/kraken/xstocks/job/cancel')
+
+   const { data: jobData, mutate: mutateJob } = useSWR(JOB_KEY, {
+      refreshInterval: latest => isJobRunning(latest?.job) ? 1000 : 0,
+      onSuccess: (latest) => {
+         const latestJob = latest?.job ?? null
+
+         if (isJobRunning(latestJob)) {
+            startedRef.current = true
+
+            const settled = jobCounts(latestJob).settled
+            if (settled !== settledRef.current) {
+               settledRef.current = settled
+               mutate()
+            }
+            return
+         }
+
+         if (!startedRef.current) return
+
+         startedRef.current = false
+         settledRef.current = 0
+         mutate()
+         if (latestJob) announce(latestJob)
+      }
+   })
+
+   const job = jobData?.job ?? null
 
    const listings = useMemo(() => data?.listings ?? [], [data])
 
@@ -144,64 +195,37 @@ export default function KrakenXStocks() {
    const isFiltered = search !== '' || type !== ANY
    const visible = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
 
-   const runInBatches = async (tickers, label, worker) => {
+   const startJob = (tickers, kind, trigger) => {
 
-      if (tickers.length === 0) {
-         toast.info(`Nothing to ${label}.`)
-         return
-      }
+      if (tickers.length === 0) return toast.info(`Nothing to ${jobVerbs[kind].action}.`)
 
-      stopRequested.current = false
-      setProgress({ done: 0, total: tickers.length })
+      settledRef.current = 0
 
-      let completed = 0
-      let failed = false
-
-      for (let index = 0; index < tickers.length; index += BATCH_SIZE) {
-         if (stopRequested.current) break
-
-         const batch = tickers.slice(index, index + BATCH_SIZE)
-         setDescribing(new Set(batch))
-
-         try {
-            await worker(batch)
-            completed += batch.length
-         }
-         catch (reason) {
-            failed = true
-            toast.error(typeof reason === 'string' ? reason : `Could not ${label} those listings.`)
-            break
-         }
-
-         setProgress({ done: completed, total: tickers.length })
-         await mutate()
-      }
-
-      setDescribing(new Set())
-      setProgress(null)
-
-      if (!failed && completed > 0) {
-         const stopped = stopRequested.current && completed < tickers.length
-         toast.success(`${label === 'describe' ? 'Described' : 'Classified'} ${asCount(completed, 'listing')}${stopped ? ' before stopping' : ''}.`)
-      }
+      trigger({ tickers, wordCount })
+         .then(() => mutateJob())
+         .catch(reason => toast.error(typeof reason === 'string'
+            ? reason
+            : `Could not start ${jobVerbs[kind].gerund}.`))
    }
 
-   const generateDescriptions = (tickers) =>
-      runInBatches(tickers, 'describe', batch => describe({ tickers: batch, wordCount }))
+   const generateDescriptions = (tickers) => startJob(tickers, 'describe', describe)
 
-   const classifyUnknown = () =>
-      runInBatches(
-         listings.filter(listing => listing.type === 'unclassified').map(listing => listing.ticker),
-         'classify',
-         batch => classify({ tickers: batch }))
+   const classifyUnknown = () => startJob(
+      listings.filter(listing => listing.type === 'unclassified').map(listing => listing.ticker),
+      'classify',
+      classify)
 
    const describeScope = () =>
       generateDescriptions(listings
          .filter(listing => inScope(listing, scope) && !listing.description)
          .map(listing => listing.ticker))
 
-   const isBusy = progress !== null
+   const stop = () => cancel().then(() => mutateJob()).catch(() => {})
+
+   const isBusy = isJobRunning(job)
+   const isGenerating = isBusy && job.kind === 'describe'
    const canDescribe = hasAnthropicKey && !isBusy
+   const describing = describingTickers(job)
 
    const pendingInScope = useMemo(
       () => listings.filter(listing => inScope(listing, scope) && !listing.description).length,
@@ -274,7 +298,7 @@ export default function KrakenXStocks() {
                         {isBusy &&
                            <span className="flex items-center gap-2 text-sm text-muted-foreground">
                               <Loader2Icon className="size-4 animate-spin" />
-                              {progress.done} of {progress.total}
+                              {jobVerbs[job.kind]?.present ?? 'Working'}
                            </span>}
                      </CardAction>
                   </CardHeader>
@@ -297,16 +321,18 @@ export default function KrakenXStocks() {
                            type="button"
                            disabled={!canDescribe || pendingInScope === 0}
                            onClick={describeScope}>
-                           {isBusy
+                           {isGenerating
                               ? <Loader2Icon className="size-3.5 animate-spin" />
                               : <SparklesIcon className="size-3.5" />}
-                           {isBusy ? 'Generating…' : 'Generate'}
+                           {isGenerating ? 'Generating…' : 'Generate'}
                         </Button>
                         {isBusy &&
-                           <Button variant="ghost" type="button" onClick={() => { stopRequested.current = true }}>
+                           <Button variant="ghost" type="button" onClick={stop}>
                               Stop
                            </Button>}
                      </div>
+
+                     <XStockJobProgress job={job} />
 
                      {!hasAnthropicKey &&
                         <Alert>


### PR DESCRIPTION
Closes #240.

## What was wrong

Two symptoms, one cause.

**The spurious error.** Generating descriptions ran inside the HTTP request that asked for them, twenty listings per request. One listing takes a minute or more, so a batch far outlived Bun's default `idleTimeout` of ten seconds. Bun closed the connection under the client, `fetch` rejected with a `TypeError` (not the string the page's error path expects), and the page fell back to "Could not describe those listings." Nothing was logged server-side because the handler never errored — it kept running, finished, and wrote the descriptions that then appeared on the next revalidation. `src/electrobun/index.ts` already ran with `idleTimeout: 0`, so only the web build was affected.

**No feedback.** Progress only advanced once per batch of twenty, which is minutes apart, and Stop was only checked between batches.

## What changed

`src/server/index.js` now serves with `idleTimeout: 0`, matching the packaged app. Generation no longer sits in a request at all.

A run is a job on the server (`src/server/services/xstock-ai-job.js`), polled the way a ledger sync is: `POST /describe` and `POST /classify` start one and return immediately, `GET /job` reports it, `POST /job/cancel` stops it. Each listing is its own step, so the page shows which tickers are in flight and what Claude is searching the web for right now.

Claude is called through `streamText` instead of `generateText` so the `web_search` tool calls can be reported while the model is still working. Real output from a run:

```
running | Asking Claude…
running | Reading the results for “Meta Platforms Inc META stock business model”
running | Reading the results for “Meta Platforms risks challenges regulation”
running | Writing the answer…
done
```

Descriptions are stored as each one lands rather than after all twenty, so a stopped or interrupted run keeps what it finished and the table fills in behind the progress list. Stop aborts the calls in flight via `AbortSignal` rather than waiting out the current batch. One listing failing now fails only that listing — it is reported on its own row instead of ending the run.

## Verified

- End-to-end against the real Anthropic API: single listing, five concurrent listings, and cancel mid-run. Per-listing DB writes confirmed by distinct `generated_at` timestamps seconds apart.
- The classify path exercised directly (no unclassified listings exist in the current reference data to drive it from the UI).
- The UI in mock mode: progress bar, per-ticker activity lines, live `Described n / total`, completion toast, and Stop.
- `eslint` and `vite build` clean.

## Note

Per the repo owner's standing instruction I did not add code comments to the new files, which reads differently from the surrounding heavily-commented code — say the word and I'll bring them in line with the house style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)