### PR TITLE
feat(tools): add a risk-based trade calculator

### DIFF
--- a/src/views/app.jsx
+++ b/src/views/app.jsx
@@ -12,6 +12,7 @@ import KrakenOpenOrders from './pages/kraken/open-orders'
 import KrakenOrderBatch from './pages/kraken/order-batch'
 import KrakenRewards from './pages/kraken/rewards'
 import KrakenXStocks from './pages/kraken/xstocks'
+import TradeCalculator from './pages/tools/trade-calculator'
 
 export const isMockMode = import.meta.env.VITE_MOCK_DATA === 'true'
 // Under views:// (Electrobun) the page's origin is opaque and the History API is unusable,
@@ -76,6 +77,7 @@ export default function App() {
                <Route path="/kraken/order-batch" element={<KrakenOrderBatch />} />
                <Route path="/kraken/rewards" element={<KrakenRewards />} />
                <Route path="/kraken/xstocks" element={<KrakenXStocks />} />
+               <Route path="/tools/trade-calculator" element={<TradeCalculator />} />
                <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>
          </Router>

--- a/src/views/components/layout.jsx
+++ b/src/views/components/layout.jsx
@@ -36,6 +36,7 @@ export default function Layout({ children, name }) {
                <nav className="flex items-center gap-3 sm:gap-4">
                   <MenuLink href={groupHref('Kraken')} isActive={isSection}>Kraken</MenuLink>
                   <MenuLink href={groupHref('Binance')} isActive={isSection}>Binance</MenuLink>
+                  <MenuLink href={groupHref('Tools')} isActive={isSection}>Tools</MenuLink>
                   <MenuLink href="/settings" isActive={isSection}>Settings</MenuLink>
                </nav>
                <div className="ml-auto flex items-center gap-1">

--- a/src/views/components/tools/take-profit-table.jsx
+++ b/src/views/components/tools/take-profit-table.jsx
@@ -1,0 +1,68 @@
+import { asAssetAmount, asDollarAmount, asPercentage } from '../../../utils/format'
+import { Table, TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell } from '@/components/ui/table'
+
+const Missing = () => <span className="text-muted-foreground">—</span>
+
+export default function TakeProfitTable({ result }) {
+
+   const { tpLevels, totals } = result
+
+   if (tpLevels.length === 0) {
+      return (
+         <p className="text-sm text-muted-foreground">
+            Fill in an entry price, a stop loss and a strategy to see the take profit levels.
+         </p>
+      )
+   }
+
+   return (
+      <Table className="tabular-nums">
+         <TableHeader>
+            <TableRow>
+               <TableHead>Level</TableHead>
+               <TableHead className="text-right">Closed</TableHead>
+               <TableHead className="text-right">Price</TableHead>
+               <TableHead className="text-right">Quantity</TableHead>
+               <TableHead className="text-right">Profit</TableHead>
+               <TableHead className="text-right">ROI</TableHead>
+            </TableRow>
+         </TableHeader>
+         <TableBody>
+            {tpLevels.map(level =>
+               <TableRow key={level.label}>
+                  <TableCell className="font-medium">{level.label}</TableCell>
+                  <TableCell className="text-right">{level.pct}%</TableCell>
+                  <TableCell className="text-right">
+                     {level.price ? asAssetAmount(level.price.toNumber()) : <Missing />}
+                  </TableCell>
+                  <TableCell className="text-right">
+                     {level.quantity ? asAssetAmount(level.quantity.toNumber()) : <Missing />}
+                  </TableCell>
+                  <TableCell className="text-right">
+                     {level.profit ? asDollarAmount(level.profit.toNumber()) : <Missing />}
+                  </TableCell>
+                  <TableCell className="text-right">
+                     {level.roi ? asPercentage(level.roi.toNumber()) : <Missing />}
+                  </TableCell>
+               </TableRow>
+            )}
+         </TableBody>
+         <TableFooter>
+            <TableRow>
+               <TableCell>Total</TableCell>
+               <TableCell className="text-right">{totals.pct}%</TableCell>
+               <TableCell></TableCell>
+               <TableCell className="text-right">
+                  {totals.quantity.gt(0) ? asAssetAmount(totals.quantity.toNumber()) : <Missing />}
+               </TableCell>
+               <TableCell className="text-right">
+                  {totals.profit ? asDollarAmount(totals.profit.toNumber()) : <Missing />}
+               </TableCell>
+               <TableCell className="text-right">
+                  {totals.roi ? asPercentage(totals.roi.toNumber()) : <Missing />}
+               </TableCell>
+            </TableRow>
+         </TableFooter>
+      </Table>
+   )
+}

--- a/src/views/components/tools/tools-layout.jsx
+++ b/src/views/components/tools/tools-layout.jsx
@@ -1,0 +1,15 @@
+import SubNav from '../lib/sub-nav'
+import Layout from '../layout'
+import { subNavItems } from '@/lib/tools'
+
+
+const tabs = subNavItems('Tools')
+
+export default function ToolsLayout({ children, name }) {
+   return (
+      <Layout name={name}>
+         <SubNav items={tabs} />
+         {children}
+      </Layout>
+   )
+}

--- a/src/views/components/tools/trade-calculator-form.jsx
+++ b/src/views/components/tools/trade-calculator-form.jsx
@@ -1,0 +1,122 @@
+import Input from '../lib/input'
+import NumericInput from '../lib/numeric-input'
+import SelectField from '../lib/select-field'
+import FieldHint from '../lib/field-hint'
+import Field from '../lib/field'
+import { asAssetAmount, asDollarAmount, asPercentage } from '../../../utils/format'
+import { directionOptions, strategyOptions } from '@/lib/trade-calculator'
+
+const Section = ({ title, children }) => (
+   <section className="space-y-3 border-t border-border pt-4 first:border-t-0 first:pt-0">
+      <h3 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">{title}</h3>
+      {children}
+   </section>
+)
+
+const Grid = ({ children }) => (
+   <div className="grid grid-cols-1 gap-x-4 gap-y-3 sm:grid-cols-2">{children}</div>
+)
+
+export default function TradeCalculatorForm({ formValues, setFormValues, result }) {
+
+   const handleChange = (name, value) => {
+      setFormValues(prev => ({ ...prev, [name]: value }))
+   }
+
+   return (
+      <form onSubmit={event => event.preventDefault()} className="space-y-4">
+
+         <Section title="Pair info">
+            <Grid>
+               <Input
+                  name="pair"
+                  label="Trading pair"
+                  hint={
+                     <FieldHint label="About the trading pair">
+                        Optional. Used to label the summary and to pick the chart symbol on the
+                        right, which you can still override there.
+                     </FieldHint>
+                  }
+                  value={formValues.pair}
+                  onChange={event => handleChange('pair', event.target.value)}
+               />
+               <Input
+                  name="token-address"
+                  label="Token address"
+                  hint={
+                     <FieldHint label="About the token address">
+                        Optional contract address, carried into the copied summary so a note about
+                        the trade says exactly which token it was.
+                     </FieldHint>
+                  }
+                  value={formValues.tokenAddress}
+                  onChange={event => handleChange('tokenAddress', event.target.value)}
+               />
+            </Grid>
+         </Section>
+
+         <Section title="Portfolio & risk">
+            <Grid>
+               <NumericInput
+                  name="portfolio-value"
+                  label="Portfolio value (USD)"
+                  value={formValues.portfolioValue}
+                  onChange={event => handleChange('portfolioValue', event.target.value)}
+               />
+               <NumericInput
+                  name="risk-pct"
+                  label="Risk (%)"
+                  value={formValues.riskPct}
+                  onChange={event => handleChange('riskPct', event.target.value)}
+               />
+            </Grid>
+            {result.riskAmount &&
+               <Field label="Risk amount">{asDollarAmount(result.riskAmount.toNumber())}</Field>}
+         </Section>
+
+         <Section title="Entry & stop loss">
+            <SelectField
+               name="direction"
+               label="Direction"
+               value={formValues.direction}
+               onValueChange={value => handleChange('direction', value)}
+               options={directionOptions}
+               className="sm:w-[calc(50%-0.5rem)]"
+            />
+            <Grid>
+               <NumericInput
+                  name="entry-price"
+                  label="Entry price"
+                  value={formValues.entryPrice}
+                  onChange={event => handleChange('entryPrice', event.target.value)}
+               />
+               <NumericInput
+                  name="stop-loss"
+                  label="Stop loss price"
+                  value={formValues.stopLoss}
+                  onChange={event => handleChange('stopLoss', event.target.value)}
+               />
+            </Grid>
+            {result.positionValue &&
+               <div className="grid grid-cols-3 gap-x-4">
+                  <Field label="Position value">{asDollarAmount(result.positionValue.toNumber())}</Field>
+                  <Field label="Position size">{asAssetAmount(result.positionSize.toNumber())}</Field>
+                  <Field label="Stop distance">{asPercentage(result.stopDistance.toNumber())}</Field>
+               </div>}
+         </Section>
+
+         <Section title="Take profit">
+            <SelectField
+               name="strategy"
+               label="Strategy"
+               value={formValues.strategy}
+               onValueChange={value => handleChange('strategy', value)}
+               options={strategyOptions}
+               placeholder="Select a strategy"
+               className="sm:w-1/2 sm:pr-2"
+            />
+         </Section>
+
+      </form>
+   )
+}

--- a/src/views/components/tools/trade-summary.jsx
+++ b/src/views/components/tools/trade-summary.jsx
@@ -1,0 +1,120 @@
+import { toast } from 'sonner'
+import { CopyIcon } from 'lucide-react'
+import { asAssetAmount, asDollarAmount, asPercentage } from '../../../utils/format'
+import { Button } from '@/components/ui/button'
+import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
+
+const directionLabel = result => result.isLong ? 'Buy (long)' : 'Sell (short)'
+
+const levelLine = level => {
+   const price = level.price ? asAssetAmount(level.price.toNumber()) : 'no target'
+   const quantity = level.quantity ? asAssetAmount(level.quantity.toNumber()) : '—'
+   return `  • ${level.label} — ${level.pct}% @ ${price} (${quantity} units)`
+}
+
+const buildSummaryText = (formValues, result) => {
+
+   const lines = []
+
+   if (formValues.pair) {
+      lines.push(formValues.tokenAddress
+         ? `Pair: ${formValues.pair} (${formValues.tokenAddress})`
+         : `Pair: ${formValues.pair}`)
+   }
+
+   lines.push(`Direction: ${directionLabel(result)}`)
+   lines.push(`Position size: ${asAssetAmount(result.positionSize.toNumber())} units (${asDollarAmount(result.positionValue.toNumber())})`)
+   lines.push(`Entry price: ${asAssetAmount(result.entryPrice.toNumber())}`)
+   lines.push(`Stop loss: ${asAssetAmount(result.stopLoss.toNumber())} (${asPercentage(result.stopDistance.toNumber())} from entry)`)
+
+   if (result.riskAmount) {
+      lines.push(`Risk: ${asDollarAmount(result.riskAmount.toNumber())} (${asPercentage(result.riskPct.div(100).toNumber())} of portfolio)`)
+   }
+
+   if (result.tpLevels.length > 0) {
+      lines.push('')
+      lines.push(`Take profit — ${result.strategyLabel}:`)
+      result.tpLevels.forEach(level => lines.push(levelLine(level)))
+   }
+
+   return lines.join('\n')
+}
+
+const Row = ({ label, children }) => (
+   <p>
+      <span className="font-medium">{label}:</span>{' '}
+      <span className="tabular-nums">{children}</span>
+   </p>
+)
+
+export default function TradeSummary({ formValues, result }) {
+
+   const copy = async () => {
+      try {
+         await navigator.clipboard.writeText(buildSummaryText(formValues, result))
+         toast.success('Trade summary copied to the clipboard.')
+      }
+      catch {
+         toast.error('Could not copy the trade summary.')
+      }
+   }
+
+   return (
+      <Card size="sm">
+         <CardHeader>
+            <CardTitle>Trade summary</CardTitle>
+            <CardAction>
+               <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  type="button"
+                  onClick={copy}
+                  className="text-muted-foreground hover:text-foreground">
+                  <CopyIcon />
+                  <span className="sr-only">Copy the trade summary</span>
+               </Button>
+            </CardAction>
+         </CardHeader>
+         <CardContent className="space-y-1 text-sm">
+
+            {formValues.pair &&
+               <Row label="Pair">
+                  {formValues.pair}
+                  {formValues.tokenAddress &&
+                     <span className="ml-2 font-mono text-xs text-muted-foreground">
+                        {formValues.tokenAddress}
+                     </span>}
+               </Row>}
+
+            <Row label="Direction">{directionLabel(result)}</Row>
+            <Row label="Position size">
+               {asAssetAmount(result.positionSize.toNumber())} units ({asDollarAmount(result.positionValue.toNumber())})
+            </Row>
+            <Row label="Entry price">{asAssetAmount(result.entryPrice.toNumber())}</Row>
+            <Row label="Stop loss">
+               {asAssetAmount(result.stopLoss.toNumber())} ({asPercentage(result.stopDistance.toNumber())} from entry)
+            </Row>
+
+            {result.riskAmount &&
+               <Row label="Risk">
+                  {asDollarAmount(result.riskAmount.toNumber())} ({asPercentage(result.riskPct.div(100).toNumber())} of portfolio)
+               </Row>}
+
+            {result.tpLevels.length > 0 &&
+               <div className="space-y-1 border-t border-border pt-2">
+                  <p className="font-medium">Take profit — {result.strategyLabel}</p>
+                  <ul className="ml-4 list-outside list-disc space-y-0.5 tabular-nums text-muted-foreground">
+                     {result.tpLevels.map(level =>
+                        <li key={level.label}>
+                           {level.label} — {level.pct}% @{' '}
+                           {level.price ? asAssetAmount(level.price.toNumber()) : 'no target'}{' '}
+                           ({level.quantity ? asAssetAmount(level.quantity.toNumber()) : '—'} units)
+                        </li>
+                     )}
+                  </ul>
+               </div>}
+
+         </CardContent>
+      </Card>
+   )
+}

--- a/src/views/components/tools/tradingview-chart.jsx
+++ b/src/views/components/tools/tradingview-chart.jsx
@@ -1,0 +1,83 @@
+import { memo, useEffect, useRef, useState } from 'react'
+import ExternalLink from '../lib/external-link'
+
+const SCRIPT_SRC = 'https://s3.tradingview.com/external-embedding/embed-widget-advanced-chart.js'
+const LOAD_TIMEOUT = 8000
+const SYMBOL_DEBOUNCE = 700
+
+function TradingViewChart({ symbol }) {
+
+   const containerRef = useRef(null)
+   const [failed, setFailed] = useState(false)
+   const [activeSymbol, setActiveSymbol] = useState(symbol)
+
+   useEffect(() => {
+      const timer = setTimeout(() => setActiveSymbol(symbol), SYMBOL_DEBOUNCE)
+      return () => clearTimeout(timer)
+   }, [symbol])
+
+   useEffect(() => {
+
+      const container = containerRef.current
+      if (!container || !activeSymbol) return
+
+      setFailed(false)
+      container.innerHTML = ''
+
+      const widget = document.createElement('div')
+      widget.className = 'tradingview-widget-container__widget h-full w-full'
+      container.appendChild(widget)
+
+      const script = document.createElement('script')
+      script.src = SCRIPT_SRC
+      script.type = 'text/javascript'
+      script.async = true
+      script.onerror = () => setFailed(true)
+      script.innerHTML = JSON.stringify({
+         autosize: true,
+         symbol: activeSymbol,
+         interval: '60',
+         timezone: 'Etc/UTC',
+         theme: document.documentElement.classList.contains('dark') ? 'dark' : 'light',
+         style: '1',
+         locale: 'en',
+         allow_symbol_change: false,
+         support_host: 'https://www.tradingview.com'
+      })
+      container.appendChild(script)
+
+      const timer = setTimeout(() => {
+         if (!container.querySelector('iframe')) setFailed(true)
+      }, LOAD_TIMEOUT)
+
+      return () => {
+         clearTimeout(timer)
+         container.innerHTML = ''
+      }
+   }, [activeSymbol])
+
+   if (!activeSymbol) {
+      return (
+         <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+            Enter a trading pair to show a chart.
+         </div>
+      )
+   }
+
+   return (
+      <div className="relative h-full w-full">
+         <div ref={containerRef} className="tradingview-widget-container h-full w-full" />
+         {failed &&
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-card p-6 text-center text-sm text-muted-foreground">
+               <p>The TradingView chart could not be loaded.</p>
+               <ExternalLink
+                  href={`https://www.tradingview.com/chart/?symbol=${encodeURIComponent(activeSymbol)}`}
+                  className="font-medium text-foreground underline underline-offset-4">
+                  Open {activeSymbol} on TradingView
+               </ExternalLink>
+            </div>}
+      </div>
+   )
+}
+
+export default memo(TradingViewChart)

--- a/src/views/lib/page-help.jsx
+++ b/src/views/lib/page-help.jsx
@@ -87,6 +87,17 @@ const pageHelp = {
          them — unlike the Kraken pages there is no local database behind this one, so
          nothing is shown until you fetch. Locked staking positions are listed with the
          date each one is released and the products they were subscribed to.
+      </>,
+
+   '/tools/trade-calculator':
+      <>
+         Turns the loss you are prepared to take into a position size: risk amount over the
+         distance from entry to stop loss. From there it lays out the take profit tiers as
+         multiples of that same risk, with the profit and return each one realises. It reaches
+         no exchange and knows nothing about your account — every number comes from what you
+         type, and only the form is kept, on this machine. The chart beside it is an embedded{' '}
+         <ExternalLink href="https://www.tradingview.com/" className="underline">TradingView</ExternalLink>{' '}
+         widget, the one part of the page that talks to the network.
       </>
 }
 

--- a/src/views/lib/tools.js
+++ b/src/views/lib/tools.js
@@ -1,4 +1,4 @@
-import { CoinsIcon, GiftIcon, LayersIcon, ListChecksIcon, ReceiptIcon, ScrollTextIcon, SigmaIcon, SparklesIcon, WalletIcon } from 'lucide-react'
+import { CalculatorIcon, CoinsIcon, GiftIcon, LayersIcon, ListChecksIcon, ReceiptIcon, ScrollTextIcon, SigmaIcon, SparklesIcon, WalletIcon } from 'lucide-react'
 
 
 // The single source of truth for navigation: the home dashboard, the per-exchange
@@ -77,6 +77,17 @@ export const toolGroups = [
             title: 'Staking',
             description: 'Overview of your staking positions and upcoming redemptions.',
             icon: CoinsIcon
+         }
+      ]
+   },
+   {
+      name: 'Tools',
+      tools: [
+         {
+            href: '/tools/trade-calculator',
+            title: 'Trade Calculator',
+            description: 'Size a position from the risk you are willing to take, and lay out its take profit levels.',
+            icon: CalculatorIcon
          }
       ]
    }

