### PR TITLE
feat(kraken): sharpen the balances filters and flag migrated assets

### DIFF
--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -6,6 +6,7 @@ const utcLongDateFormatter = new Intl.DateTimeFormat(locales, { year: 'numeric',
 const monthDateFormatter = new Intl.DateTimeFormat(locales, { year: 'numeric', month: 'long' })
 const shortMonthDateFormatter = new Intl.DateTimeFormat(locales, { year: '2-digit', month: 'short' })
 const percentageFormatter = new Intl.NumberFormat(locales, { style: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 })
+const shortPercentageFormatter = new Intl.NumberFormat(locales, { style: 'percent', minimumFractionDigits: 1, maximumFractionDigits: 1 })
 const usDollarFormatter = new Intl.NumberFormat(locales, { style: 'currency', currency: 'USD', currencyDisplay: 'narrowSymbol', minimumFractionDigits: 2, maximumFractionDigits: 2 })
 const decimalOneFormatter = new Intl.NumberFormat(locales, { style: 'decimal', minimumFractionDigits: 1, maximumFractionDigits: 1 })
 const localTimestampFormatter = new Intl.DateTimeFormat(locales, {
@@ -81,6 +82,10 @@ export function asLocalTimestamp(timestamp) {
 
 export function asPercentage(number) {
    return percentageFormatter.format(number)
+}
+
+export function asShortPercentage(number) {
+   return shortPercentageFormatter.format(number)
 }
 
 export function asDollarAmount(number) {

--- a/src/views/components/kraken/aggregate-summary.jsx
+++ b/src/views/components/kraken/aggregate-summary.jsx
@@ -98,7 +98,7 @@ export default function AggregateSummary({ summary, market, targetQuote, rateAt,
                   <TableHead />
                   <TableHead className="text-right">Volume</TableHead>
                   <TableHead className="text-right">
-                     <span className="cursor-help" title={VWAP_HINT}>VWAP</span>
+                     <span className="cursor-help underline decoration-dotted underline-offset-2" title={VWAP_HINT}>VWAP</span>
                   </TableHead>
                   <TableHead className="text-right">Cost</TableHead>
                   <TableHead className="text-right">Fee</TableHead>

--- a/src/views/components/kraken/asset-migrations.js
+++ b/src/views/components/kraken/asset-migrations.js
@@ -1,0 +1,19 @@
+export const assetMigrations = {
+   AI16Z: { to: 'ELIZAOS', ratio: 6, on: '2025-12-19', credited: 'an airdrop' }
+}
+
+export const migrationOf = asset => assetMigrations[asset] ?? null
+
+export const migrationSummary = (asset) => {
+   const migration = migrationOf(asset)
+   return migration ? `${asset} → ${migration.to} (${migration.on}, 1:${migration.ratio})` : null
+}
+
+export const migrationNote = (asset) => {
+
+   const migration = migrationOf(asset)
+   if (!migration) return null
+
+   return `Migrated to ${migration.to} on ${migration.on} at 1:${migration.ratio}, credited as ${migration.credited}.`
+      + ' Kraken credits the new asset and leaves this balance behind; it has no tradable pair, so it cannot be valued or sold.'
+}

--- a/src/views/components/kraken/asset-migrations.js
+++ b/src/views/components/kraken/asset-migrations.js
@@ -4,11 +4,6 @@ export const assetMigrations = {
 
 export const migrationOf = asset => assetMigrations[asset] ?? null
 
-export const migrationSummary = (asset) => {
-   const migration = migrationOf(asset)
-   return migration ? `${asset} → ${migration.to} (${migration.on}, 1:${migration.ratio})` : null
-}
-
 export const migrationNote = (asset) => {
 
    const migration = migrationOf(asset)

--- a/src/views/components/kraken/balance-filters.jsx
+++ b/src/views/components/kraken/balance-filters.jsx
@@ -1,28 +1,46 @@
 import { Button } from '@/components/ui/button'
+import ComboboxField from '../lib/combobox-field'
 import SelectField from '../lib/select-field'
-import Input from '../lib/input'
-import Checkbox from '../lib/checkbox'
+import NumericInput from '../lib/numeric-input'
 import { ANY } from '../lib/filter-options'
 
 // Dust is hidden to begin with: a long tail of positions left over from a swap or a
-// delisting is what makes this list unreadable, and how many are hidden is spelled out
-// under the table rather than only in the checkbox.
-export const DUST_USD = 1
+// delisting is what makes this list unreadable. The threshold is the user's to set,
+// and clearing the field shows everything.
+export const DEFAULT_DUST_USD = '1'
 
-export const defaultFilters = { placement: '', search: '', hideDust: true }
+export const EARNING = 'earning'
 
-// Everything here is local — the whole table is already on the page — so the search box
-// is bound straight to the filters instead of being debounced into a request.
+export const defaultFilters = { asset: '', placement: '', dust: DEFAULT_DUST_USD }
+
+export const dustLimit = (filters) => {
+   const limit = Number(filters.dust)
+   return Number.isFinite(limit) && limit > 0 ? limit : 0
+}
+
+// Everything here is local — the whole table is already on the page — so each field is
+// bound straight to the filters instead of being debounced into a request.
 export default function BalanceFilters({ filters, options, onChange, onReset }) {
 
    const update = (changes) => onChange({ ...filters, ...changes })
 
-   const isFiltered = filters.placement || filters.search
-      || filters.hideDust !== defaultFilters.hideDust
+   const isFiltered = filters.asset || filters.placement
+      || filters.dust !== defaultFilters.dust
 
    return (
       <div className="space-y-3">
          <div className="grid grid-cols-2 items-end gap-x-4 gap-y-3 md:grid-cols-3 lg:grid-cols-6">
+
+            <ComboboxField
+               name="balance-asset"
+               label="Asset"
+               value={filters.asset}
+               onValueChange={(value) => update({ asset: value })}
+               options={[{ value: '', label: 'All assets' },
+                  ...(options?.assets ?? []).map(asset => ({ value: asset, label: asset }))]}
+               placeholder="All assets"
+               searchPlaceholder="Search assets…"
+               emptyText="No asset found." />
 
             <SelectField
                name="balance-placement"
@@ -31,18 +49,11 @@ export default function BalanceFilters({ filters, options, onChange, onReset }) 
                onValueChange={(value) => update({ placement: value === ANY ? '' : value })}
                options={[{ value: ANY, label: 'Anywhere' }, ...(options?.placements ?? [])]} />
 
-            <Input
-               name="balance-search"
-               label="Search asset"
-               value={filters.search}
-               onChange={(e) => update({ search: e.target.value })} />
-
-            <Checkbox
-               name="balance-hide-dust"
-               className="h-9"
-               checked={filters.hideDust}
-               onChange={(e) => update({ hideDust: e.target.checked })}
-               label={`Hide under $${DUST_USD}`} />
+            <NumericInput
+               name="balance-dust"
+               label="Hide under ($)"
+               value={filters.dust}
+               onChange={(e) => update({ dust: e.target.value })} />
 
          </div>
 

--- a/src/views/components/kraken/balance-placement-card.jsx
+++ b/src/views/components/kraken/balance-placement-card.jsx
@@ -83,7 +83,7 @@ export default function BalancePlacementCard({ balances, rates }) {
                   <span
                      className="cursor-help underline decoration-dotted underline-offset-2"
                      title={migratedAssets.map(migrationSummary).join(' · ')}>
-                     {migrated} migrated position{migrated === 1 ? '' : 's'}
+                     {migrated} position{migrated === 1 ? '' : 's'}
                   </span>
                   {' '}left behind by a token migration{migrated === 1 ? ' is' : ' are'} left out.
                </p>}

--- a/src/views/components/kraken/balance-placement-card.jsx
+++ b/src/views/components/kraken/balance-placement-card.jsx
@@ -1,20 +1,32 @@
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import Donut from './donut'
-import { PLACEMENT_ORDER, placementColor, placementLabel, placementOf } from './placement'
+import { migrationOf, migrationSummary } from './asset-migrations'
+import { placementColor, placementLabel, placementOf } from './placement'
 
 // Every position, valued in USD and grouped by where it sits. Positions in an asset
 // Kraken has no USD pair for cannot be added to the others and are counted apart, so
-// that the ring never quietly omits a holding without saying so.
+// that the ring never quietly omits a holding without saying so — and the assets they
+// are in are named, because "left out" is only actionable if you know what was.
 export function placementTotals(assets, rates) {
 
    const totals = new Map()
+   const unvaluedAssets = new Set()
+   const migratedAssets = new Set()
    let unvalued = 0
+   let migrated = 0
 
    for (const asset of assets ?? []) {
       const rate = rates?.[asset.asset]
       for (const position of asset.positions) {
          if (rate == null) {
-            unvalued++
+            if (migrationOf(asset.asset)) {
+               migrated++
+               migratedAssets.add(asset.asset)
+            }
+            else {
+               unvalued++
+               unvaluedAssets.add(asset.asset)
+            }
             continue
          }
          const key = placementOf(position)
@@ -25,16 +37,21 @@ export function placementTotals(assets, rates) {
       }
    }
 
-   const slices = [...totals.values()]
-      .toSorted((a, b) => PLACEMENT_ORDER.indexOf(a.key) - PLACEMENT_ORDER.indexOf(b.key))
+   const slices = [...totals.values()].toSorted((a, b) => b.value - a.value)
 
-   return { slices, unvalued }
+   return {
+      slices,
+      unvalued,
+      unvaluedAssets: [...unvaluedAssets].toSorted(),
+      migrated,
+      migratedAssets: [...migratedAssets].toSorted()
+   }
 }
 
 
 export default function BalancePlacementCard({ balances, rates }) {
 
-   const { slices, unvalued } = placementTotals(balances?.assets, rates)
+   const { slices, unvalued, unvaluedAssets, migrated, migratedAssets } = placementTotals(balances?.assets, rates)
 
    return (
       <Card>
@@ -43,9 +60,9 @@ export default function BalancePlacementCard({ balances, rates }) {
          </CardHeader>
          <CardContent className="space-y-3">
 
-            {/* Ordered by placement rather than by size, and coloured the same way
-                wherever a placement is named, so the ring can be read against the
-                badges in the table without looking anything up. */}
+            {/* Ordered biggest share first, so the legend reads down in the order its
+                percentages do, and coloured the same way wherever a placement is named,
+                so the ring can still be read against the badges in the table. */}
             <Donut
                slices={slices}
                colorFor={slice => placementColor(slice.key)}
@@ -53,8 +70,22 @@ export default function BalancePlacementCard({ balances, rates }) {
 
             {unvalued > 0 &&
                <p className="text-xs text-muted-foreground">
-                  {unvalued} position{unvalued === 1 ? '' : 's'} in assets with no USD pair
-                  {unvalued === 1 ? ' is' : ' are'} left out.
+                  <span
+                     className="underline decoration-dotted underline-offset-2"
+                     title={`No USD pair: ${unvaluedAssets.join(', ')}`}>
+                     {unvalued} position{unvalued === 1 ? '' : 's'}
+                  </span>
+                  {' '}in assets with no USD pair{unvalued === 1 ? ' is' : ' are'} left out.
+               </p>}
+
+            {migrated > 0 &&
+               <p className="text-xs text-muted-foreground">
+                  <span
+                     className="cursor-help underline decoration-dotted underline-offset-2"
+                     title={migratedAssets.map(migrationSummary).join(' · ')}>
+                     {migrated} migrated position{migrated === 1 ? '' : 's'}
+                  </span>
+                  {' '}left behind by a token migration{migrated === 1 ? ' is' : ' are'} left out.
                </p>}
 
          </CardContent>

--- a/src/views/components/kraken/balance-placement-card.jsx
+++ b/src/views/components/kraken/balance-placement-card.jsx
@@ -1,6 +1,6 @@
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import Donut from './donut'
-import { migrationOf, migrationSummary } from './asset-migrations'
+import { migrationOf } from './asset-migrations'
 import { placementColor, placementLabel, placementOf } from './placement'
 
 // Every position, valued in USD and grouped by where it sits. Positions in an asset
@@ -11,19 +11,13 @@ export function placementTotals(assets, rates) {
 
    const totals = new Map()
    const unvaluedAssets = new Set()
-   const migratedAssets = new Set()
    let unvalued = 0
-   let migrated = 0
 
    for (const asset of assets ?? []) {
       const rate = rates?.[asset.asset]
       for (const position of asset.positions) {
          if (rate == null) {
-            if (migrationOf(asset.asset)) {
-               migrated++
-               migratedAssets.add(asset.asset)
-            }
-            else {
+            if (!migrationOf(asset.asset)) {
                unvalued++
                unvaluedAssets.add(asset.asset)
             }
@@ -39,19 +33,13 @@ export function placementTotals(assets, rates) {
 
    const slices = [...totals.values()].toSorted((a, b) => b.value - a.value)
 
-   return {
-      slices,
-      unvalued,
-      unvaluedAssets: [...unvaluedAssets].toSorted(),
-      migrated,
-      migratedAssets: [...migratedAssets].toSorted()
-   }
+   return { slices, unvalued, unvaluedAssets: [...unvaluedAssets].toSorted() }
 }
 
 
 export default function BalancePlacementCard({ balances, rates }) {
 
-   const { slices, unvalued, unvaluedAssets, migrated, migratedAssets } = placementTotals(balances?.assets, rates)
+   const { slices, unvalued, unvaluedAssets } = placementTotals(balances?.assets, rates)
 
    return (
       <Card>
@@ -76,16 +64,6 @@ export default function BalancePlacementCard({ balances, rates }) {
                      {unvalued} position{unvalued === 1 ? '' : 's'}
                   </span>
                   {' '}in assets with no USD pair{unvalued === 1 ? ' is' : ' are'} left out.
-               </p>}
-
-            {migrated > 0 &&
-               <p className="text-xs text-muted-foreground">
-                  <span
-                     className="cursor-help underline decoration-dotted underline-offset-2"
-                     title={migratedAssets.map(migrationSummary).join(' · ')}>
-                     {migrated} position{migrated === 1 ? '' : 's'}
-                  </span>
-                  {' '}left behind by a token migration{migrated === 1 ? ' is' : ' are'} left out.
                </p>}
 
          </CardContent>

--- a/src/views/components/kraken/balance-table.jsx
+++ b/src/views/components/kraken/balance-table.jsx
@@ -5,7 +5,8 @@ import { Card, CardHeader, CardTitle, CardAction, CardContent } from '@/componen
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Table, TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell } from '@/components/ui/table'
-import BalanceFilters, { DUST_USD } from './balance-filters'
+import BalanceFilters, { EARNING, dustLimit } from './balance-filters'
+import { migrationNote } from './asset-migrations'
 import { PLACEMENT_ORDER, isEarning, placementColor, placementDescription, placementLabel, placementOf } from './placement'
 import { asCount } from '../lib/filter-options'
 import { asAssetAmount, asDollarAmount, asPercentage } from '../../../utils/format'
@@ -57,6 +58,19 @@ function SortableHead({ column, sort, onSortChange, align, children }) {
    )
 }
 
+function AssetName({ asset }) {
+
+   const note = migrationNote(asset)
+
+   return (
+      <span
+         className={note ? 'cursor-help underline decoration-dotted underline-offset-2' : undefined}
+         title={note ?? undefined}>
+         {asset}
+      </span>
+   )
+}
+
 // The badge carries the colour its slice has in the ring above, so a row can be read
 // against the chart without a legend, and its title spells out what the placement
 // actually means — which is the part Kraken never says.
@@ -95,8 +109,6 @@ export default function BalanceTable({ balances, rates, live, filters, onFilters
    const portfolioValue = assets
       .reduce((sum, asset) => sum + (valueOf(asset.totalNum, rateFor(asset.asset)) ?? 0), 0)
 
-   const search = filters.search.trim().toUpperCase()
-
    // Filtering by placement narrows the positions themselves, so that "Earn · Locked"
    // shows what is locked rather than every asset that happens to have some locked.
    const rows = assets
@@ -104,7 +116,7 @@ export default function BalanceTable({ balances, rates, live, filters, onFilters
          // Ordered the way the ring above is, so a row's badges and the legend read in
          // the same sequence rather than each by its own size.
          const positions = asset.positions
-            .filter(position => !filters.placement || placementOf(position) === filters.placement)
+            .filter(position => matchesPlacement(position, filters.placement))
             .toSorted((a, b) => PLACEMENT_ORDER.indexOf(placementOf(a)) - PLACEMENT_ORDER.indexOf(placementOf(b)))
          const amount = positions.reduce((sum, position) => sum + position.amountNum, 0)
          return {
@@ -121,14 +133,15 @@ export default function BalanceTable({ balances, rates, live, filters, onFilters
          }
       })
       .filter(row => row.positions.length > 0)
-      .filter(row => !search || row.asset.includes(search))
+      .filter(row => !filters.asset || row.asset === filters.asset)
 
    // An asset with no USD pair is never dust: it cannot be valued, so there is no
    // ground to hide it on.
-   const isDust = row => row.value != null && Math.abs(row.value) < DUST_USD
+   const limit = dustLimit(filters)
+   const isDust = row => limit > 0 && row.value != null && Math.abs(row.value) < limit
 
    const dust = rows.filter(isDust)
-   const shown = filters.hideDust ? rows.filter(row => !isDust(row)) : rows
+   const shown = rows.filter(row => !isDust(row))
 
    const sortValue = {
       asset: row => row.asset,
@@ -178,7 +191,10 @@ export default function BalanceTable({ balances, rates, live, filters, onFilters
 
             <BalanceFilters
                filters={filters}
-               options={{ placements: placementOptions(assets) }}
+               options={{
+                  assets: assets.map(asset => asset.asset),
+                  placements: placementOptions(assets)
+               }}
                onChange={onFiltersChange}
                onReset={onReset} />
 
@@ -188,8 +204,8 @@ export default function BalanceTable({ balances, rates, live, filters, onFilters
                </p>
                : sorted.length === 0
                   ? <p className="text-sm text-muted-foreground">
-                     No asset matches the filters{dust.length > 0 && filters.hideDust
-                        ? `, though ${asCount(dust.length, 'asset')} worth under $${DUST_USD} ${dust.length === 1 ? 'is' : 'are'} hidden`
+                     No asset matches the filters{dust.length > 0
+                        ? `, though ${asCount(dust.length, 'asset')} worth under $${limit} ${dust.length === 1 ? 'is' : 'are'} hidden`
                         : ''}.
                   </p>
                   : <div className="space-y-3">
@@ -223,9 +239,9 @@ export default function BalanceTable({ balances, rates, live, filters, onFilters
                                              {isExpanded
                                                 ? <ChevronDownIcon className="size-3.5" />
                                                 : <ChevronRightIcon className="size-3.5" />}
-                                             {row.asset}
+                                             <AssetName asset={row.asset} />
                                           </button>
-                                          : <span className="pl-[1.125rem]">{row.asset}</span>}
+                                          : <span className="pl-[1.125rem]"><AssetName asset={row.asset} /></span>}
                                     </TableCell>
                                     <TableCell>
                                        <div className="flex flex-wrap gap-1">
@@ -293,20 +309,19 @@ export default function BalanceTable({ balances, rates, live, filters, onFilters
                            </TableRow>
                         </TableFooter>
                      </Table>
-
-                     <p className="text-xs text-muted-foreground">
-                        Amounts are rebuilt from the stored ledger and priced at today&apos;s market rate,
-                        so the values move with the market. An asset held in more than one place expands
-                        into a line per placement. <b>In orders</b> is what an order still on the book has
-                        reserved, read from Kraken rather than from the ledger.
-                        {filters.hideDust && dust.length > 0 &&
-                           ` ${asCount(dust.length, 'asset')} worth under $${DUST_USD} ${dust.length === 1 ? 'is' : 'are'} hidden.`}
-                     </p>
                   </div>}
 
          </CardContent>
       </Card>
    )
+}
+
+function matchesPlacement(position, placement) {
+
+   if (!placement) return true
+
+   const key = placementOf(position)
+   return placement === EARNING ? isEarning(key) : key === placement
 }
 
 // Only the placements this account actually uses: offering "Earn · Bonded" to someone
@@ -322,5 +337,8 @@ function placementOptions(assets) {
       }
    }
 
-   return [...seen.values()].toSorted((a, b) => a.label.localeCompare(b.label))
+   const named = [...seen.values()].toSorted((a, b) => a.label.localeCompare(b.label))
+   const earns = [...seen.keys()].some(isEarning)
+
+   return earns ? [{ value: EARNING, label: 'Any rewards' }, ...named] : named
 }

--- a/src/views/components/kraken/donut.jsx
+++ b/src/views/components/kraken/donut.jsx
@@ -1,6 +1,6 @@
 import { Cell, Pie, PieChart } from 'recharts'
 import { ChartContainer, ChartTooltip, ChartTooltipContent, ChartLegend, ChartLegendContent } from '@/components/ui/chart'
-import { asAssetAmount, asDollarAmount, asPercentage } from '../../../utils/format'
+import { asAssetAmount, asDollarAmount, asShortPercentage } from '../../../utils/format'
 
 // A slice thinner than this is a sliver on the ring and a line in the legend that says
 // nothing, so the whole tail is folded into one "Others" slice — the tables below still
@@ -66,7 +66,7 @@ export default function Donut({ slices, colorFor, emptyText }) {
             <span className="flex w-full items-baseline justify-between gap-3">
                <span>{slice.label}</span>
                <span className="tabular-nums text-muted-foreground">
-                  {asPercentage(slice.value / total)}
+                  {asShortPercentage(slice.value / total)}
                </span>
             </span>
       }]))


### PR DESCRIPTION
Two things that looked unrelated and were not: the Balances page was hard to narrow down, and the one holding it could not price was reported as a missing rate when the asset is in fact retired.

## Where it sits

The ring and its legend run biggest share first, rather than in placement order, so the legend reads down in the order its percentages do. Colours are still pinned per placement, so a row's badges below match the slice above.

Legend shares lose a decimal — `56.4%`, not `56.36%`. Two decimals of a share nobody adds up is noise in something read at a glance; the tables keep theirs. This is a change to the shared `Donut`, so the Rewards page ring follows.

The note about unpriced positions now names the assets in a hover bubble rather than leaving a bare count.

## Holdings

- **Asset** replaces the free-text *Search asset* box with the searchable dropdown the other pages use, and moves ahead of **Placement**. The match is exact rather than substring.
- **Placement** gains **Any rewards** at the top, offered only when the account has something earning. It covers every placement that pays — the Earn products and Opt-In Rewards — so seeing what is working no longer takes one pass per product. It excludes the `Other` bucket, which is an unrecognised wallet rather than a reward.
- **Hide under ($)** replaces the fixed `Hide under $1` checkbox with a field, defaulting to 1. Empty or 0 hides nothing.
- The explanatory paragraph under the table is removed. The dust count it carried still shows in the empty state.

`defaultFilters` changed shape (`asset`/`dust` in, `search`/`hideDust` out). Stored filters from before merge over the default, so the stale keys are ignored rather than breaking the page.

## Migrated assets

`AI16Z` is what prompted this. The ledger holds one row for it — a deposit of 1757.259981 on 2025-07-11, never debited — and on 2025-12-19 an `ELIZAOS` credit of 10543.559 arrived as `transfer/airdrop`. That is exactly 6×: Kraken paid the ai16z → elizaOS redenomination as an airdrop and left the old balance in place. Its own `Balance` endpoint still returns both, so the fold is right and the position is real. But `AI16Z` has no tradable pair (`Assets` still lists it as enabled; `AssetPairs` has nothing), so it cannot be valued, and it was being counted as an asset waiting on a rate.

`src/views/components/kraken/asset-migrations.js` is a small table naming these:

```js
AI16Z: { to: 'ELIZAOS', ratio: 6, on: '2025-12-19', credited: 'an airdrop' }
```

It is display-only, and deliberately quiet: the asset cell gets a dotted underline and a tooltip saying what happened, and the ring stops counting the position among the unpriced ones. Nothing is said under the chart — the leftover balance is Kraken's housekeeping, not something to act on. **No amount changes**, so the ledger still reconciles against Kraken.

This is deliberately not an entry in `assetAliases` (`MATIC → POL`, `ETH2 → ETH`). Those are 1:1 renames where Kraken zeroed the old ticker. Here both balances exist at once at a 1:6 ratio: aliasing would sum 1757 + 10543 and price the lot, inventing value that cannot be sold, and rewriting the old rows into the new asset would double-count against the airdrop row while leaving the live comparison unreconcilable.

## Aggregated Trades

The **VWAP** header already carried a hint on hover with no sign that it did. It now has the same dotted underline as the tooltips above.

## Verification

`bun run lint` is clean. Checked in mocked mode and against the real ledger:

- Legend percentages descend and carry one decimal; slice colours still line up with the row badges; the table Share column still shows two.
- **Any rewards** drops every spot-only row and totals to the same figure as the *Earning* tile on the summary card.
- Dust field at 0 shows the tail; reset restores $1.
- Real account: the `AI16Z` row renders underlined with the full tooltip, price and value as em-dashes, and no note appears under the ring.
- The mocked fixture has no unpriced asset, so the "no USD pair" path was checked by temporarily dropping `LINK` from the mocked rates, then put back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
