### PR TITLE
feat(app): add an About dialog reachable from the header version

### DIFF
--- a/src/views/components/about-dialog.jsx
+++ b/src/views/components/about-dialog.jsx
@@ -1,0 +1,57 @@
+import ExternalLink from './lib/external-link'
+import { APP_VERSION } from '@/lib/about-event'
+import {
+   Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle
+} from '@/components/ui/dialog'
+
+const REPOSITORY_URL = 'https://github.com/nyg/crypto-tools'
+
+const Command = ({ children }) =>
+   <code className="rounded bg-muted px-1 py-0.5 text-xs">{children}</code>
+
+const SectionTitle = ({ children }) =>
+   <h3 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+      {children}
+   </h3>
+
+export default function AboutDialog({ open, onOpenChange }) {
+
+   return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+         <DialogContent>
+
+            <DialogHeader>
+               <DialogTitle>Crypto Tools</DialogTitle>
+               <DialogDescription>
+                  {APP_VERSION ? `Version ${APP_VERSION}` : 'Development build'}
+               </DialogDescription>
+            </DialogHeader>
+
+            <section className="space-y-2">
+               <SectionTitle>Updates</SectionTitle>
+               <p className="text-sm text-muted-foreground">
+                  The app never updates itself. Installed with Scoop or Homebrew? Update it
+                  with your package manager — <Command>scoop update crypto-tools</Command> or{' '}
+                  <Command>brew upgrade --cask nyg/tap/crypto-tools</Command>.
+               </p>
+            </section>
+
+            <section className="space-y-2">
+               <SectionTitle>Project</SectionTitle>
+               <p className="text-sm">
+                  <ExternalLink href={REPOSITORY_URL} className="font-medium underline underline-offset-4">
+                     Source code
+                  </ExternalLink>
+                  <span className="text-muted-foreground"> — MIT licensed.</span>
+               </p>
+               <p className="text-sm">
+                  <ExternalLink href={`${REPOSITORY_URL}/issues`} className="font-medium underline underline-offset-4">
+                     Report an issue
+                  </ExternalLink>
+               </p>
+            </section>
+
+         </DialogContent>
+      </Dialog>
+   )
+}

--- a/src/views/components/layout.jsx
+++ b/src/views/components/layout.jsx
@@ -1,9 +1,11 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Link, useLocation } from 'react-router'
+import AboutDialog from './about-dialog'
 import MenuLink from './lib/menu-link'
 import PageHelpButton from './lib/page-help-button'
 import { Button } from '@/components/ui/button'
 import { Toaster } from '@/components/ui/sonner'
+import { APP_VERSION, SHOW_ABOUT_EVENT } from '@/lib/about-event'
 import { groupHref, toolPaths } from '@/lib/tools'
 
 
