### PR TITLE
fix(server): bind the API to loopback

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -3,6 +3,7 @@ import path from 'path'
 import { createApp } from './app.js'
 
 const PORT = parseInt(process.env.PORT ?? '3001', 10)
+const HOST = process.env.HOST ?? '127.0.0.1'
 const IS_PROD = process.env.NODE_ENV === 'production'
 
 const app = createApp()
@@ -39,10 +40,11 @@ if (IS_PROD) {
 try {
    Bun.serve({
       port: PORT,
+      hostname: HOST,
       fetch: app.fetch,
       idleTimeout: 0,
    })
-   console.log(`✓ Server listening on http://localhost:${PORT}`)
+   console.log(`✓ Server listening on http://${HOST}:${PORT}`)
 }
 catch (error) {
    if (error.code !== 'EADDRINUSE') throw error


### PR DESCRIPTION
Closes the second box of #253. Stacked on #267 — **review the [second commit](https://github.com/nyg/crypto-tools/pull/268/commits) only**; base retargets to `master` once #267 merges.

## First, a correction to the issue

> make sure electrobun server binds on 127.0.0.1 instead of 0.0.0.0 (causes prompt on Windows first run)

**The Electrobun server already does, and always has** — `hostname: '127.0.0.1'` has been in `src/electrobun/index.ts` since #165. So whatever caused that Windows prompt, it was not this app's desktop bind. Electrobun's own webview RPC transport is loopback too. I could not reproduce a wildcard listener in a packaged app, so this PR does not claim to fix the prompt; it fixes the one genuinely wildcard-bound listener in the repo, which the issue's premise led me to.

## What was actually wrong

`src/server/index.js` — the standalone web/`bun run start` entry — passed no `hostname` to `Bun.serve`, so it bound the wildcard while its startup line claimed `http://localhost:${PORT}`. That log line is why this went unnoticed: it said loopback and meant everything.

That server holds the exchange API keys (`settings.json`) and the Kraken ledger database, and answers `/api/kraken/order-batch`. On a shared network it was reachable by anything on the LAN — the CORS allowlist in `src/server/app.js` guards browsers, not `curl`.

It now binds `127.0.0.1`, matching the desktop entry point. `HOST` remains as the deliberate opt-out for a container or a LAN deployment, so the wildcard becomes something asked for rather than inherited, and the log reports the address actually bound.

## Verification

Same server, same port, before and after:

```
before:  ✓ Server listening on http://localhost:3022
         TCP *:3022 (LISTEN)            ← IPv6 dual-stack wildcard

after:   ✓ Server listening on http://127.0.0.1:3021
         TCP 127.0.0.1:3021 (LISTEN)
```

`bun run dev` still works end to end — Vite's `/api` proxy reaches the Hono server and `GET /api/settings` returns 200 through it.

One behaviour change worth knowing: `http://[::1]:3001` no longer connects (it did before, via the dual-stack wildcard). Vite's proxy resolves `localhost` to IPv4 and is unaffected, but anything hardcoding the IPv6 loopback would need `HOST=::1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)