### PR TITLE
fix(desktop): drop the application menu on Windows

### DIFF
--- a/src/electrobun/index.ts
+++ b/src/electrobun/index.ts
@@ -7,6 +7,9 @@ import { resolveInitialWindowState, trackWindowState } from './window-state'
 const DEV_API_PORT = Number(process.env.PORT ?? 3001)
 const DEV_SERVER_URL = `http://localhost:${process.env.VITE_PORT ?? 3000}`
 const VIEWS_URL = 'views://main/index.html'
+const ABOUT_ACTION = 'show-about'
+const SHOW_ABOUT_JS = 'window.dispatchEvent(new CustomEvent(\'crypto-tools:show-about\'))'
+const hasApplicationMenu = process.platform !== 'win32'
 
 async function resolveUrl(): Promise<string> {
    if (BuildConfig.getSync().channel !== 'dev') {
@@ -84,11 +87,27 @@ async function main() {
 
    win.show()
 
+   if (!hasApplicationMenu) {
+      return
+   }
+
+   ApplicationMenu.on('application-menu-clicked', (event: any) => {
+      if (event?.data?.action !== ABOUT_ACTION) {
+         return
+      }
+      try {
+         win.webview.executeJavascript(SHOW_ABOUT_JS)
+      }
+      catch (error) {
+         console.error('✗ Could not open the About dialog:', error)
+      }
+   })
+
    ApplicationMenu.setApplicationMenu([
       {
          label: 'Crypto Tools',
          submenu: [
-            { role: 'about' },
+            { label: 'About Crypto Tools', action: ABOUT_ACTION },
             { type: 'separator' },
             { role: 'hide' },
             { role: 'hideOthers' },


### PR DESCRIPTION
Closes the third box of #253. Stacked on #269 — **review the last commit only**.

## Why

Electrobun's Windows menu builder implements `quit`, the edit roles and the window roles. It implements **none** of `about`, `hide`, `hideOthers`, `showAll`, `bringAllToFront`. I checked this against `electrobun@main` rather than trusting #244's finding, since 2.0 landed in between — `package/src/native/win/nativeWrapper.cpp` dispatches exactly these and no more:

```
__quit__  __undo__  __redo__  __cut__  __copy__  __paste__  __pasteAndMatchStyle__
__delete__  __selectAll__  __minimize__  __toggleFullScreen__  __zoom__  __close__
```

So on Windows, five of the seven items in the first two menus did nothing when clicked. **2.0 does not fix this.**

## What changed

Windows gets no menu bar. Nothing is lost — WebView2 handles undo/cut/copy/paste/select-all natively, and Alt+F4 and the title bar close the window. macOS keeps its menu unchanged.

The one remaining dead item is `{ role: 'about' }` on macOS: the stock about panel has nothing to show for an app that never configured one. It becomes a custom action, and the main process answers it by asking the webview to dispatch the `crypto-tools:show-about` event the dialog from #269 listens for.

```
Windows:  (no menu bar)
macOS:    Crypto Tools ▸ About Crypto Tools → opens the About dialog
                       ▸ Hide / Hide Others / Show All / Quit
          Edit ▸ …     Window ▸ …
```

## Verification

The menu item cannot be clicked programmatically here — System Events refused with `-1743`, no Accessibility grant. So I verified the chain underneath it instead, in the **packaged macOS app**, by temporarily calling exactly what the menu handler calls and having the page report back over the local API:

```
✓ API server listening on http://127.0.0.1:62194
GET /api/settings → 200
GET /api/probe-dialog-open-true → 404
```

`…-true` is the page answering that `[data-slot="dialog-content"]` is in the DOM after `executeJavascript` dispatched the event — i.e. main process → webview → listener → React → dialog rendered, which is everything the menu item does apart from the click itself. The probe was reverted; the diff is only what you see.

Also: `bun run typecheck`, `bun run lint`, and a full `build:stable` whose app launches with the menu registered and no error.

**Windows is unverified** — it needs a release build. The change there is a `return` before any menu call, so the risk is low, but the visible outcome (no bar at all) is worth an eyeball on the next release.

## Note on ordering

#253 lists this before the About page; I swapped them so this PR's About item has something to open the moment it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)