### PR TITLE
fix(desktop): let the API server take an OS-assigned port

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ A single HTTP requester (`src/server/adapters/http-requester/server-http-request
 
 **Utils** (`src/utils/`) — `crypto.js` wraps Web Crypto API using higher-order factory functions (`hash(algo)`, `hmac(algo)`) that export `sha256`, `hmacSha256`, `hmacSha512`. `format.js` provides en-GB locale formatting via `Intl`. `event-bus.js` is a DOM-based pub/sub (SSR-safe, returns cleanup functions for `useEffect`).
 
-**Electrobun main process** (`src/electrobun/index.ts`) — TypeScript entry point for the desktop app. Starts the Hono server on port 3001, opens a `BrowserWindow`, and wires up menus and external link handling.
+**Electrobun main process** (`src/electrobun/index.ts`) — TypeScript entry point for the desktop app. Starts the Hono server on an OS-assigned port (port 3001 only when it attaches to the Vite dev server, whose proxy needs a fixed target) and injects that port into the page as `window.__API_PORT__`, opens a `BrowserWindow`, and wires up menus and external link handling.
 
 ### Data Flow
 

--- a/scripts/prebuild.ts
+++ b/scripts/prebuild.ts
@@ -1,9 +1,5 @@
 /// <reference types="bun-types" />
 import { $ } from "bun";
 
-// Set VITE_API_BASE so the bundled SPA fetches against the local Hono server
-// rather than resolving /api/* relative to views:// (which has no proxy).
-process.env.VITE_API_BASE = `http://127.0.0.1:${process.env.PORT ?? 3001}`;
-
 // Compile the Vite SPA to dist/ so ElectroBun can copy it into the app bundle.
 await $`bun run build`;

--- a/src/electrobun/index.ts
+++ b/src/electrobun/index.ts
@@ -4,7 +4,7 @@ import { createApp } from '../server/app.js'
 import { systemLocales } from './locale'
 import { resolveInitialWindowState, trackWindowState } from './window-state'
 
-const PORT = Number(process.env.PORT ?? 3001)
+const DEV_API_PORT = Number(process.env.PORT ?? 3001)
 const DEV_SERVER_URL = `http://localhost:${process.env.VITE_PORT ?? 3000}`
 const VIEWS_URL = 'views://main/index.html'
 
@@ -25,24 +25,31 @@ async function main() {
 
    const honoApp = createApp()
 
+   // The dev server proxies /api to a fixed port; a packaged app takes whatever port
+   // the OS hands out, so two Electrobun apps never fight over the same one.
+   const usingDevServer = url === DEV_SERVER_URL
+   let server: ReturnType<typeof Bun.serve>
    try {
-      Bun.serve({
-         port: PORT,
+      server = Bun.serve({
+         port: usingDevServer ? DEV_API_PORT : 0,
          hostname: '127.0.0.1',
          fetch: honoApp.fetch,
          idleTimeout: 0,
       })
-      console.log(`✓ API server listening on http://127.0.0.1:${PORT}`)
+      console.log(`✓ API server listening on http://127.0.0.1:${server.port}`)
    }
    catch (error: any) {
       if (error?.code !== 'EADDRINUSE') throw error
-      console.error(`✗ Port ${PORT} is already in use — another instance is running.`)
+      console.error(`✗ Port ${DEV_API_PORT} is already in use — another instance is running.`)
       console.error('  Start this one on its own ports: PORT=3011 VITE_PORT=3010 bun run desktop:dev')
       process.exit(1)
    }
 
    const locales = systemLocales()
-   const preload = locales.length ? `window.__LOCALES__ = ${JSON.stringify(locales)};` : null
+   const preload = [
+      `window.__API_PORT__ = ${server.port};`,
+      locales.length ? `window.__LOCALES__ = ${JSON.stringify(locales)};` : null,
+   ].filter(Boolean).join(' ')
 
    // Created hidden so the geometry is applied before the window is ever drawn; the frame
    // is the restored (un-maximized) size, the maximized rectangle is left to the OS.

--- a/src/views/app.jsx
+++ b/src/views/app.jsx
@@ -20,8 +20,11 @@ export const isMockMode = import.meta.env.VITE_MOCK_DATA === 'true'
 // Hash-based routing keeps navigation inside the page regardless of scheme.
 const Router = window.location.protocol === 'views:' ? HashRouter : BrowserRouter
 // In Electrobun production, the page loads from views:// so relative /api paths won't reach
-// the Hono server. VITE_API_BASE is injected at build time by scripts/prebuild.ts.
-export const API_BASE = import.meta.env.VITE_API_BASE ?? ''
+// the Hono server. The main process picks a free port at startup and injects it through
+// the preload, so several Electrobun apps can run at once.
+export const API_BASE = window.__API_PORT__
+   ? `http://127.0.0.1:${window.__API_PORT__}`
+   : import.meta.env.VITE_API_BASE ?? ''
 
 async function fetcher(key, params) {
 


### PR DESCRIPTION
## Problem

The packaged desktop app hard-codes its local Hono server to `127.0.0.1:3001`, and so does [qoqa-compta](https://github.com/nyg/qoqa-compta). Whichever app starts second hits `EADDRINUSE` and dies before its window is shown, so the two can never be open at the same time.

## Change

`Bun.serve` now requests port `0` — an OS-assigned free port — whenever the window is not attached to the Vite dev server. The resolved `server.port` is injected into the page through the Electrobun preload as `window.__API_PORT__`, riding the same channel as `window.__LOCALES__`, and the SPA reads it at module scope to build `API_BASE`. That also makes `scripts/prebuild.ts` baking `VITE_API_BASE` into the bundle unnecessary, so it is gone; the env var stays as a fallback for anyone who sets it explicitly.

Development is unchanged. When the window attaches to the Vite dev server the API keeps the fixed port (`PORT`, default 3001) that Vite's `/api` proxy targets, including the existing `EADDRINUSE` message that points at `PORT=3011 VITE_PORT=3010`.

## Verification

`bun run lint` and `tsc --noEmit` are clean. The preload path is the one `window.__LOCALES__` already uses, so the value is present before the SPA's module scope runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)