### PR TITLE
feat(kraken): total both sides of an aggregated trades range

### DIFF
--- a/src/server/db/trade-repository.js
+++ b/src/server/db/trade-repository.js
@@ -101,7 +101,7 @@ export default function TradeRepository(accountId) {
       const empty = {
          rows: [], total: 0, page, pageSize,
          baseAsset: filters.base ?? '', quoteAsset: filters.quote ?? '',
-         quoteAssets: [], truncated: false
+         quoteAssets: [], summary: emptySummary(), truncated: false
       }
 
       if (!filters.base) return empty
@@ -125,7 +125,8 @@ export default function TradeRepository(accountId) {
          ? trades.filter(trade => trade.orderKey !== trades[0].orderKey)
          : trades
 
-      const groups = asAggregations(foldOrders(kept))
+      const orders = foldOrders(kept)
+      const groups = asAggregations(orders)
       const ordered = filters.order === 'asc' ? groups : groups.toReversed()
 
       return {
@@ -136,6 +137,7 @@ export default function TradeRepository(accountId) {
          baseAsset: filters.base,
          quoteAsset: filters.quote ?? '',
          quoteAssets: [...new Set(groups.flatMap(group => group.quotes.map(quote => quote.quoteAsset)))],
+         summary: asSummary(orders),
          truncated
       }
    }
@@ -193,6 +195,60 @@ export default function TradeRepository(accountId) {
       db.query('DELETE FROM trade WHERE account_id = ?').run(accountId)
       return deleted
    }
+}
+
+// Both sides of the whole selection, so the page can show what the range averages
+// out to. Every order in the range counts, not only the ones on the current page,
+// and each side keeps its quote currencies apart the way a run does — the view
+// converts them once it knows which quote to total in.
+function asSummary(orders) {
+
+   const sides = { buy: newSummarySide(), sell: newSummarySide() }
+
+   for (const order of orders) {
+
+      const side = sides[order.direction]
+      if (!side) continue
+
+      side.orderCount += 1
+      side.tradeCount += order.tradeCount
+
+      const totals = side.byQuote.get(order.quoteAsset)
+         ?? { volume: Big(0), cost: Big(0), fee: Big(0), netCost: Big(0), decimals: 2 }
+      totals.volume = totals.volume.plus(order.volume)
+      totals.cost = totals.cost.plus(order.cost)
+      totals.fee = totals.fee.plus(order.fee)
+      totals.netCost = totals.netCost.plus(order.netCost)
+      totals.decimals = Math.max(totals.decimals, decimalCount(order.price))
+      side.byQuote.set(order.quoteAsset, totals)
+   }
+
+   return { buy: asSummarySide(sides.buy), sell: asSummarySide(sides.sell) }
+}
+
+function newSummarySide() {
+   return { orderCount: 0, tradeCount: 0, byQuote: new Map() }
+}
+
+function asSummarySide(side) {
+   return {
+      orderCount: side.orderCount,
+      tradeCount: side.tradeCount,
+      volume: [...side.byQuote.values()]
+         .reduce((total, totals) => total.plus(totals.volume), Big(0)).toString(),
+      quotes: [...side.byQuote.entries()].map(([quoteAsset, totals]) => ({
+         quoteAsset,
+         volume: totals.volume.toString(),
+         cost: totals.cost.toString(),
+         fee: totals.fee.toString(),
+         netCost: totals.netCost.toString(),
+         price: totals.volume.eq(0) ? '0' : totals.cost.div(totals.volume).toFixed(totals.decimals)
+      }))
+   }
+}
+
+function emptySummary() {
+   return { buy: asSummarySide(newSummarySide()), sell: asSummarySide(newSummarySide()) }
 }
 
 function foldOrders(trades) {

--- a/src/views/components/kraken/aggregate-summary.jsx
+++ b/src/views/components/kraken/aggregate-summary.jsx
@@ -1,0 +1,147 @@
+import { cn } from '@/lib/utils'
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table'
+import { asDecimal } from '../../../utils/format'
+import { asCount } from '../lib/filter-options'
+import { convertQuotes } from '../../lib/quote-conversion'
+
+const decimalsIn = (value) => (String(value).split('.')[1] ?? '').length
+
+const decimalsOf = (quotes, key, minimum) =>
+   Math.max(minimum, ...quotes.map(quote => decimalsIn(quote[key])))
+
+// Below this share of the volume traded, the two sides have cancelled each other out
+// and the net price stops being about the range.
+const NET_FLOOR = 0.01
+
+export default function AggregateSummary({ summary, market, targetQuote, rateAt, isLoadingRates }) {
+
+   if (!market || !summary) return null
+
+   const bought = convertQuotes(summary.buy.quotes, targetQuote, rateAt)
+   const sold = convertQuotes(summary.sell.quotes, targetQuote, rateAt)
+
+   const allQuotes = [...summary.buy.quotes, ...summary.sell.quotes]
+
+   if (allQuotes.length === 0) return null
+
+   const missing = [...new Set([...bought.missing, ...sold.missing])]
+   const pending = isLoadingRates && missing.length === 0 && (bought.converted || sold.converted)
+
+   const volume = bought.volume.minus(sold.volume)
+   const cost = bought.cost.minus(sold.cost)
+   const fee = bought.fee.plus(sold.fee)
+
+   const volumeDecimals = decimalsOf(allQuotes, 'volume', 8)
+   const costDecimals = decimalsOf(allQuotes, 'cost', 2)
+   const priceDecimals = decimalsOf(allQuotes, 'price', 2)
+
+   const amount = (value, decimals) => asDecimal(Number(value.toFixed(decimals)), decimals)
+
+   // The net line answers what the range did on balance: the volume that stayed, and
+   // the price it stayed at once the trades of the other side are paid for. It only
+   // means something while one side dominates — two sides that cancel out divide a
+   // leftover cost by almost no volume, which prints a price out of all proportion to
+   // the range rather than a number worth reading.
+   const traded = bought.volume.plus(sold.volume)
+   const cancelled = traded.eq(0) || volume.abs().lt(traded.times(NET_FLOOR))
+   const netPrice = cancelled ? null : cost.div(volume).abs()
+
+   const rows = [
+      {
+         key: 'buy',
+         label: 'Bought',
+         side: summary.buy,
+         volume: bought.volume,
+         cost: bought.cost,
+         fee: bought.fee,
+         price: bought.price,
+         className: 'text-emerald-700 dark:text-emerald-300'
+      },
+      {
+         key: 'sell',
+         label: 'Sold',
+         side: summary.sell,
+         volume: sold.volume,
+         cost: sold.cost,
+         fee: sold.fee,
+         price: sold.price,
+         className: 'text-rose-700 dark:text-rose-300'
+      },
+      {
+         key: 'net',
+         label: volume.lt(0) ? 'Net sold' : 'Net bought',
+         volume: volume.abs(),
+         cost: cost.abs(),
+         fee,
+         price: netPrice,
+         priceTitle: cancelled && !traded.eq(0)
+            ? 'The range bought and sold about the same volume, so what it cost on balance says nothing about the price it traded at.'
+            : undefined,
+         className: 'font-medium'
+      }
+   ]
+
+   return (
+      <div className="space-y-2 border-t border-border pt-4">
+
+         <Table className="tabular-nums">
+            <TableHeader>
+               <TableRow>
+                  <TableHead>Range</TableHead>
+                  <TableHead />
+                  <TableHead className="text-right">Volume</TableHead>
+                  <TableHead className="text-right">VWAP</TableHead>
+                  <TableHead className="text-right">Cost</TableHead>
+                  <TableHead className="text-right">Fee</TableHead>
+               </TableRow>
+            </TableHeader>
+            <TableBody>
+               {rows.map(row =>
+                  <TableRow key={row.key}>
+                     <TableCell className={cn('whitespace-nowrap', row.className)}>
+                        {row.label}
+                     </TableCell>
+                     <TableCell className="whitespace-nowrap text-muted-foreground">
+                        {row.side && asCount(row.side.orderCount, 'order')}
+                     </TableCell>
+                     <TableCell className="text-right whitespace-nowrap">
+                        {amount(row.volume, volumeDecimals)}{' '}
+                        <span className="text-muted-foreground">{market.baseAsset}</span>
+                     </TableCell>
+                     <TableCell
+                        className={cn('text-right whitespace-nowrap', row.className)}
+                        title={row.priceTitle}>
+                        {row.price === null
+                           ? '—'
+                           : <>{amount(row.price, priceDecimals)}{' '}
+                              <span className="text-muted-foreground">{targetQuote}</span></>}
+                     </TableCell>
+                     <TableCell className="text-right whitespace-nowrap">
+                        {amount(row.cost, costDecimals)}{' '}
+                        <span className="text-muted-foreground">{targetQuote}</span>
+                     </TableCell>
+                     <TableCell className="text-right whitespace-nowrap text-muted-foreground">
+                        {amount(row.fee, costDecimals)}
+                     </TableCell>
+                  </TableRow>)}
+            </TableBody>
+         </Table>
+
+         <p className="text-xs text-muted-foreground">
+            {pending
+               ? 'Converting the other quote currencies…'
+               : <>
+                  Every order in the range counts, not only the ones on this page. <b>Bought</b> and{' '}
+                  <b>Sold</b> weight each side&apos;s price by its own volume; <b>{rows[2].label}</b>{' '}
+                  is the two sides against each other, so the counter-trend orders inside a range pay
+                  for themselves instead of being averaged in.
+                  {(bought.converted || sold.converted) &&
+                     ` Other quote currencies are converted to ${targetQuote} at today's rate.`}
+                  {missing.length > 0 &&
+                     ` No rate for ${missing.join(', ')}, so those orders are left out.`}
+               </>}
+         </p>
+
+      </div>
+   )
+}

--- a/src/views/mocks/kraken-trades.js
+++ b/src/views/mocks/kraken-trades.js
@@ -167,7 +167,7 @@ export function tradeAggregations(body = {}) {
    const empty = {
       rows: [], total: 0, page, pageSize,
       baseAsset: filters.base ?? '', quoteAsset: filters.quote ?? '',
-      quoteAssets: [], truncated: false
+      quoteAssets: [], summary: emptySummary(), truncated: false
    }
 
    if (!filters.base) return empty
@@ -205,8 +205,59 @@ export function tradeAggregations(body = {}) {
       baseAsset: filters.base,
       quoteAsset: filters.quote ?? '',
       quoteAssets: [...new Set(groups.flatMap(group => group.quotes.map(quote => quote.quoteAsset)))],
+      summary: asSummary(orders),
       truncated: false
    }
+}
+
+function asSummary(orders) {
+
+   const sides = { buy: newSummarySide(), sell: newSummarySide() }
+
+   for (const order of orders) {
+
+      const side = sides[order.direction]
+      if (!side) continue
+
+      side.orderCount += 1
+      side.tradeCount += order.tradeCount
+
+      const totals = side.byQuote.get(order.quoteAsset)
+         ?? { volume: Big(0), cost: Big(0), fee: Big(0), netCost: Big(0), decimals: 2 }
+      totals.volume = totals.volume.plus(order.volume)
+      totals.cost = totals.cost.plus(order.cost)
+      totals.fee = totals.fee.plus(order.fee)
+      totals.netCost = totals.netCost.plus(order.netCost)
+      totals.decimals = Math.max(totals.decimals, decimalCount(order.price))
+      side.byQuote.set(order.quoteAsset, totals)
+   }
+
+   return { buy: asSummarySide(sides.buy), sell: asSummarySide(sides.sell) }
+}
+
+function newSummarySide() {
+   return { orderCount: 0, tradeCount: 0, byQuote: new Map() }
+}
+
+function asSummarySide(side) {
+   return {
+      orderCount: side.orderCount,
+      tradeCount: side.tradeCount,
+      volume: [...side.byQuote.values()]
+         .reduce((total, totals) => total.plus(totals.volume), Big(0)).toString(),
+      quotes: [...side.byQuote.entries()].map(([quoteAsset, totals]) => ({
+         quoteAsset,
+         volume: totals.volume.toString(),
+         cost: totals.cost.toString(),
+         fee: totals.fee.toString(),
+         netCost: totals.netCost.toString(),
+         price: totals.volume.eq(0) ? '0' : totals.cost.div(totals.volume).toFixed(totals.decimals)
+      }))
+   }
+}
+
+function emptySummary() {
+   return { buy: asSummarySide(newSummarySide()), sell: asSummarySide(newSummarySide()) }
 }
 
 function asAggregation(run, index) {

--- a/src/views/pages/kraken/aggregated-trades.jsx
+++ b/src/views/pages/kraken/aggregated-trades.jsx
@@ -4,6 +4,7 @@ import { Loader2Icon } from 'lucide-react'
 import KrakenLayout from '../../components/kraken/kraken-layout'
 import AggregateFilters, { defaultFilters } from '../../components/kraken/aggregate-filters'
 import AggregateTable from '../../components/kraken/aggregate-table'
+import AggregateSummary from '../../components/kraken/aggregate-summary'
 import { isJobRunning } from '../../components/kraken/sync-status'
 import { useProvider } from '../../lib/use-settings'
 import CredentialsAlert from '../../components/lib/credentials-alert'
@@ -107,6 +108,12 @@ export default function KrakenAggregatedTrades() {
                      markets={markets}
                      onChange={changeFilters}
                      onReset={() => changeFilters(defaultFilters)} />
+                  <AggregateSummary
+                     summary={groups?.summary}
+                     market={market}
+                     targetQuote={targetQuote}
+                     rateAt={ratesAt(rateData?.rates)}
+                     isLoadingRates={needsRates && isLoadingRates} />
                   <AggregateTable
                      groups={groups}
                      market={market}


### PR DESCRIPTION
The Aggregated Trades page averages a price per run, and a run is one-sided by construction, so nothing on the page answered what a whole range did. A range that accumulated through a bear market still holds a few sells, and averaging them into the same number as the buys is wrong in both directions at once.

This adds a summary above the table, over every order the filters select rather than the ones on the current page: **Bought** and **Sold** each weighted by their own volume, and a **Net bought** / **Net sold** line that puts the two sides against each other. Netting is what makes the counter-trend orders pay for themselves — a range whose buys average 22 398 and whose late sells average 44 387 kept its coins at 18 395, not at 22 398.

Netting at run level is exact: a run has a constant side, so folding orders into runs and then netting gives the same result as walking every order.

## Changes

- `queryAggregations` returns a `summary` of `{ buy, sell }`, each carrying `volume`, `orderCount`, `tradeCount` and the same per-quote `quotes[]` shape a run already exposes, so the view converts mixed quote currencies through the existing `convertQuotes` / `ratesAt` path.
- New `aggregate-summary.jsx` renders the three lines with Volume, VWAP, Cost and Fee.
- The mock generator mirrors the server, as it already does for runs and orders.

The net price is withheld — an em dash and a tooltip — when the two sides cancel to within 1% of the volume traded, where the ratio is a leftover cost divided by rounding rather than by a position.

## Verification

- The repository, run against a copy of a real synced ledger, reproduces figures computed independently from Kraken's REST trade history: volumes to the satoshi and per-quote costs to the cent across three multi-year ranges.
- The mock summary reconciles against a brute-force sum over all groups — totals, per-quote splits and order counts — for BTC/USD, BTC across all quotes, and DOT/EUR.
- Driven in mocked mode: full range, mixed-currency mode including the no-rate exclusion notice, a buys-only range, and an empty range where the summary hides itself.
- `bun run lint` is clean.

`public/screenshot-kraken-aggregated-trades.png` predates this and no longer shows the page as it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
