### PR TITLE
feat(app): check for a newer release without ever replacing the app

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
+import appRoutes from './routes/app.js'
 import binanceRoutes from './routes/binance.js'
 import krakenRoutes from './routes/kraken.js'
 import settingsRoutes from './routes/settings.js'
@@ -58,6 +59,7 @@ export function createApp() {
       console.log(`${color}${c.req.method} ${new URL(c.req.url).pathname} → ${status}${reset} (${ms}ms)`)
    })
 
+   app.route('/api/app', appRoutes)
    app.route('/api/binance', binanceRoutes)
    app.route('/api/kraken', krakenRoutes)
    app.route('/api/settings', settingsRoutes)

--- a/src/server/routes/app.js
+++ b/src/server/routes/app.js
@@ -1,0 +1,54 @@
+import { Hono } from 'hono'
+
+const app = new Hono()
+
+const LATEST_RELEASE_URL = 'https://api.github.com/repos/nyg/crypto-tools/releases/latest'
+const RELEASES_URL = 'https://github.com/nyg/crypto-tools/releases/latest'
+const REQUEST_TIMEOUT_MS = 5000
+const SUCCESS_TTL_MS = 6 * 60 * 60 * 1000
+const FAILURE_TTL_MS = 15 * 60 * 1000
+
+let cached = null
+
+async function fetchLatestRelease() {
+
+   const response = await fetch(LATEST_RELEASE_URL, {
+      headers: { accept: 'application/vnd.github+json', 'user-agent': 'crypto-tools' },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+   })
+
+   if (!response.ok) {
+      throw new Error(`GitHub answered ${response.status}`)
+   }
+
+   const release = await response.json()
+   const version = String(release?.tag_name ?? '').replace(/^v/, '')
+
+   if (!version) {
+      throw new Error('the latest release has no tag name')
+   }
+
+   return { version, url: release.html_url || RELEASES_URL }
+}
+
+app.get('/latest-release', async (c) => {
+
+   if (cached && Date.now() < cached.expiresAt) {
+      return cached.release
+         ? c.json(cached.release)
+         : c.json({ error: cached.error }, 502)
+   }
+
+   try {
+      const release = await fetchLatestRelease()
+      cached = { release, expiresAt: Date.now() + SUCCESS_TTL_MS }
+      return c.json(release)
+   }
+   catch (error) {
+      console.warn('Could not read the latest release:', error.message)
+      cached = { error: 'Could not check for updates.', expiresAt: Date.now() + FAILURE_TTL_MS }
+      return c.json({ error: cached.error }, 502)
+   }
+})
+
+export default app

--- a/src/views/components/about-dialog.jsx
+++ b/src/views/components/about-dialog.jsx
@@ -1,5 +1,7 @@
+import { ArrowUpCircleIcon, CheckCircleIcon, CircleAlertIcon, LoaderCircleIcon } from 'lucide-react'
 import ExternalLink from './lib/external-link'
 import { APP_VERSION } from '@/lib/about-event'
+import useLatestRelease from '@/lib/use-latest-release'
 import {
    Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle
 } from '@/components/ui/dialog'
@@ -13,6 +15,50 @@ const SectionTitle = ({ children }) =>
    <h3 className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
       {children}
    </h3>
