### PR TITLE
refactor(views): migrate the shadcn/ui primitives to TypeScript

### DIFF
--- a/components.json
+++ b/components.json
@@ -2,7 +2,7 @@
   "$schema": "https://ui.shadcn.com/schema.json",
   "style": "radix-nova",
   "rsc": false,
-  "tsx": false,
+  "tsx": true,
   "tailwind": {
     "config": "",
     "css": "src/views/styles/global.css",

--- a/src/views/components/ui/alert-dialog.tsx
+++ b/src/views/components/ui/alert-dialog.tsx
@@ -5,29 +5,30 @@ import { AlertDialog as AlertDialogPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
 import { buttonVariants } from '@/components/ui/button'
+import type { VariantProps } from 'class-variance-authority'
 
 function AlertDialog({
    ...props
-}) {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
    return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
 }
 
 function AlertDialogTrigger({
    ...props
-}) {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
    return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
 }
 
 function AlertDialogPortal({
    ...props
-}) {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
    return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
 }
 
 function AlertDialogOverlay({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
    return (
       <AlertDialogPrimitive.Overlay
          data-slot="alert-dialog-overlay"
@@ -42,7 +43,7 @@ function AlertDialogOverlay({
 function AlertDialogContent({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
    return (
       <AlertDialogPortal>
          <AlertDialogOverlay />
@@ -60,7 +61,7 @@ function AlertDialogContent({
 function AlertDialogHeader({
    className,
    ...props
-}) {
+}: React.ComponentProps<'div'>) {
    return (
       <div
          data-slot="alert-dialog-header"
@@ -72,7 +73,7 @@ function AlertDialogHeader({
 function AlertDialogFooter({
    className,
    ...props
-}) {
+}: React.ComponentProps<'div'>) {
    return (
       <div
          data-slot="alert-dialog-footer"
@@ -84,7 +85,7 @@ function AlertDialogFooter({
 function AlertDialogTitle({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
    return (
       <AlertDialogPrimitive.Title
          data-slot="alert-dialog-title"
@@ -96,7 +97,7 @@ function AlertDialogTitle({
 function AlertDialogDescription({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
    return (
       <AlertDialogPrimitive.Description
          data-slot="alert-dialog-description"
@@ -109,7 +110,7 @@ function AlertDialogAction({
    className,
    variant = 'default',
    ...props
-}) {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> & VariantProps<typeof buttonVariants>) {
    return (
       <AlertDialogPrimitive.Action
          className={cn(buttonVariants({ variant }), className)}
@@ -120,7 +121,7 @@ function AlertDialogAction({
 function AlertDialogCancel({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
    return (
       <AlertDialogPrimitive.Cancel
          className={cn(buttonVariants({ variant: 'outline' }), className)}

--- a/src/views/components/ui/alert.tsx
+++ b/src/views/components/ui/alert.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { cva } from 'class-variance-authority'
+import type { VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/lib/utils'
 
@@ -23,7 +24,7 @@ function Alert({
    className,
    variant,
    ...props
-}) {
+}: React.ComponentProps<'div'> & VariantProps<typeof alertVariants>) {
    return (
       <div
          data-slot="alert"
@@ -36,7 +37,7 @@ function Alert({
 function AlertTitle({
    className,
    ...props
-}) {
+}: React.ComponentProps<'div'>) {
    return (
       <div
          data-slot="alert-title"
@@ -51,7 +52,7 @@ function AlertTitle({
 function AlertDescription({
    className,
    ...props
-}) {
+}: React.ComponentProps<'div'>) {
    return (
       <div
          data-slot="alert-description"
@@ -66,7 +67,7 @@ function AlertDescription({
 function AlertAction({
    className,
    ...props
-}) {
+}: React.ComponentProps<'div'>) {
    return (
       <div
          data-slot="alert-action"

--- a/src/views/components/ui/badge.tsx
+++ b/src/views/components/ui/badge.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { cva } from 'class-variance-authority'
+import type { VariantProps } from 'class-variance-authority'
 import { Slot } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
@@ -32,7 +33,7 @@ function Badge({
    variant = 'default',
    asChild = false,
    ...props
-}) {
+}: React.ComponentProps<'span'> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
    const Comp = asChild ? Slot.Root : 'span'
 
    return (

--- a/src/views/components/ui/button.tsx
+++ b/src/views/components/ui/button.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { cva } from 'class-variance-authority'
+import type { VariantProps } from 'class-variance-authority'
 import { Slot } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
@@ -47,7 +48,7 @@ function Button({
    size = 'default',
    asChild = false,
    ...props
-}) {
+}: React.ComponentProps<'button'> & VariantProps<typeof buttonVariants> & { asChild?: boolean }) {
    const Comp = asChild ? Slot.Root : 'button'
 
    return (

--- a/src/views/components/ui/calendar.tsx
+++ b/src/views/components/ui/calendar.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 import { DayPicker, getDefaultClassNames } from 'react-day-picker'
+import type { DayButton } from 'react-day-picker'
+import type { VariantProps } from 'class-variance-authority'
 
 import { cn } from '@/lib/utils'
 import { Button, buttonVariants } from '@/components/ui/button'
@@ -15,6 +17,8 @@ function Calendar({
    formatters,
    components,
    ...props
+}: React.ComponentProps<typeof DayPicker> & {
+   buttonVariant?: VariantProps<typeof buttonVariants>['variant']
 }) {
    const defaultClassNames = getDefaultClassNames()
 
@@ -145,10 +149,10 @@ function CalendarDayButton({
    modifiers,
    locale,
    ...props
-}) {
+}: React.ComponentProps<typeof DayButton> & { locale?: React.ComponentProps<typeof DayPicker>['locale'] }) {
    const defaultClassNames = getDefaultClassNames()
 
-   const ref = React.useRef(null)
+   const ref = React.useRef<HTMLButtonElement>(null)
    React.useEffect(() => {
       if (modifiers.focused) ref.current?.focus()
    }, [modifiers.focused])

--- a/src/views/components/ui/card.tsx
+++ b/src/views/components/ui/card.tsx
@@ -6,7 +6,7 @@ function Card({
    className,
    size = 'default',
    ...props
-}) {
+}: React.ComponentProps<'div'> & { size?: 'default' | 'sm' }) {
    return (
       <div
          data-slot="card"
@@ -22,7 +22,7 @@ function Card({
 function CardHeader({
    className,
    ...props
-}) {
+}: React.ComponentProps<'div'>) {
    return (
       <div
          data-slot="card-header"
@@ -37,7 +37,7 @@ function CardHeader({
 function CardTitle({
    className,
    ...props
-}) {
+}: React.ComponentProps<'div'>) {
    return (
       <div
          data-slot="card-title"
@@ -52,7 +52,7 @@ function CardTitle({
 function CardDescription({
    className,
    ...props
-}) {
+}: React.ComponentProps<'div'>) {
    return (
       <div
          data-slot="card-description"
@@ -64,7 +64,7 @@ function CardDescription({
 function CardAction({
    className,
    ...props
-}) {
+}: React.ComponentProps<'div'>) {
    return (
       <div
          data-slot="card-action"
@@ -79,7 +79,7 @@ function CardAction({
 function CardContent({
    className,
    ...props
-}) {
+}: React.ComponentProps<'div'>) {
    return (
       <div
          data-slot="card-content"
@@ -91,7 +91,7 @@ function CardContent({
 function CardFooter({
    className,
    ...props
-}) {
+}: React.ComponentProps<'div'>) {
    return (
       <div
          data-slot="card-footer"

--- a/src/views/components/ui/chart.tsx
+++ b/src/views/components/ui/chart.tsx
@@ -8,6 +8,28 @@ import { asNumber } from '../../../utils/format'
 const THEMES = {
    light: '',
    dark: '.dark'
+} as const
+
+type Theme = keyof typeof THEMES
+
+export type ChartConfig = Record<string, {
+   label?: React.ReactNode
+   icon?: React.ComponentType
+} & ({ color?: string, theme?: never } | { color?: never, theme: Record<Theme, string> })>
+
+interface ChartContextProps {
+   config: ChartConfig
+}
+
+// The payload entries Recharts hands to a custom tooltip or legend. Its own types
+// describe them loosely, so the fields actually read here are named instead.
+type ChartPayloadItem = {
+   type?: string
+   value?: unknown
+   name?: string
+   dataKey?: string | number
+   color?: string
+   payload?: Record<string, unknown>
 }
 
 const INITIAL_DIMENSION = {
@@ -15,7 +37,7 @@ const INITIAL_DIMENSION = {
    height: 200
 }
 
-const ChartContext = React.createContext(null)
+const ChartContext = React.createContext<ChartContextProps | null>(null)
 
 function useChart() {
    const context = React.useContext(ChartContext)
@@ -34,6 +56,10 @@ function ChartContainer({
    config,
    initialDimension = INITIAL_DIMENSION,
    ...props
+}: React.ComponentProps<'div'> & {
+   config: ChartConfig
+   initialDimension?: { width: number, height: number }
+   children: React.ComponentProps<typeof RechartsPrimitive.ResponsiveContainer>['children']
 }) {
    const uniqueId = React.useId()
    const chartId = `chart-${id ?? uniqueId.replace(/:/g, '')}`
@@ -63,7 +89,7 @@ function ChartContainer({
 const ChartStyle = ({
    id,
    config
-}) => {
+}: { id: string, config: ChartConfig }) => {
    const colorConfig = Object.entries(config).filter(([, config]) => config.theme ?? config.color)
 
    if (!colorConfig.length) {
@@ -79,7 +105,7 @@ ${prefix} [data-chart=${id}] {
 ${colorConfig
          .map(([key, itemConfig]) => {
             const color =
-  itemConfig.theme?.[theme] ??
+  itemConfig.theme?.[theme as Theme] ??
   itemConfig.color
             return color ? `  --color-${key}: ${color};` : null
          })
@@ -107,6 +133,22 @@ function ChartTooltipContent({
    color,
    nameKey,
    labelKey
+}: {
+   active?: boolean
+   payload?: ChartPayloadItem[]
+   className?: string
+   indicator?: 'line' | 'dot' | 'dashed'
+   hideLabel?: boolean
+   hideIndicator?: boolean
+   label?: unknown
+   labelFormatter?: (value: React.ReactNode, payload: ChartPayloadItem[]) => React.ReactNode
+   labelClassName?: string
+   formatter?: (
+      value: unknown, name: string, item: ChartPayloadItem, index: number, payload: unknown
+   ) => React.ReactNode
+   color?: string
+   nameKey?: string
+   labelKey?: string
 }) {
    const { config } = useChart()
 
@@ -194,7 +236,7 @@ function ChartTooltipContent({
                                           {
                                              '--color-bg': indicatorColor,
                                              '--color-border': indicatorColor
-                                          }
+                                          } as React.CSSProperties
                                        } />
                                  )
                               )}
@@ -235,6 +277,12 @@ function ChartLegendContent({
    payload,
    verticalAlign = 'bottom',
    nameKey
+}: {
+   className?: string
+   hideIcon?: boolean
+   payload?: ChartPayloadItem[]
+   verticalAlign?: 'top' | 'bottom' | 'middle'
+   nameKey?: string
 }) {
    const { config } = useChart()
 
@@ -279,28 +327,30 @@ function ChartLegendContent({
 }
 
 function getPayloadConfigFromPayload(
-   config,
-   payload,
-   key
+   config: ChartConfig,
+   payload: unknown,
+   key: string
 ) {
    if (typeof payload !== 'object' || payload === null) {
       return undefined
    }
 
+   const entry = payload as Record<string, unknown>
+
    const payloadPayload =
-    'payload' in payload &&
-    typeof payload.payload === 'object' &&
-    payload.payload !== null
-       ? payload.payload
+    'payload' in entry &&
+    typeof entry.payload === 'object' &&
+    entry.payload !== null
+       ? entry.payload as Record<string, unknown>
        : undefined
 
    let configLabelKey = key
 
    if (
-      key in payload &&
-    typeof payload[key] === 'string'
+      key in entry &&
+    typeof entry[key] === 'string'
    ) {
-      configLabelKey = payload[key]
+      configLabelKey = entry[key]
    } else if (
       payloadPayload &&
     key in payloadPayload &&

--- a/src/views/components/ui/checkbox.tsx
+++ b/src/views/components/ui/checkbox.tsx
@@ -9,7 +9,7 @@ import { CheckIcon } from 'lucide-react'
 function Checkbox({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
    return (
       <CheckboxPrimitive.Root
          data-slot="checkbox"

--- a/src/views/components/ui/command.tsx
+++ b/src/views/components/ui/command.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils'
 function Command({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof CommandPrimitive>) {
    return (
       <CommandPrimitive
          data-slot="command"
@@ -22,7 +22,7 @@ function Command({
 function CommandInput({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
    return (
       <div data-slot="command-input-wrapper" className="flex h-9 items-center gap-2 border-b px-2.5">
          <SearchIcon className="size-4 shrink-0 text-muted-foreground" />
@@ -40,7 +40,7 @@ function CommandInput({
 function CommandList({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
    return (
       <CommandPrimitive.List
          data-slot="command-list"
@@ -51,7 +51,7 @@ function CommandList({
 
 function CommandEmpty({
    ...props
-}) {
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
    return (
       <CommandPrimitive.Empty
          data-slot="command-empty"
@@ -63,7 +63,7 @@ function CommandEmpty({
 function CommandGroup({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
    return (
       <CommandPrimitive.Group
          data-slot="command-group"
@@ -78,7 +78,7 @@ function CommandGroup({
 function CommandSeparator({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
    return (
       <CommandPrimitive.Separator
          data-slot="command-separator"
@@ -90,7 +90,7 @@ function CommandSeparator({
 function CommandItem({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
    return (
       <CommandPrimitive.Item
          data-slot="command-item"

--- a/src/views/components/ui/dialog.tsx
+++ b/src/views/components/ui/dialog.tsx
@@ -8,32 +8,32 @@ import { cn } from '@/lib/utils'
 
 function Dialog({
    ...props
-}) {
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
    return <DialogPrimitive.Root data-slot="dialog" {...props} />
 }
 
 function DialogTrigger({
    ...props
-}) {
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
    return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
 }
 
 function DialogPortal({
    ...props
-}) {
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
    return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
 }
 
 function DialogClose({
    ...props
-}) {
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
    return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
 }
 
 function DialogOverlay({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
    return (
       <DialogPrimitive.Overlay
          data-slot="dialog-overlay"
@@ -50,7 +50,7 @@ function DialogContent({
    children,
    showCloseButton = true,
    ...props
-}) {
+}: React.ComponentProps<typeof DialogPrimitive.Content> & { showCloseButton?: boolean }) {
    return (
       <DialogPortal>
          <DialogOverlay />
@@ -77,7 +77,7 @@ function DialogContent({
 function DialogHeader({
    className,
    ...props
-}) {
+}: React.ComponentProps<'div'>) {
    return (
       <div
          data-slot="dialog-header"
@@ -89,7 +89,7 @@ function DialogHeader({
 function DialogFooter({
    className,
    ...props
-}) {
+}: React.ComponentProps<'div'>) {
    return (
       <div
          data-slot="dialog-footer"
@@ -101,7 +101,7 @@ function DialogFooter({
 function DialogTitle({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
    return (
       <DialogPrimitive.Title
          data-slot="dialog-title"
@@ -113,7 +113,7 @@ function DialogTitle({
 function DialogDescription({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
    return (
       <DialogPrimitive.Description
          data-slot="dialog-description"

--- a/src/views/components/ui/input.tsx
+++ b/src/views/components/ui/input.tsx
@@ -6,7 +6,7 @@ function Input({
    className,
    type,
    ...props
-}) {
+}: React.ComponentProps<'input'>) {
    return (
       <input
          type={type}

--- a/src/views/components/ui/label.tsx
+++ b/src/views/components/ui/label.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils'
 function Label({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
    return (
       <LabelPrimitive.Root
          data-slot="label"

--- a/src/views/components/ui/popover.tsx
+++ b/src/views/components/ui/popover.tsx
@@ -7,13 +7,13 @@ import { cn } from '@/lib/utils'
 
 function Popover({
    ...props
-}) {
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
    return <PopoverPrimitive.Root data-slot="popover" {...props} />
 }
 
 function PopoverTrigger({
    ...props
-}) {
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
    return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
 }
 
@@ -22,7 +22,7 @@ function PopoverContent({
    align = 'center',
    sideOffset = 4,
    ...props
-}) {
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
    return (
       <PopoverPrimitive.Portal>
          <PopoverPrimitive.Content
@@ -40,14 +40,14 @@ function PopoverContent({
 
 function PopoverAnchor({
    ...props
-}) {
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
    return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
 }
 
 function PopoverHeader({
    className,
    ...props
-}) {
+}: React.ComponentProps<'div'>) {
    return (
       <div
          data-slot="popover-header"
@@ -59,7 +59,7 @@ function PopoverHeader({
 function PopoverTitle({
    className,
    ...props
-}) {
+}: React.ComponentProps<'div'>) {
    return (
       <div
          data-slot="popover-title"
@@ -71,7 +71,7 @@ function PopoverTitle({
 function PopoverDescription({
    className,
    ...props
-}) {
+}: React.ComponentProps<'p'>) {
    return (
       <p
          data-slot="popover-description"

--- a/src/views/components/ui/select.tsx
+++ b/src/views/components/ui/select.tsx
@@ -6,14 +6,14 @@ import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from 'lucide-react'
 
 function Select({
    ...props
-}) {
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
    return <SelectPrimitive.Root data-slot="select" {...props} />
 }
 
 function SelectGroup({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
    return (
       <SelectPrimitive.Group
          data-slot="select-group"
@@ -24,7 +24,7 @@ function SelectGroup({
 
 function SelectValue({
    ...props
-}) {
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
    return <SelectPrimitive.Value data-slot="select-value" {...props} />
 }
 
@@ -33,7 +33,7 @@ function SelectTrigger({
    size = 'default',
    children,
    ...props
-}) {
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & { size?: 'sm' | 'default' }) {
    return (
       <SelectPrimitive.Trigger
          data-slot="select-trigger"
@@ -57,7 +57,7 @@ function SelectContent({
    position = 'item-aligned',
    align = 'center',
    ...props
-}) {
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
    return (
       <SelectPrimitive.Portal>
          <SelectPrimitive.Content
@@ -89,7 +89,7 @@ function SelectContent({
 function SelectLabel({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
    return (
       <SelectPrimitive.Label
          data-slot="select-label"
@@ -102,7 +102,7 @@ function SelectItem({
    className,
    children,
    ...props
-}) {
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
    return (
       <SelectPrimitive.Item
          data-slot="select-item"
@@ -125,7 +125,7 @@ function SelectItem({
 function SelectSeparator({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
    return (
       <SelectPrimitive.Separator
          data-slot="select-separator"
@@ -137,7 +137,7 @@ function SelectSeparator({
 function SelectScrollUpButton({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
    return (
       <SelectPrimitive.ScrollUpButton
          data-slot="select-scroll-up-button"
@@ -154,7 +154,7 @@ function SelectScrollUpButton({
 function SelectScrollDownButton({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
    return (
       <SelectPrimitive.ScrollDownButton
          data-slot="select-scroll-down-button"

--- a/src/views/components/ui/sonner.tsx
+++ b/src/views/components/ui/sonner.tsx
@@ -1,9 +1,10 @@
+import type * as React from 'react'
 import { Toaster as Sonner } from 'sonner'
 import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from 'lucide-react'
 
 const Toaster = ({
    ...props
-}) => {
+}: React.ComponentProps<typeof Sonner>) => {
    return (
       <Sonner
          theme="system"
@@ -31,7 +32,7 @@ const Toaster = ({
                '--normal-text': 'var(--popover-foreground)',
                '--normal-border': 'var(--border)',
                '--border-radius': 'var(--radius)'
-            }
+            } as React.CSSProperties
          }
          toastOptions={{
             classNames: {

--- a/src/views/components/ui/table.tsx
+++ b/src/views/components/ui/table.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils'
 function Table({
    className,
    ...props
-}) {
+}: React.ComponentProps<'table'>) {
    return (
       <div data-slot="table-container" className="relative w-full overflow-x-auto">
          <table
@@ -19,7 +19,7 @@ function Table({
 function TableHeader({
    className,
    ...props
-}) {
+}: React.ComponentProps<'thead'>) {
    return (
       <thead
          data-slot="table-header"
@@ -31,7 +31,7 @@ function TableHeader({
 function TableBody({
    className,
    ...props
-}) {
+}: React.ComponentProps<'tbody'>) {
    return (
       <tbody
          data-slot="table-body"
@@ -43,7 +43,7 @@ function TableBody({
 function TableFooter({
    className,
    ...props
-}) {
+}: React.ComponentProps<'tfoot'>) {
    return (
       <tfoot
          data-slot="table-footer"
@@ -55,7 +55,7 @@ function TableFooter({
 function TableRow({
    className,
    ...props
-}) {
+}: React.ComponentProps<'tr'>) {
    return (
       <tr
          data-slot="table-row"
@@ -70,7 +70,7 @@ function TableRow({
 function TableHead({
    className,
    ...props
-}) {
+}: React.ComponentProps<'th'>) {
    return (
       <th
          data-slot="table-head"
@@ -85,7 +85,7 @@ function TableHead({
 function TableCell({
    className,
    ...props
-}) {
+}: React.ComponentProps<'td'>) {
    return (
       <td
          data-slot="table-cell"
@@ -100,7 +100,7 @@ function TableCell({
 function TableCaption({
    className,
    ...props
-}) {
+}: React.ComponentProps<'caption'>) {
    return (
       <caption
          data-slot="table-caption"

--- a/src/views/components/ui/tabs.tsx
+++ b/src/views/components/ui/tabs.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils'
 function Tabs({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
    return (
       <TabsPrimitive.Root
          data-slot="tabs"
@@ -18,7 +18,7 @@ function Tabs({
 function TabsList({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
    return (
       <TabsPrimitive.List
          data-slot="tabs-list"
@@ -33,7 +33,7 @@ function TabsList({
 function TabsTrigger({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
    return (
       <TabsPrimitive.Trigger
          data-slot="tabs-trigger"
@@ -48,7 +48,7 @@ function TabsTrigger({
 function TabsContent({
    className,
    ...props
-}) {
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
    return (
       <TabsPrimitive.Content
          data-slot="tabs-content"

--- a/src/views/lib/utils.ts
+++ b/src/views/lib/utils.ts
@@ -1,6 +1,7 @@
 import { clsx } from 'clsx'
+import type { ClassValue } from 'clsx'
 import { twMerge } from 'tailwind-merge'
 
-export function cn(...inputs) {
+export function cn(...inputs: ClassValue[]): string {
    return twMerge(clsx(inputs))
 }


### PR DESCRIPTION
Third of six. Stacked on #276.

The 17 files under `src/views/components/ui` become `.tsx`, typed the way upstream shadcn types them: `React.ComponentProps<typeof Primitive.Root>` for the Radix wrappers, with `VariantProps<typeof xVariants>` alongside for the three built on `cva`. Nothing about what they render changes — only the props they declare. `src/views/lib/utils` becomes `.ts` with a `ClassValue[]` rest parameter, since every one of them calls `cn()`.

## The two that needed more than an annotation

**`chart.tsx`** — `ChartConfig` and `ChartContextProps` are declared here rather than inferred from a `null` context. The tooltip and legend describe their own props instead of borrowing Recharts': Recharts 3 does not surface `payload` or `label` on the `Tooltip`/`Legend` prop types, so a local `ChartPayloadItem` names exactly the fields these two actually read. The style objects that set CSS custom properties (`--color-bg`, `--color-border`) are asserted as `CSSProperties`, which is what upstream does too. The local additions — `asNumber` formatting of tooltip values, `initialDimension` — carry over untouched.

**`calendar.tsx`** — `DayPicker`'s own props, plus `buttonVariant` narrowed to the `Button` variants it is forwarded to, and a typed ref for the day button.

`sonner.tsx` needed the same `CSSProperties` assertion for its `--normal-bg` block.

## `components.json`

`tsx` flips to `true`, so the next `shadcn add` writes `.tsx` rather than dropping a `.jsx` file back into a TypeScript directory.

## Verification

`bun run typecheck`, `bun run lint` and `bun run build` are clean. Then every page in mocked mode (`VITE_MOCK_DATA=true vite --port 3100`), exercising each primitive rather than just loading it:

- **Charts** — the Fees stacked bar chart renders with its legend, and hovering a bar shows the tooltip with its coloured indicators and formatted values (`ChartContainer`, `ChartLegendContent`, `ChartTooltipContent`, all three of the hard ones)
- **Popover + Calendar** — the Ledger date filter opens its month grid with the year/month dropdowns and nav chevrons
- **AlertDialog** — the Open Orders cancel confirmation opens over its overlay with the destructive action button
- **Command** — the Aggregated Trades pair combobox filters and selects, and the page folds 29 groups
- **Table, Card, Badge, Button, Checkbox, Tabs, Select, Input, Label** — Ledger, Balances, Rewards, Open Orders, Order Batch, xStocks, Settings, Trade Calculator, Binance Staking, all rendering with no console errors

I also ran the pre-PR state side by side on another port to be sure nothing regressed. Nothing did.

*(An earlier revision of this description claimed the Balances and Rewards donuts were empty in mocked mode. That was wrong — I had screenshotted those pages mid-load. The asset-rates request only fires once the balances arrive and the mock fetcher adds a 300ms delay, so the donuts and prices fill in a moment later. Both render correctly.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
