### PR TITLE
fix(kraken): rate the inverted fiat pairs and guard the net VWAP

### DIFF
--- a/src/server/adapters/kraken-api/adapter.js
+++ b/src/server/adapters/kraken-api/adapter.js
@@ -235,20 +235,33 @@ export default function KrakenAPI(credentials) {
       const assetPairs = (await resource.fetchAllAssetPairs()).result
       const pairIndex = buildPairIndex(assetPairs)
 
-      const altnames = new Map()
-      for (const pair of Object.values(assetPairs ?? {})) {
+      const tradeable = Object.values(assetPairs ?? {}).filter(pair => {
          // Darkpool pairs (XBT/USD.d) quote the same asset but trade separately, and
          // an offline pair has no meaningful last trade.
-         if (!pair.altname || pair.altname.includes('.')) continue
-         if (pair.status && pair.status !== 'online') continue
-         // Matched exactly rather than through normalizeAsset, which strips the digit
-         // off Kraken's USD1 stablecoin and would let the thin ETHUSD1 book stand in
-         // for ETHUSD.
-         if (!['USD', 'ZUSD'].includes(pair.quote)) continue
+         if (!pair.altname || pair.altname.includes('.')) return false
+         return !pair.status || pair.status === 'online'
+      })
 
+      // Matched exactly rather than through normalizeAsset, which strips the digit
+      // off Kraken's USD1 stablecoin and would let the thin ETHUSD1 book stand in
+      // for ETHUSD.
+      const isUsd = asset => ['USD', 'ZUSD'].includes(asset)
+
+      const altnames = new Map()
+
+      for (const pair of tradeable) {
+         if (!isUsd(pair.quote)) continue
          const baseAsset = normalizeAsset(pair.base)
          if (wanted.has(baseAsset) && !altnames.has(baseAsset)) {
             altnames.set(baseAsset, pair.altname)
+         }
+      }
+
+      for (const pair of tradeable) {
+         if (!isUsd(pair.base)) continue
+         const quoteAsset = normalizeAsset(pair.quote)
+         if (wanted.has(quoteAsset) && !altnames.has(quoteAsset)) {
+            altnames.set(quoteAsset, pair.altname)
          }
       }
 
@@ -258,11 +271,12 @@ export default function KrakenAPI(credentials) {
       // the page can tell "not traded here" apart from "worth nothing".
       const ticker = (await resource.fetchTicker([...altnames.values()])).result ?? {}
       for (const [name, entry] of Object.entries(ticker)) {
-         const { baseAsset } = resolvePair(name, pairIndex)
+         const { baseAsset, quoteAsset } = resolvePair(name, pairIndex)
          const price = Number(entry?.c?.[0])
-         if (wanted.has(baseAsset) && Number.isFinite(price)) {
-            rates[baseAsset] = price
-         }
+         if (!Number.isFinite(price) || price === 0) continue
+
+         if (quoteAsset === 'USD' && wanted.has(baseAsset)) rates[baseAsset] = price
+         else if (baseAsset === 'USD' && wanted.has(quoteAsset)) rates[quoteAsset] = 1 / price
       }
 
       return rates

--- a/src/views/components/kraken/aggregate-summary.jsx
+++ b/src/views/components/kraken/aggregate-summary.jsx
@@ -11,7 +11,7 @@ const decimalsOf = (quotes, key, minimum) =>
 
 // Below this share of the volume traded, the two sides have cancelled each other out
 // and the net price stops being about the range.
-const NET_FLOOR = 0.01
+const NET_FLOOR = 1 / 3
 
 export default function AggregateSummary({ summary, market, targetQuote, rateAt, isLoadingRates }) {
 
@@ -44,7 +44,15 @@ export default function AggregateSummary({ summary, market, targetQuote, rateAt,
    // the range rather than a number worth reading.
    const traded = bought.volume.plus(sold.volume)
    const cancelled = traded.eq(0) || volume.abs().lt(traded.times(NET_FLOOR))
-   const netPrice = cancelled ? null : cost.div(volume).abs()
+
+   const netRatio = cancelled ? null : cost.div(volume)
+   const netPrice = netRatio === null || netRatio.lte(0) ? null : netRatio
+
+   const netPriceTitle = netPrice !== null || traded.eq(0)
+      ? undefined
+      : cancelled
+         ? 'The range bought and sold about the same volume, so what it cost on balance says nothing about the price it traded at.'
+         : 'The other side of the range more than paid for this one, so what is left has no price of its own.'
 
    const rows = [
       {
@@ -74,9 +82,7 @@ export default function AggregateSummary({ summary, market, targetQuote, rateAt,
          cost: cost.abs(),
          fee,
          price: netPrice,
-         priceTitle: cancelled && !traded.eq(0)
-            ? 'The range bought and sold about the same volume, so what it cost on balance says nothing about the price it traded at.'
-            : undefined,
+         priceTitle: netPriceTitle,
          className: 'font-medium'
       }
    ]


### PR DESCRIPTION
Two unrelated fixes to the aggregated trades page, one commit each. The second was written against #257 while it was still open and has been rebased onto `master` now that it has merged.

## No rate for CHF

The aggregations dropped every CHF-quoted order and said so in the caption, even though Kraken trades USD against CHF. `fetchUsdRates` only ever looked at pairs whose **quote** was USD, and Kraken quotes the traditional currencies the way the FX market does — there is no `CHFUSD`, only `USDCHF` with CHF as the quote. **CAD and JPY** were silently in the same position; a sweep of live `AssetPairs` turns up exactly those three.

The pair scan now runs a second pass over pairs the wanted asset is the *quote* of, for assets the first pass found nothing for, and inverts the price — same book, read the other way up. A direct pair still wins where both exist, and a zero last price is skipped rather than turned into infinity.

Live check:

| Asset | Pair used | Rate (USD) |
| --- | --- | --- |
| CHF | USDCHF, inverted | 1.2486 |
| CAD | USDCAD, inverted | 0.7299 |
| JPY | USDJPY, inverted | 0.006378 |
| EUR | EURUSD, direct | 1.16914 |
| GBP | GBPUSD, direct | 1.36413 |
| BTC | XBTUSD, direct | 77 189.9 |

## Net VWAP of 259 741

The net line divides the two sides' costs by what is left of their volumes, which only reads as a price while one side dominates. On a real range — 2.15995810 BTC bought at 46 563.12 against 2.79043007 sold at 94 728.63 — the leftover 0.63047197 BTC carried the entire 163 759 USD between the two sides and printed **259 740.69 USD**, more than twice the higher of the two VWAPs and a price nothing on the page ever traded at.

Two guards were wrong:

- `NET_FLOOR` at 1% only caught the two sides cancelling almost exactly. The range above kept 12.7% of its volume and went straight through. Raised to a third, which is the point where the smaller side is still no more than half the larger — as close as the two can get before the remainder is mostly the gap between their prices rather than the price itself.
- The ratio was taken through `abs()`. A side that more than paid for the other leaves cost and volume with opposite signs, and its **profit** was printed as though the remainder had traded there. Now rejected on its sign.

Both cases show a dash and explain themselves on hover. Cases checked:

| Range | Net | Before | After |
| --- | --- | --- | --- |
| 2.16 @ 46 563 / 2.79 @ 94 729 | 0.63 sold | 259 740.69 | — |
| 2 @ 40 000 / — | 2 bought | 40 000 | 40 000 |
| 3 @ 40 000 / 1 @ 50 000 | 2 bought | 35 000 | 35 000 |
| 1 @ 40 000 / 3 @ 50 000 | 2 sold | 55 000 | 55 000 |
| 2 @ 40 000 / 1 @ 50 000 | 1 bought | 30 000 | 30 000 |
| 3 @ 10 000 / 1 @ 100 000 | 2 bought | 35 000 | — |
| 1 @ 40 000 / 1 @ 50 000 | nothing | — | — |

The sides that genuinely pay for each other keep their number; only the ones out of proportion to the range lose it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