+
+function UpdateStatus() {
+
+   const { version, url, updateAvailable, isLoading, error } = useLatestRelease()
+
+   if (isLoading) {
+      return (
+         <p className="flex items-center gap-2 text-sm text-muted-foreground">
+            <LoaderCircleIcon className="size-4 animate-spin" />
+            Checking for updates…
+         </p>
+      )
+   }
+
+   if (error || !version) {
+      return (
+         <p className="flex items-center gap-2 text-sm text-muted-foreground">
+            <CircleAlertIcon className="size-4" />
+            Could not check for updates.
+         </p>
+      )
+   }
+
+   if (!updateAvailable) {
+      return (
+         <p className="flex items-center gap-2 text-sm text-muted-foreground">
+            <CheckCircleIcon className="size-4" />
+            Up to date.
+         </p>
+      )
+   }
+
+   return (
+      <p className="flex items-center gap-2 text-sm">
+         <ArrowUpCircleIcon className="size-4 shrink-0 text-muted-foreground" />
+         <span>
+            Version {version} is available.{' '}
+            <ExternalLink href={url} className="font-medium underline underline-offset-4">
+               Release notes
+            </ExternalLink>
+         </span>
+      </p>
+   )
+}
 
 export default function AboutDialog({ open, onOpenChange }) {
 
@@ -29,6 +75,7 @@ export default function AboutDialog({ open, onOpenChange }) {
 
             <section className="space-y-2">
                <SectionTitle>Updates</SectionTitle>
+               <UpdateStatus />
                <p className="text-sm text-muted-foreground">
                   The app never updates itself. Installed with Scoop or Homebrew? Update it
                   with your package manager — <Command>scoop update crypto-tools</Command> or{' '}

--- a/src/views/components/layout.jsx
+++ b/src/views/components/layout.jsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Toaster } from '@/components/ui/sonner'
 import { APP_VERSION, SHOW_ABOUT_EVENT } from '@/lib/about-event'
 import { groupHref, toolPaths } from '@/lib/tools'
+import useLatestRelease from '@/lib/use-latest-release'
 
 
 const isSection = (path, href) => path.split('/')[1] === href.split('/')[1]
@@ -23,6 +24,7 @@ export default function Layout({ children, name }) {
 
    const { pathname } = useLocation()
    const [aboutOpen, setAboutOpen] = useState(false)
+   const { updateAvailable } = useLatestRelease()
 
    useEffect(() => {
       document.title = `Crypto Tools — ${name}`
@@ -56,10 +58,11 @@ export default function Layout({ children, name }) {
                      variant="ghost"
                      size="sm"
                      className="text-muted-foreground tabular-nums hover:text-foreground"
-                     aria-label="About Crypto Tools"
-                     title="About Crypto Tools"
+                     aria-label={updateAvailable ? 'Update available' : 'About Crypto Tools'}
+                     title={updateAvailable ? 'Update available' : 'About Crypto Tools'}
                      onClick={() => setAboutOpen(true)}>
                      {APP_VERSION ? `v${APP_VERSION}` : 'About'}
+                     {updateAvailable && <span aria-hidden className="size-1.5 rounded-full bg-primary" />}
                   </Button>
                   <Button asChild variant="ghost" size="icon-sm" className="text-muted-foreground hover:text-foreground">
                      <a href="https://github.com/nyg/crypto-tools" target="_blank" rel="noreferrer">

--- a/src/views/lib/use-latest-release.js
+++ b/src/views/lib/use-latest-release.js
@@ -1,0 +1,37 @@
+import useSWR from 'swr'
+import { APP_VERSION } from './about-event'
+
+export const LATEST_RELEASE_KEY = '/api/app/latest-release'
+
+const segments = version =>
+   String(version).split('-')[0].split('.').map(part => parseInt(part, 10) || 0)
+
+export function isNewer(candidate, current) {
+
+   if (!candidate || !current) return false
+
+   const [left, right] = [segments(candidate), segments(current)]
+   for (let index = 0; index < Math.max(left.length, right.length); index++) {
+      const difference = (left[index] ?? 0) - (right[index] ?? 0)
+      if (difference !== 0) return difference > 0
+   }
+
+   return !String(candidate).includes('-') && String(current).includes('-')
+}
+
+export default function useLatestRelease() {
+
+   const { data, error, isLoading } = useSWR(LATEST_RELEASE_KEY, {
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+      shouldRetryOnError: false
+   })
+
+   return {
+      version: data?.version ?? null,
+      url: data?.url ?? null,
+      updateAvailable: isNewer(data?.version, APP_VERSION),
+      isLoading,
+      error
+   }
+}

--- a/src/views/mocks/index.js
+++ b/src/views/mocks/index.js
@@ -37,6 +37,12 @@ const mockRoutes = {
    '/api/binance/aggregate-balance': () => aggregateBalance,
    '/api/settings': () => mockSettings(false),
    '/api/settings?reveal=true': () => mockSettings(true),
+   '/api/app/latest-release': () => mockLatestRelease,
+}
+
+const mockLatestRelease = {
+   version: '99.0.0',
+   url: 'https://github.com/nyg/crypto-tools/releases/latest'
 }
 
 const mockSettings = (reveal) => ({


### PR DESCRIPTION
Closes the fifth box of #253. Stacked on #270 — **review the last commit only**.

## What changed

The About dialog now reports whether a newer release exists, and the header version carries a dot when one does:

```
header:   … v0.5.0 •              aria-label="Update available"
dialog:   UPDATES
          ↑ Version 0.6.0 is available.  Release notes
          The app never updates itself. Installed with Scoop or Homebrew? …
```

Nothing interrupts — no launch toast, no modal. #244 used a toast; the dot is quieter and the header version is already the way into the dialog.

## What is deliberately not here

**Self-updating.** Electrobun's `Updater.applyUpdate()` replaces the installed app in place: on Windows it writes to `%LOCALAPPDATA%\<identifier>\<channel>\app` regardless of where the running copy lives, so a Scoop install would silently fork into a second copy; on macOS it would overwrite a bundle Homebrew believes it manages. Both are the recommended install paths for this app. It also needs a `release.baseUrl` and a published `update.json`, neither of which exists here — the build log still says `no release.baseUrl configured; skipping delta patch`.

So the dialog names `scoop update crypto-tools` / `brew upgrade --cask` and the app never touches itself. This keeps the promise the release workflow already makes in a comment on the Scoop step.

## Design notes

**GitHub is queried server-side.** Under `views://` the page origin is opaque, and the cache belongs somewhere that outlives a page reload. Unauthenticated callers get 60 requests/hour, so a success is held 6 h and a **failure 15 min** — long enough not to hammer the API on a flaky connection, short enough to heal by itself.

**A development build never claims an update** (`APP_VERSION` is empty → `isNewer` returns false), and a plain release counts as newer than its own prerelease.

**One request per load** — both consumers share the SWR key with revalidation and retries off.

## Verification

Against the real API:

```
GET /api/app/latest-release → 200 (250ms)   {"version":"0.5.0","url":"…/tag/v0.5.0"}
GET /api/app/latest-release → 200   (0ms)   ← cache; no upstream round trip
```

Against a deliberately broken upstream:

```
Could not read the latest release: GitHub answered 404
GET /api/app/latest-release → 502 (253ms)
GET /api/app/latest-release → 502   (0ms)   ← negative cache
```

`isNewer` across 12 cases, all passing — including `0.10.0 > 0.9.0` (numeric, not lexical), `0.5.0 > 0.5.0-beta.1`, `0.5.0-beta.1 ≯ 0.5.0`, and both empty-string directions.

In the browser, all four UI states driven via the mock:

| mock | header | dialog |
|---|---|---|
| `99.0.0` | dot, `aria-label="Update available"` | `Version 99.0.0 is available. Release notes` |
| `0.5.0` | no dot, `aria-label="About Crypto Tools"` | `Up to date.` |
| `{}` | no dot | `Could not check for updates.` |
| in flight | no dot | `Checking for updates…` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)