--- a/src/views/lib/trade-calculator.js
+++ b/src/views/lib/trade-calculator.js
@@ -1,0 +1,170 @@
+import Big from 'big.js'
+
+
+export const tpStrategies = {
+   conservative: {
+      label: 'Conservative (2 tiers)',
+      tiers: [
+         { pct: 50, rMultiple: 2 },
+         { pct: 50, rMultiple: 4 }
+      ]
+   },
+   normal: {
+      label: 'Normal (3 tiers)',
+      tiers: [
+         { pct: 33, rMultiple: 2 },
+         { pct: 33, rMultiple: 3 },
+         { pct: 34, rMultiple: 5 }
+      ]
+   },
+   aggressive: {
+      label: 'Aggressive (4 tiers)',
+      tiers: [
+         { pct: 25, rMultiple: 1.5 },
+         { pct: 25, rMultiple: 3 },
+         { pct: 25, rMultiple: 5 },
+         { pct: 25, rMultiple: null }
+      ]
+   }
+}
+
+export const strategyOptions =
+   Object.entries(tpStrategies).map(([value, strategy]) => ({ value, label: strategy.label }))
+
+export const directionOptions = [
+   { value: 'buy', label: 'Buy (long)' },
+   { value: 'sell', label: 'Sell (short)' }
+]
+
+const positive = value => {
+   if (value === null || value === undefined || value === '') return null
+   try {
+      const parsed = Big(value)
+      return parsed.gt(0) ? parsed : null
+   }
+   catch {
+      return null
+   }
+}
+
+const tierPrice = (tier, entryPrice, riskPerUnit, isLong) => {
+   if (tier.rMultiple === null) return null
+   const move = riskPerUnit.times(tier.rMultiple)
+   const price = isLong ? entryPrice.plus(move) : entryPrice.minus(move)
+   return price.gt(0) ? price : null
+}
+
+const tierLevel = (tier, entryPrice, riskPerUnit, positionSize, isLong) => {
+
+   const price = tierPrice(tier, entryPrice, riskPerUnit, isLong)
+   const quantity = positionSize ? positionSize.times(tier.pct).div(100) : null
+   const cost = quantity ? entryPrice.times(quantity) : null
+
+   const profit = price && quantity
+      ? (isLong ? price.minus(entryPrice) : entryPrice.minus(price)).times(quantity)
+      : null
+
+   return {
+      label: tier.rMultiple === null ? 'Runner' : `${tier.rMultiple}R`,
+      rMultiple: tier.rMultiple,
+      pct: tier.pct,
+      price,
+      quantity,
+      profit,
+      roi: profit && cost && cost.gt(0) ? profit.div(cost) : null
+   }
+}
+
+const totalsOf = (tpLevels, positionValue) => {
+
+   const pct = tpLevels.reduce((sum, level) => sum + level.pct, 0)
+
+   const quantity = tpLevels.reduce(
+      (sum, level) => level.quantity ? sum.plus(level.quantity) : sum, Big(0))
+
+   const withProfit = tpLevels.filter(level => level.profit)
+   const profit = withProfit.length > 0
+      ? withProfit.reduce((sum, level) => sum.plus(level.profit), Big(0))
+      : null
+
+   return {
+      pct,
+      quantity,
+      profit,
+      roi: profit && positionValue?.gt(0) ? profit.div(positionValue) : null
+   }
+}
+
+export function calculate(formValues) {
+
+   const direction = formValues.direction === 'sell' ? 'sell' : 'buy'
+   const isLong = direction === 'buy'
+
+   const portfolioValue = positive(formValues.portfolioValue)
+   const riskPct = positive(formValues.riskPct)
+   const entryPrice = positive(formValues.entryPrice)
+   const stopLoss = positive(formValues.stopLoss)
+
+   const errors = []
+
+   const riskTooLarge = riskPct !== null && riskPct.gt(100)
+   if (riskTooLarge) {
+      errors.push('Risk cannot exceed 100% of the portfolio.')
+   }
+
+   const stopOnWrongSide = entryPrice !== null && stopLoss !== null &&
+      (isLong ? stopLoss.gte(entryPrice) : stopLoss.lte(entryPrice))
+   if (stopOnWrongSide) {
+      errors.push(isLong
+         ? 'For a buy the stop loss must sit below the entry price.'
+         : 'For a sell the stop loss must sit above the entry price.')
+   }
+
+   const riskAmount = portfolioValue && riskPct && !riskTooLarge
+      ? portfolioValue.times(riskPct).div(100)
+      : null
+
+   const riskPerUnit = entryPrice && stopLoss && !stopOnWrongSide
+      ? entryPrice.minus(stopLoss).abs()
+      : null
+
+   const positionSize = riskAmount && riskPerUnit ? riskAmount.div(riskPerUnit) : null
+   const positionValue = positionSize && entryPrice ? positionSize.times(entryPrice) : null
+   const stopDistance = riskPerUnit && entryPrice ? riskPerUnit.div(entryPrice) : null
+   const leverage = positionValue && portfolioValue ? positionValue.div(portfolioValue) : null
+
+   const strategy = tpStrategies[formValues.strategy]
+   const tpLevels = strategy && entryPrice && riskPerUnit
+      ? strategy.tiers.map(tier => tierLevel(tier, entryPrice, riskPerUnit, positionSize, isLong))
+      : []
+
+   return {
+      direction,
+      isLong,
+      strategyLabel: strategy?.label,
+      portfolioValue,
+      riskPct,
+      entryPrice,
+      stopLoss,
+      riskAmount,
+      riskPerUnit,
+      positionSize,
+      positionValue,
+      stopDistance,
+      leverage,
+      tpLevels,
+      totals: tpLevels.length > 0 ? totalsOf(tpLevels, positionValue) : null,
+      errors
+   }
+}
+
+export const chartSymbol = (pair, override) => {
+
+   const explicit = (override ?? '').trim().toUpperCase()
+   if (explicit) return explicit
+
+   const cleaned = (pair ?? '').trim().toUpperCase().replace(/[^A-Z0-9:]/g, '')
+   if (!cleaned) return ''
+
+   return cleaned.includes(':') ? cleaned : `BINANCE:${cleaned}`
+}

