### PR TITLE
feat(release): ship a single-file Windows installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,64 @@ jobs:
           ( cd "${appdirs[0]}" && zip -r "$GITHUB_WORKSPACE/artifacts/crypto-tools-${VERSION}-windows-x64-scoop.zip" . )
           rm -rf _scoop_build
 
+      - name: Create single-file installer EXE
+        env:
+          VERSION: ${{ needs.prepare.outputs.release_version }}
+        run: |
+          set -euo pipefail
+          rm -rf _exe_build && mkdir -p _exe_build
+          unzip -q "artifacts/crypto-tools-${VERSION}-windows-x64-setup.zip" -d _exe_build
+
+          setup_exe=$(find _exe_build -maxdepth 1 -type f -name '*-Setup.exe' -print -quit)
+          metadata=$(find _exe_build/.installer -maxdepth 1 -type f -name '*.metadata.json' -print -quit)
+          payload=$(find _exe_build/.installer -maxdepth 1 -type f -name '*.tar.zst' -print -quit)
+
+          for required in "$setup_exe" "$metadata" "$payload"; do
+            if [ -z "$required" ]; then
+              echo "::error::Windows installer ZIP is missing the exe, metadata or payload — Electrobun layout may have changed"
+              exit 1
+            fi
+          done
+
+          output="artifacts/crypto-tools-${VERSION}-windows-x64-setup.exe"
+          {
+            cat "$setup_exe"
+            printf '%s' 'ELECTROBUN_METADATA_V1'
+            cat "$metadata"
+            printf '%s' 'ELECTROBUN_ARCHIVE_V1'
+            cat "$payload"
+          } > "$output"
+
+          exe_size=$(wc -c < "$setup_exe")
+          metadata_size=$(wc -c < "$metadata")
+          metadata_marker='ELECTROBUN_METADATA_V1'
+          archive_marker='ELECTROBUN_ARCHIVE_V1'
+
+          at_offset() {
+            dd if="$output" bs=1 skip="$1" count="$2" 2>/dev/null
+          }
+
+          if [ "$(at_offset "$exe_size" "${#metadata_marker}")" != "$metadata_marker" ]; then
+            echo "::error::Metadata marker is not at offset ${exe_size} in ${output}"
+            exit 1
+          fi
+
+          archive_offset=$(( exe_size + ${#metadata_marker} + metadata_size ))
+          if [ "$(at_offset "$archive_offset" "${#archive_marker}")" != "$archive_marker" ]; then
+            echo "::error::Archive marker is not at offset ${archive_offset} in ${output}"
+            exit 1
+          fi
+
+          lfanew=$(od -An -tu4 -j 60 -N 4 "$output" | tr -d ' ')
+          subsystem=$(od -An -tu1 -j $((lfanew + 92)) -N 1 "$output" | tr -d ' ')
+          if [ "$subsystem" != "2" ]; then
+            echo "::error::Installer PE subsystem is ${subsystem}, expected 2 (GUI) — it would flash a console during install"
+            exit 1
+          fi
+
+          ls -l "$output"
+          rm -rf _exe_build
+
       - name: Generate release notes
         uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
@@ -231,7 +289,9 @@ jobs:
           scoop install crypto-tools
           ```
 
-          **Manual ZIP** — download the `…-windows-x64-setup.zip` asset, extract it, and run `Crypto Tools-Setup.exe` inside. The app installs per-user to `%LOCALAPPDATA%` (no admin rights needed). Because the app is not code-signed, SmartScreen shows *"Windows protected your PC"* — click **More info → Run anyway** (offered to administrators only). Installing via Scoop avoids this prompt entirely.
+          **Manual installer** — download the `…-windows-x64-setup.exe` asset and run it. The app installs per-user to `%LOCALAPPDATA%` (no admin rights needed) and finishes by putting a **Crypto Tools** shortcut on your Desktop and in the Start menu; there is no completion dialog, so that shortcut is how you know it worked. Because the app is not code-signed, SmartScreen shows *"Windows protected your PC"* — click **More info → Run anyway** (offered to administrators only). Installing via Scoop avoids this prompt entirely.
+
+          The `…-windows-x64-setup.zip` asset is the same installer in Electrobun's original layout, kept for one release as a fallback.
           EOF
 
       - name: Create GitHub release
@@ -242,6 +302,7 @@ jobs:
           set -uo pipefail
           assets=(
             "artifacts/crypto-tools-${VERSION}-macos-arm64.dmg"
+            "artifacts/crypto-tools-${VERSION}-windows-x64-setup.exe"
             "artifacts/crypto-tools-${VERSION}-windows-x64-setup.zip"
             "artifacts/crypto-tools-${VERSION}-windows-x64-scoop.zip"
           )

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you don't have Scoop: `irm get.scoop.sh | iex`. It installs software in `C:\U
 
 ### Without package managers
 
-To install by hand instead, take the `.dmg` (macOS) or `.zip` (Windows) from the [latest release](https://github.com/nyg/crypto-tools/releases): drag **Crypto Tools.app** to **Applications**, or extract the ZIP and run **Crypto Tools-Setup.exe**.
+To install by hand instead, take the `.dmg` (macOS) or `-setup.exe` (Windows) from the [latest release](https://github.com/nyg/crypto-tools/releases): drag **Crypto Tools.app** to **Applications**, or run the installer. It installs per-user to `%LOCALAPPDATA%`, needs no admin rights, and shows no window while it works — the **Crypto Tools** shortcut it leaves on your Desktop and in the Start menu is how you know it finished.
 
 ### First launch
 
@@ -86,6 +86,8 @@ The app is ad-hoc signed on macOS and unsigned on Windows, so a manual install i
 
 - **macOS**: `xattr -dr com.apple.quarantine "/Applications/Crypto Tools.app"`, then open it. (**System Settings → Privacy & Security → Open Anyway** works for the *could not verify* dialog only.)
 - **Windows**: **More info → Run anyway**, which SmartScreen offers to administrators only. Standard users need the Scoop install.
+
+The app tells you when a newer release exists — a dot beside the version in the header, and the details in **About**, reachable by clicking that version. It never replaces itself, so Scoop and Homebrew installs stay under their package manager's control.
 
 ## Run locally
 


### PR DESCRIPTION
Closes the sixth box of #253. Stacked on #271 — **review the last commit only**. Depends on #267 for the GUI-subsystem assertion.

## What changed

Installing on Windows by hand meant: download a ZIP, extract it, notice the executable inside needs an adjacent hidden `.installer/` folder to work, run it from there. Now it is one file you download and run.

```
before:  crypto-tools-0.5.0-windows-x64-setup.zip
           ├── Crypto Tools-Setup.exe          ← useless on its own
           └── .installer/
                 ├── Crypto Tools-Setup.metadata.json
                 └── Crypto Tools-Setup.tar.zst

after:   crypto-tools-0.5.0-windows-x64-setup.exe   (34 MB, self-contained)
```

**This is not a wrapper of our own.** Electrobun's extractor prefers the adjacent files but falls back to scanning *itself* for two magic markers — which is exactly how Electrobun builds its own Linux installer. Appending the metadata and payload to the extractor produces a file it already knows how to read.

## The GUI-subsystem assertion

The v0.5.0 installer is **subsystem 3 (console)** — that is the terminal that flashes over the install. Electrobun 2.0 fixed it upstream; from `package/src/extractor/build.zig`:

```zig
// Installers are user-facing GUI executables. The console subsystem
// both flashes a debug terminal and can keep the parent terminal tied
// to the installer process. Keep an explicit opt-in for diagnostics.
exe.subsystem = if (windows_console) .Console else .Windows;
```

So this asserts rather than patches (#244 had to patch the byte against 1.18.1): an upstream regression fails the build instead of shipping quietly. **This is why the PR depends on #267** — run against a 1.x-built exe it fails by design.

## Verification

I ran the workflow step's script verbatim, extracted from the YAML, against the **real v0.5.0 artifact**.

**Unmodified (1.x, console):** assembly and both marker checks pass, then

```
::error::Installer PE subsystem is 3, expected 2 (GUI) — it would flash a console during install
```

which is the guard doing its job on the exact defect it exists to catch.

**With the subsystem byte flipped to 2, simulating a 2.0 build:** exits 0 and produces a 34,208,518-byte `.exe`. I then parsed that file the way `findEmbeddedMetadata` parses it:

```
metadata marker at: 423,936     ← exactly exe_size, and only 2 occurrences in the file
archive marker at:  424,082     ← inside the extractor's 4096-byte bounded search
metadata:  {"identifier":"io.github.nyg.crypto-tools","name":"Crypto Tools",
            "channel":"stable","hash":"1uwiw06qxtdnf"}
payload:   33,784,415 bytes, zstd magic 28b52ffd
           → decompresses to a 29-entry tar: CryptoTools/bin, Resources/app, …
```

`actionlint` clean.

**Not verified: running the installer on Windows.** The bytes are right and the extractor's own parsing logic accepts them, but nobody has double-clicked it. Worth doing before the next release, especially since the release job pushes the tag before any of this runs.

## Also

- The `…-setup.zip` asset stays for one release as a fallback; the Scoop path is untouched.
- Release notes and README updated: run the `.exe` directly, per-user to `%LOCALAPPDATA%`, no admin rights — and **the installer finishes silently**, so the Desktop/Start-menu shortcut is the only signal it worked. SmartScreen is unchanged, so Scoop stays the recommended path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)