### PR TITLE
feat(kraken): tighten order batch parameters layout

### DIFF
--- a/src/views/components/kraken/order-batch-params.jsx
+++ b/src/views/components/kraken/order-batch-params.jsx
@@ -92,9 +92,9 @@ export default function OrderBatchParameters({ formValues, setFormValues, tradin
                label="Reference"
                hint={
                   <FieldHint label="About the reference">
-                     Optional. Kraken&apos;s <span className="font-mono">userref</span>: a whole number
-                     stamped on every order in the batch and shown as a column on the Open Orders page,
-                     so a ladder can be told apart from the rest of the book. Left empty, none is sent.
+                     Optional whole number sent as Kraken&apos;s <span className="font-mono">userref</span> on
+                     every order in the batch. It shows as a column on the Open Orders page, so you can
+                     tell this series apart from your other orders.
                   </FieldHint>
                }
                value={formValues.userref ?? ''}

--- a/src/views/components/kraken/order-batch-params.jsx
+++ b/src/views/components/kraken/order-batch-params.jsx
@@ -2,6 +2,7 @@ import NumericInput from '../lib/numeric-input'
 import SelectField from '../lib/select-field'
 import ComboboxField from '../lib/combobox-field'
 import Input from '../lib/input'
+import FieldHint from '../lib/field-hint'
 import { Button } from '@/components/ui/button'
 
 const directionOptions = [
@@ -28,7 +29,7 @@ export default function OrderBatchParameters({ formValues, setFormValues, tradin
 
    return (
       <form onSubmit={(e) => e.preventDefault()} className="space-y-4">
-         <div className="grid grid-cols-2 gap-x-4 gap-y-3 md:grid-cols-3 lg:grid-cols-4">
+         <div className="grid grid-cols-2 gap-x-4 gap-y-3 md:grid-cols-3 lg:grid-cols-5">
             <ComboboxField
                name="pair"
                label="Pair"
@@ -88,17 +89,18 @@ export default function OrderBatchParameters({ formValues, setFormValues, tradin
             <Input
                name="userref"
                type="number"
-               label="Reference (optional)"
+               label="Reference"
+               hint={
+                  <FieldHint label="About the reference">
+                     Optional. Kraken&apos;s <span className="font-mono">userref</span>: a whole number
+                     stamped on every order in the batch and shown as a column on the Open Orders page,
+                     so a ladder can be told apart from the rest of the book. Left empty, none is sent.
+                  </FieldHint>
+               }
                value={formValues.userref ?? ''}
                onChange={(e) => handleChange('userref', e.target.value)}
             />
          </div>
-
-         <p className="text-xs text-muted-foreground">
-            The reference is Kraken&apos;s <span className="font-mono">userref</span>: a whole number
-            of your own stamped on every order in the batch, shown as a column on the Open Orders page
-            so a ladder can be told apart from the rest of the book. Left empty, no reference is sent.
-         </p>
 
          <div className="flex flex-wrap gap-2">
             <Button variant="outline" size="sm" type="button" onClick={onShowPreview}>Show preview</Button>

--- a/src/views/components/lib/field-hint.jsx
+++ b/src/views/components/lib/field-hint.jsx
@@ -1,0 +1,18 @@
+import { InfoIcon } from 'lucide-react'
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
+
+export default function FieldHint({ label = 'More information', children }) {
+   return (
+      <Popover>
+         <PopoverTrigger
+            type="button"
+            aria-label={label}
+            className="text-muted-foreground transition-colors hover:text-foreground focus-visible:text-foreground focus-visible:outline-hidden">
+            <InfoIcon className="size-3.5" />
+         </PopoverTrigger>
+         <PopoverContent align="start" className="text-xs leading-relaxed text-muted-foreground">
+            <p>{children}</p>
+         </PopoverContent>
+      </Popover>
+   )
+}

--- a/src/views/components/lib/input.jsx
+++ b/src/views/components/lib/input.jsx
@@ -1,13 +1,16 @@
 import { Input as ShadcnInput } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 
-export default function Input({ name, type = 'text', defaultValue, value, onChange, label, disabled = false, className = '' }) {
+export default function Input({ name, type = 'text', defaultValue, value, onChange, label, hint, disabled = false, className = '' }) {
 
    const autoComplete = type === 'password' ? 'current-password' : 'none'
 
    return (
       <div className={`space-y-1 ${className}`}>
-         <Label htmlFor={name} className="pl-2.5 text-xs">{label}</Label>
+         <div className="flex items-center gap-1 pl-2.5">
+            <Label htmlFor={name} className="text-xs">{label}</Label>
+            {hint}
+         </div>
          <ShadcnInput
             type={type}
             id={name}

--- a/src/views/lib/tools.js
+++ b/src/views/lib/tools.js
@@ -42,13 +42,13 @@ export const toolGroups = [
          {
             href: '/kraken/open-orders',
             title: 'Open Orders',
-            description: 'See what is still on the book, grouped by pair, and cancel one order or a whole ladder.',
+            description: 'See what is still on the book, grouped by pair, and cancel one order or a whole series.',
             icon: ListChecksIcon
          },
          {
             href: '/kraken/order-batch',
             title: 'Order Batch',
-            description: 'Create a ladder of limit orders for a trading pair in one go.',
+            description: 'Create a series of limit orders for a trading pair in one go.',
             icon: LayersIcon
          },
          {

--- a/src/views/pages/kraken/order-batch.jsx
+++ b/src/views/pages/kraken/order-batch.jsx
@@ -149,10 +149,9 @@ export default function KrakenOrderBatch() {
       <KrakenLayout name="Order Batch">
          <div className="space-y-6">
             <InfoBanner>
-               Create multiple limit orders for a trading pair in one go — for example a ladder of
-               buy orders below the current price, or sell orders above it. Orders are {postLimitOrders} and
-               the quote currency is used for fees. Depending on your verification level Kraken allows
-               between {maxOpenOrders} across all pairs. Orders are sent in batches of 15 (Kraken API limit).
+               Create a ladder of limit orders on one pair in a single go. Orders are {postLimitOrders},
+               fees are taken in the quote currency, and orders are sent 15 at a time (Kraken API limit).
+               Kraken allows between {maxOpenOrders} across all pairs, depending on your verification level.
             </InfoBanner>
 
             <Card size="sm">

--- a/src/views/pages/kraken/order-batch.jsx
+++ b/src/views/pages/kraken/order-batch.jsx
@@ -149,7 +149,7 @@ export default function KrakenOrderBatch() {
       <KrakenLayout name="Order Batch">
          <div className="space-y-6">
             <InfoBanner>
-               Create a ladder of limit orders on one pair in a single go. Orders are {postLimitOrders},
+               Create a series of limit orders on one pair in a single go. Orders are {postLimitOrders},
                fees are taken in the quote currency, and orders are sent 15 at a time (Kraken API limit).
                Kraken allows between {maxOpenOrders} across all pairs, depending on your verification level.
             </InfoBanner>


### PR DESCRIPTION
## What changed

- The page banner is cut to three lines: it keeps both support links (post limit orders, open order limits) and the 15-orders-per-batch API limit, and drops the restatement of what a ladder is.
- The paragraph explaining `userref` under the form is gone. It now lives behind an info icon next to the **Reference** label, opened on click.
- The parameters grid goes from `lg:grid-cols-4` to `lg:grid-cols-5`, so the nine fields sit in two rows (5 + 4) and the action buttons move up.
- The field label is now **Reference** rather than **Reference (optional)**; "optional" moved into the hint text.

## New component

`src/views/components/lib/field-hint.jsx` wraps the already-installed `popover.jsx` primitive with an `InfoIcon` trigger — no new dependency, no new shadcn primitive. `Input` gained an optional `hint` slot rendered beside its label; every other `Input` call site renders unchanged.

## Note for reviewers

While looking at this I checked the `userref` question that started it: the field is still in the Kraken API and is not deprecated. It is easy to miss in the docs because it is a per-order field nested in the `orders` array schema, not a batch-level parameter — `resource.js` already spreads it inside `orders.map(...)`, so no server change was needed here.

Verified in mocked mode (`bun run mocked`) at 1440×900: five columns, popover renders as a single paragraph, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)