--- a/src/views/pages/home.jsx
+++ b/src/views/pages/home.jsx
@@ -19,7 +19,8 @@ export default function Home() {
                <h2 className="font-heading text-2xl font-semibold tracking-tight">Welcome</h2>
                <p className="text-sm text-muted-foreground">
                   A small collection of tools for managing Kraken and Binance accounts — batch order
-                  creation, closed-order reports, balances and staking overviews.
+                  creation, closed-order reports, balances and staking overviews — and a few that
+                  need no account at all.
                </p>
             </section>
 

--- a/src/views/pages/tools/trade-calculator.jsx
+++ b/src/views/pages/tools/trade-calculator.jsx
@@ -1,0 +1,109 @@
+import { useMemo } from 'react'
+import { TriangleAlertIcon } from 'lucide-react'
+import ToolsLayout from '../../components/tools/tools-layout'
+import TradeCalculatorForm from '../../components/tools/trade-calculator-form'
+import TakeProfitTable from '../../components/tools/take-profit-table'
+import TradeSummary from '../../components/tools/trade-summary'
+import TradingViewChart from '../../components/tools/tradingview-chart'
+import usePersistentState from '../../lib/use-persistent-state'
+import { calculate, chartSymbol } from '../../lib/trade-calculator'
+import { asDecimal } from '../../../utils/format'
+import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/components/ui/card'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Input } from '@/components/ui/input'
+
+const STORAGE_KEY = 'tools.tradeCalculator.formValues'
+
+const defaultFormValues = {
+   pair: 'BTC/USDT',
+   tokenAddress: '',
+   portfolioValue: '10000',
+   riskPct: '2',
+   direction: 'buy',
+   entryPrice: '',
+   stopLoss: '',
+   strategy: 'normal',
+   chartSymbol: ''
+}
+
+export default function TradeCalculator() {
+
+   const [formValues, setFormValues] = usePersistentState(STORAGE_KEY, defaultFormValues)
+
+   const result = useMemo(() => calculate(formValues), [formValues])
+   const symbol = chartSymbol(formValues.pair, formValues.chartSymbol)
+   const derivedSymbol = chartSymbol(formValues.pair)
+
+   const isSized = Boolean(result.positionSize && result.positionValue)
+   const isLeveraged = Boolean(result.leverage?.gt(1))
+
+   return (
+      <ToolsLayout name="Trade Calculator">
+         <div className="flex flex-col gap-6 lg:flex-row">
+
+            <div className="flex w-full flex-col gap-6 lg:w-[480px] lg:shrink-0">
+
+               <Card size="sm">
+                  <CardHeader>
+                     <CardTitle>Parameters</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-4">
+                     <TradeCalculatorForm
+                        formValues={formValues}
+                        setFormValues={setFormValues}
+                        result={result} />
+                     {result.errors.map(error =>
+                        <Alert key={error} variant="destructive">
+                           <AlertDescription>{error}</AlertDescription>
+                        </Alert>
+                     )}
+                     {isLeveraged &&
+                        <Alert>
+                           <TriangleAlertIcon />
+                           <AlertDescription>
+                              The position is worth {asDecimal(result.leverage.toNumber())}× the
+                              portfolio. Holding it needs margin, and the stop loss no longer caps
+                              the loss at the risk amount.
+                           </AlertDescription>
+                        </Alert>}
+                  </CardContent>
+               </Card>
+
+               <Card size="sm">
+                  <CardHeader>
+                     <CardTitle>Take profit</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                     <TakeProfitTable result={result} />
+                  </CardContent>
+               </Card>
+
+               {isSized && <TradeSummary formValues={formValues} result={result} />}
+
+            </div>
+
+            <Card size="sm" className="flex min-h-[560px] flex-col pb-0 lg:min-h-0 lg:flex-1">
+               <CardHeader>
+                  <CardTitle>Chart</CardTitle>
+                  <CardAction>
+                     <Input
+                        name="chart-symbol"
+                        aria-label="Chart symbol"
+                        placeholder={derivedSymbol || 'BINANCE:BTCUSDT'}
+                        className="h-8 w-52 font-mono text-xs"
+                        autoComplete="off"
+                        value={formValues.chartSymbol}
+                        onChange={event => setFormValues(prev => ({ ...prev, chartSymbol: event.target.value }))} />
+                  </CardAction>
+               </CardHeader>
+               <CardContent className="flex-1 px-0">
+                  <div className="h-full w-full border-t border-border">
+                     <TradingViewChart symbol={symbol} />
+                  </div>
+               </CardContent>
+            </Card>
+
+         </div>
+      </ToolsLayout>
+   )
+}


### PR DESCRIPTION
Ports [nyg/trade-calculator](https://github.com/nyg/trade-calculator), a standalone Next.js + daisyUI proof of concept, into the app as a third navigation section, **Tools**, with one tab at `/tools/trade-calculator`.

## What it does

Turns the loss you are prepared to take into a position size — risk amount over the distance from entry to stop loss — and lays out the take profit tiers as multiples of that same risk, with the profit and return each one realises. There are three tierings: conservative (2 tiers), normal (3), aggressive (4, the last a runner with no target).

The page reaches no exchange and needs no API key. Every number comes from what you type; only the form is kept, in local storage, the way Order Batch already remembers its parameters. Nothing under `src/server/` changed, no dependency was added, and mocked mode needs no new fixture because the page makes no SWR call at all.

## Bugs fixed in the port

- **Every short trade reported a loss.** Take profit prices were computed correctly for a short, but profit was always `(price - entry) × quantity`. The sign now follows the direction.
- **Direction was inferred** from whether the entry sat above the stop loss, so a typo silently flipped every target. It is now an explicit Buy/Sell select, and a stop loss on the wrong side of the entry is an error rather than a reversed trade.
- **The copy button** had no failure path and left a `setTimeout` running past unmount. It raises a `sonner` toast instead, with no timer.
- **Nothing flagged a position larger than the portfolio**, which a tight stop produces easily. That case now carries an alert saying what it implies, and a risk above 100% is rejected outright.

## Conventions

Floats throughout the proof of concept became `big.js`, in a UI-free `src/views/lib/trade-calculator.js` that the components read from. The hand-rolled `en-US` formatter became the shared en-GB helpers in `src/utils/format.js`. daisyUI's `card`/`btn`/`stat`/`divider`/`table` gave way to the shadcn/ui primitives and the `components/lib` field wrappers the other pages use, so the page inherits the app's spacing, tabular numerals and dark palette for free.

## On the TradingView embed

Kept, with three changes. Its theme follows the document instead of being pinned to `dark` (the app renders light today). The symbol is derived from the Pair field rather than a second input that could disagree with it, with an override beside the chart for exchange-qualified symbols. Symbol changes are debounced, because otherwise typing an override rebuilt the widget once per keystroke.

Worth a reviewer's attention: this is the one part of the page that talks to the network, and the desktop build loads from `views://`, an opaque origin where a third-party script may not resolve. If the script fails — or has not produced an iframe after 8s — the chart is replaced by a link out to TradingView and the calculator stays fully usable.

## Verification

`bun run lint` is clean. Checked against a mocked Vite instance:

- Long: portfolio 10000, risk 2%, entry 50000, SL 48000, normal → $200 risk, 0.1 units, $5,000 position, 4.00% stop distance, targets 54k/56k/60k.
- Short: entry 48000, SL 50000 → targets step down to 44k/42k/38k with **positive** profit and ROI. This is the main bug; it is the case to look at.
- Wrong-side stop and risk > 100% both surface as errors, with no NaN and no table of em-dashes.
- Leverage alert fires at portfolio 1000 / risk 50% / entry 100 / SL 99.9 (500× the portfolio), and the aggressive runner tier renders as no target rather than a zero.
- Form values survive a reload; the chart loads, and forcing the script to fail shows the fallback while the rest of the page keeps working; the two columns stack below `lg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
