### PR TITLE
fix(settings): disable the API key fields while settings load

### DIFF
--- a/src/views/components/lib/input.jsx
+++ b/src/views/components/lib/input.jsx
@@ -1,7 +1,7 @@
 import { Input as ShadcnInput } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 
-export default function Input({ name, type = 'text', defaultValue, value, onChange, label, className = '' }) {
+export default function Input({ name, type = 'text', defaultValue, value, onChange, label, disabled = false, className = '' }) {
 
    const autoComplete = type === 'password' ? 'current-password' : 'none'
 
@@ -15,6 +15,7 @@ export default function Input({ name, type = 'text', defaultValue, value, onChan
             value={value}
             defaultValue={defaultValue}
             onChange={onChange}
+            disabled={disabled}
             autoComplete={autoComplete}
          />
       </div>


### PR DESCRIPTION
## Problem

`src/views/components/lib/input.jsx` never accepted a `disabled` prop, so the `disabled={isLoading}` that `src/views/pages/settings.jsx` passes to the API Key and API Secret fields was silently dropped. Only the Save button was actually disabled.

The fields therefore stayed editable during the initial settings fetch. Their `key` includes the fetched value (`${provider.id}-key-${stored?.apiKey ?? ''}`), so when the fetch resolved the key changed, React remounted the input, and anything typed in the meantime was destroyed with no feedback.

Not exploitable for an empty overwrite: the submit button is disabled while loading, which also blocks implicit Enter submission.

## Change

Accept `disabled = false` in the `Input` signature and forward it to the underlying `ShadcnInput`, which already spreads `...props` and carries `disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50` styling.

## Other callers

`ledger-filters.jsx`, `order-filters.jsx` and `balance-filters.jsx` pass only `name`/`type`/`label`/`value`/`onChange`, all already forwarded, and none pass `disabled`, `required`, `placeholder` or `readOnly`. The `<Input>` in `xstocks.jsx` is the shadcn component imported directly, not this wrapper.

## Notes

Pre-existing, unrelated to the credential-store work in #247, so kept as its own change.

Not lint- or build-verified: `node_modules` is empty in this checkout, so `bun run lint` and `vite build` both fail on missing packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)