@@ -20,10 +22,17 @@ const GithubLogo = props => (
 export default function Layout({ children, name }) {
 
    const { pathname } = useLocation()
+   const [aboutOpen, setAboutOpen] = useState(false)
 
    useEffect(() => {
       document.title = `Crypto Tools — ${name}`
    }, [name])
+
+   useEffect(() => {
+      const open = () => setAboutOpen(true)
+      window.addEventListener(SHOW_ABOUT_EVENT, open)
+      return () => window.removeEventListener(SHOW_ABOUT_EVENT, open)
+   }, [])
 
    return (
       <div className="flex min-h-svh flex-col">
@@ -43,6 +52,15 @@ export default function Layout({ children, name }) {
                   {/* Only where no sub-nav is carrying it: on a tool page the help sits
                       beside the tabs, next to the page it describes. */}
                   {!toolPaths.has(pathname) && <PageHelpButton />}
+                  <Button
+                     variant="ghost"
+                     size="sm"
+                     className="text-muted-foreground tabular-nums hover:text-foreground"
+                     aria-label="About Crypto Tools"
+                     title="About Crypto Tools"
+                     onClick={() => setAboutOpen(true)}>
+                     {APP_VERSION ? `v${APP_VERSION}` : 'About'}
+                  </Button>
                   <Button asChild variant="ghost" size="icon-sm" className="text-muted-foreground hover:text-foreground">
                      <a href="https://github.com/nyg/crypto-tools" target="_blank" rel="noreferrer">
                         <GithubLogo />
@@ -56,6 +74,8 @@ export default function Layout({ children, name }) {
          <main className="w-full grow px-4 pt-5 pb-8 sm:px-6">
             {children}
          </main>
+
+         <AboutDialog open={aboutOpen} onOpenChange={setAboutOpen} />
 
          <Toaster />
 

--- a/src/views/components/ui/dialog.jsx
+++ b/src/views/components/ui/dialog.jsx
@@ -1,0 +1,136 @@
+'use client'
+
+import * as React from 'react'
+import { Dialog as DialogPrimitive } from 'radix-ui'
+import { XIcon } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+function Dialog({
+   ...props
+}) {
+   return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+   ...props
+}) {
+   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+   ...props
+}) {
+   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+   ...props
+}) {
+   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+   className,
+   ...props
+}) {
+   return (
+      <DialogPrimitive.Overlay
+         data-slot="dialog-overlay"
+         className={cn(
+            'fixed inset-0 z-50 bg-black/50 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
+            className
+         )}
+         {...props} />
+   )
+}
+
+function DialogContent({
+   className,
+   children,
+   showCloseButton = true,
+   ...props
+}) {
+   return (
+      <DialogPortal>
+         <DialogOverlay />
+         <DialogPrimitive.Content
+            data-slot="dialog-content"
+            className={cn(
+               'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg bg-popover p-6 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 sm:max-w-lg data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+               className
+            )}
+            {...props}>
+            {children}
+            {showCloseButton &&
+               <DialogPrimitive.Close
+                  data-slot="dialog-close"
+                  className="absolute top-4 right-4 rounded-xs text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:pointer-events-none">
+                  <XIcon className="size-4" />
+                  <span className="sr-only">Close</span>
+               </DialogPrimitive.Close>}
+         </DialogPrimitive.Content>
+      </DialogPortal>
+   )
+}
+
+function DialogHeader({
+   className,
+   ...props
+}) {
+   return (
+      <div
+         data-slot="dialog-header"
+         className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+         {...props} />
+   )
+}
+
+function DialogFooter({
+   className,
+   ...props
+}) {
+   return (
+      <div
+         data-slot="dialog-footer"
+         className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+         {...props} />
+   )
+}
+
+function DialogTitle({
+   className,
+   ...props
+}) {
+   return (
+      <DialogPrimitive.Title
+         data-slot="dialog-title"
+         className={cn('font-heading text-lg font-medium', className)}
+         {...props} />
+   )
+}
+
+function DialogDescription({
+   className,
+   ...props
+}) {
+   return (
+      <DialogPrimitive.Description
+         data-slot="dialog-description"
+         className={cn('text-sm text-muted-foreground', className)}
+         {...props} />
+   )
+}
+
+export {
+   Dialog,
+   DialogClose,
+   DialogContent,
+   DialogDescription,
+   DialogFooter,
+   DialogHeader,
+   DialogOverlay,
+   DialogPortal,
+   DialogTitle,
+   DialogTrigger,
+}

--- a/src/views/lib/about-event.js
+++ b/src/views/lib/about-event.js
@@ -1,0 +1,3 @@
+export const SHOW_ABOUT_EVENT = 'crypto-tools:show-about'
+
+export const APP_VERSION = import.meta.env.VITE_APP_VERSION ?? ''

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,16 @@
+import { readFileSync } from 'fs'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 
+const { version } = JSON.parse(
+   readFileSync(path.resolve(import.meta.dirname, 'package.json'), 'utf-8'))
+
 export default defineConfig({
+   define: {
+      'import.meta.env.VITE_APP_VERSION': JSON.stringify(version),
+   },
    // Relative base so assets resolve correctly under views:// (Electrobun's
    // custom scheme). Absolute /assets/... paths fail when loaded from
    // views://main/index.html because they resolve to the scheme root, not


### PR DESCRIPTION
Closes the fourth box of #253. Stacked on #268 — **review the last commit only**; the base retargets as the stack merges.

**Landing this before the Windows menu change** (#253's third box), even though the issue lists them the other way round: the menu PR replaces macOS's dead `about` role with a custom action, and that action needs something to open. This way the menu item works the moment it lands, instead of dispatching into nothing for one PR.

## What changed

The app never told you which version you were running — the version reached the Electrobun bundle metadata and stopped there. On Windows that is worse than an omission, since the application menu is the only other place a version could show up and none of its items work there anyway.

The header now carries the version. Clicking it opens an About dialog:

```
header:   Crypto Tools   Kraken  Binance  Tools  Settings          v0.5.0  ⃝
dialog:   Crypto Tools
          Version 0.5.0
          UPDATES   The app never updates itself. Installed with Scoop or
                    Homebrew? Update it with your package manager —
                    `scoop update crypto-tools` or `brew upgrade --cask …`
          PROJECT   Source code — MIT licensed.
                    Report an issue
```

**A dialog, not a route**, so reading it never costs you the page you were on. It lives in `Layout`, which wraps every screen and already owns `<Toaster />`.

**The version arrives through a Vite `define`**, not an API call — same string in the web build and the desktop bundle, no request to display it, and no mock to maintain. It is read from `package.json`, which `electrobun.config.ts` already reads, so one `npm version` bump moves the bundle metadata and the header together. An empty value means a build that never went through Vite's config and reads as "Development build".

**The `crypto-tools:show-about` window event** is the second way in, and the contract the next PR depends on: the main process has no route into React, but it can ask the webview to dispatch.

## On the Dialog primitive

`src/views/components/ui/dialog.jsx` is new — only `alert-dialog` was vendored. I wrote it by hand rather than taking what `shadcn add dialog` emits: the CLI wanted to write `.tsx` and offered to overwrite `button`, neither of which is right here. It follows `alert-dialog.jsx` exactly — same `radix-ui` import shape, same `data-slot` attributes, same overlay/content classes — plus the close button and `DialogClose` that alert-dialog has no use for.

## Verification

Driven in a real browser against `VITE_MOCK_DATA=true`:

- header shows `v0.5.0`; the button is exposed as `button "About Crypto Tools"` in the accessibility tree
- clicking it opens the dialog with the version, both package-manager commands and both links
- the X closes it
- from a **confirmed-closed** state, dispatching `crypto-tools:show-about` reopens it — this is the path the macOS menu will take
- `bun run build` inlines `0.5.0` into the bundle
- `bun run lint` clean

Not verified: the app doesn't follow the system dark scheme today (pre-existing, unrelated to this change), so the dialog was only exercised in light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
